### PR TITLE
Cluster the member's own details on /account, and add gi and belt sizes

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -232,6 +232,8 @@ never stored.
 | `guardian_name`                  | `text`        | yes  |                                                                                                                                                    |
 | `guardian_relationship`          | `text`        | yes  |                                                                                                                                                    |
 | `sms_whatsapp_consent`           | `boolean`     | no   | Default `false`.                                                                                                                                   |
+| `gi_size`                        | `text`        | yes  | Gi size code (`profiles_gi_size_check`: `000`…`7`). Equipment sizing, never on a waiver. Chart: `src/lib/kit-sizes.ts`.                            |
+| `belt_size`                      | `text`        | yes  | Belt size code (`profiles_belt_size_check`: `0`…`7` — the belt chart has no `000`/`00`). Same module owns both lists.                              |
 | `created_at`                     | `timestamptz` | no   | Default `now()`.                                                                                                                                   |
 | `updated_at`                     | `timestamptz` | no   | Default `now()`.                                                                                                                                   |
 
@@ -249,6 +251,21 @@ inside the waiver PDF), and no `full_name`.
   person fields onto the profile (`waiverToProfileFields`); on first approval
   lifts the ban, sends a sign-in email, and assigns the free trial
   (`assignTrialMembership`, one per person ever, activation email suppressed).
+- Waiver submission again, for the optional **gi size** the form collects
+  (`submitWaiverWithPdf`). It is equipment sizing, not part of the waiver: no
+  `waivers` column holds it and it is not on the PDF, so it is written straight
+  here. A blank one writes nothing, so re-signing never clears a size on file,
+  and `belt_size` is only ever SEEDED (`beltSizeForGiSize`, which sends the two
+  kids' gi sizes to belt `0`) so a size somebody chose deliberately survives.
+- The member themselves, from `/account` (`updateMyProfile`): `display_name`,
+  `preferred_name`, `phone`, `address`, `sms_whatsapp_consent`, the three
+  `emergency_contact_*` fields, `gi_size` and `belt_size`. The schema is
+  `.strict()`, so it cannot reach the legal name, date of birth, student number,
+  medical notes, minor/guardian fields or email. ⚠️ Its contact fields OVERLAP
+  with `waiverToProfileFields`, so a manager approving an older waiver can
+  overwrite a correction made here; `/account` says so on the card.
+- A manager, from a person's detail page (`setClubUserKitSizes`): `gi_size` and
+  `belt_size` only, either of which may be set to NULL to clear it.
 - `ensure_profile()` trigger on `auth.users` INSERT (SECURITY DEFINER, EXECUTE
   revoked from PUBLIC/anon/authenticated): inserts the profile row for every new
   auth user, however created. Pure id attachment — no email matching, so nothing

--- a/docs/waivers.md
+++ b/docs/waivers.md
@@ -57,6 +57,14 @@ system. (The contact form stores a message, not a person.)
    needs each submission also stores the signer's real IP and signing context
    (browser user agent, language, and the browser-reported timezone, screen and
    platform).
+   The form also asks, optionally, for a **gi size**, and that one is NOT part
+   of the waiver: it is equipment sizing rather than something anybody is
+   declaring, so no `waivers` column holds it, it is not on the PDF, and it goes
+   straight onto the profile. Leaving it blank writes nothing, so signing again
+   never wipes a size on file, and it seeds a belt size only when there is none
+   (the two kids' gi sizes have no belt counterpart and take the shortest belt).
+   Both sizes are editable afterwards on `/account` and by a manager.
+
 4. **Waivers are accepted at any time, without limit.** Resubmitting after a
    mistake is never blocked, before or after approval.
 5. **The active waiver is the latest approved one.** Older approved waivers are
@@ -83,6 +91,14 @@ system. (The contact form stores a message, not a person.)
    captured on a waiver is part of that frozen submission (evidence), not a
    live record. There is no self-serve email change; a future manager action
    changes it in the one place it lives.
+
+   A member can keep some of that record current themselves on `/account`: what
+   they go by, their kit sizes, and their contact and emergency-contact details.
+   That never rewrites a waiver, which keeps what was typed at the time. It does
+   mean approval and self-service can both write the contact fields, and
+   approval wins whenever it runs, so a manager working through a backlog of
+   older waivers can undo a correction a member made since.
+
 9. **No self-serve sign-up.** Logins are created locked by waiver submission
    and unlocked by approval. The auth page only signs people in (password or
    magic link, with `shouldCreateUser: false`; a locked login cannot sign in).

--- a/src/components/site/KitSizeSelect.tsx
+++ b/src/components/site/KitSizeSelect.tsx
@@ -1,0 +1,107 @@
+import { cn } from "@/lib/utils";
+import {
+  type BeltSize,
+  type GiSize,
+  beltSizeLabel,
+  beltSizes,
+  giSizeLabel,
+  giSizes,
+} from "@/lib/kit-sizes";
+
+/**
+ * The gi and belt pickers, in one place so the three screens that offer them
+ * (`/account`, `/waiver`, and a manager's view of somebody's record) cannot
+ * drift apart on labels or on the wording that explains the numbers.
+ *
+ * A native `<select>` rather than the Radix primitive in `components/ui/select`,
+ * for two reasons. Both fields are optional, and Radix's `<SelectItem>` refuses
+ * an empty value, so "not set" would need a sentinel that every caller has to
+ * remember to map back. And `/waiver` is a public, server-rendered page in the
+ * PR screenshot sweep, which is the last place to introduce a portal-based
+ * primitive nothing else on a public page uses. A native select also shows the
+ * chosen option's full text, which is the whole point below.
+ *
+ * Every option leads with the size CODE and carries the measurement as a
+ * parenthetical aid: somebody who knows their size picks it straight off,
+ * somebody who does not finds it from the measurement, and the code stays
+ * visible once chosen instead of being replaced by a number of centimetres.
+ */
+
+const selectClass =
+  "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm";
+
+/** Shown under a gi picker. Sizes are cut for a height, so nobody is exactly one. */
+export const GI_SIZE_HINT = "Round up or down depending on your body build.";
+
+/**
+ * Shown under a belt picker. The lead sentence exists because a bare "240 cm"
+ * next to a size reads as a body measurement, and it is not one.
+ */
+export const BELT_SIZE_HINT =
+  "The length is the belt itself, not your waist. If you are between sizes, take the next size up.";
+
+type BaseProps = {
+  id: string;
+  disabled?: boolean;
+  className?: string;
+  /** Label for the "no size chosen" option. Both fields are always optional. */
+  emptyLabel?: string;
+};
+
+export function GiSizeSelect({
+  id,
+  value,
+  onChange,
+  disabled,
+  className,
+  emptyLabel = "Not sure / prefer not to say",
+}: BaseProps & {
+  value: GiSize | "";
+  onChange: (value: GiSize | "") => void;
+}) {
+  return (
+    <select
+      id={id}
+      className={cn(selectClass, className)}
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value as GiSize | "")}
+    >
+      <option value="">{emptyLabel}</option>
+      {giSizes.map((size) => (
+        <option key={size} value={size}>
+          {giSizeLabel(size)}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+export function BeltSizeSelect({
+  id,
+  value,
+  onChange,
+  disabled,
+  className,
+  emptyLabel = "Not sure / prefer not to say",
+}: BaseProps & {
+  value: BeltSize | "";
+  onChange: (value: BeltSize | "") => void;
+}) {
+  return (
+    <select
+      id={id}
+      className={cn(selectClass, className)}
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value as BeltSize | "")}
+    >
+      <option value="">{emptyLabel}</option>
+      {beltSizes.map((size) => (
+        <option key={size} value={size}>
+          {beltSizeLabel(size)}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/integrations/supabase/schema-contract.test.ts
+++ b/src/integrations/supabase/schema-contract.test.ts
@@ -107,7 +107,8 @@ export type _TemplateColumns = RequireColumns<
   "acknowledgements" | "body_md" | "created_at" | "id" | "is_current" | "title" | "version"
 >;
 
-// ---- profiles: the fields waiver approval copies across ----
+// ---- profiles: the fields waiver approval copies across, plus the two the
+// club's kit sizing lives in (which approval deliberately does NOT touch) ----
 export type _ProfileColumns = RequireColumns<
   Tables["profiles"]["Row"],
   | "user_id"
@@ -116,6 +117,8 @@ export type _ProfileColumns = RequireColumns<
   | "uts_student_number"
   | "sms_whatsapp_consent"
   | "emergency_contact_relationship"
+  | "gi_size"
+  | "belt_size"
 >;
 
 // ---- interest_registrations: the consent flag the public form writes ----

--- a/src/lib/club-user.functions.ts
+++ b/src/lib/club-user.functions.ts
@@ -10,6 +10,7 @@ import { requireSupabaseAuth } from "@/integrations/supabase/auth-middleware";
 import {
   deriveWaiverListStatuses,
   managerEmailChangeSchema,
+  managerKitSizesSchema,
   nameWithPreferred,
   normalizeEmail,
 } from "@/lib/validation";
@@ -233,6 +234,8 @@ export const getClubUser = createServerFn({ method: "POST" })
         guardian_name: profile.guardian_name,
         guardian_relationship: profile.guardian_relationship,
         sms_whatsapp_consent: profile.sms_whatsapp_consent,
+        gi_size: profile.gi_size,
+        belt_size: profile.belt_size,
         updated_at: profile.updated_at,
       },
       memberships: membershipRows.map((m) => ({
@@ -431,4 +434,39 @@ export const resendClubUserVerification = createServerFn({ method: "POST" })
     });
     if (!sent) throw new Error("We couldn't send that email just now. Try again shortly.");
     return { ok: true as const, alreadyVerified: false, email: got.user.email };
+  });
+
+// ---- Manager: correct a person's kit sizes ----
+//
+// Sizing is equipment, not evidence: nothing on a signed waiver records it, so
+// unlike the fields below it on the detail page there is no frozen submission to
+// disagree with. A manager corrects it because they measured somebody, or
+// because the gi that arrived did not fit.
+//
+// Both sides are nullable, so this is also how a wrong size gets cleared rather
+// than replaced with a guess.
+export const setClubUserKitSizes = createServerFn({ method: "POST" })
+  .middleware([requireSupabaseAuth])
+  .inputValidator((d: unknown) => managerKitSizesSchema.parse(d))
+  .handler(async ({ data, context }) => {
+    await requireManager(context as { supabase: MembershipClient; userId: string });
+
+    const { supabaseAdmin: admin } = await import("@/integrations/supabase/client.server");
+    const { data: updated, error } = await admin
+      .from("profiles")
+      .update({
+        gi_size: data.gi_size,
+        belt_size: data.belt_size,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("user_id", data.userId)
+      .select("user_id");
+    if (error) throw new Error(error.message);
+    // PostgREST reports no error when the filter matched nothing. A lead has no
+    // profile row (`aggregateClubUsers` synthesises those rows), so without this
+    // the screen would say "Sizes updated." over a write that never landed.
+    if (!updated || updated.length === 0) {
+      throw new Error("That person has no profile record to hold sizes.");
+    }
+    return { ok: true as const, gi_size: data.gi_size, belt_size: data.belt_size };
   });

--- a/src/lib/club-users.test.ts
+++ b/src/lib/club-users.test.ts
@@ -24,6 +24,8 @@ function profile(over: Partial<ClubUserProfile> = {}): ClubUserProfile {
     preferred_name: null,
     phone: "0400 000 000",
     uts_student_number: null,
+    gi_size: null,
+    belt_size: null,
     created_at: "2026-01-01T00:00:00Z",
     ...over,
   };
@@ -107,6 +109,21 @@ describe("aggregateClubUsers", () => {
     expect(u.name).toBe("Ada Lovelace");
     expect(u.email).toBe("ada@example.com");
     expect(u.phone).toBe("222");
+  });
+
+  it("carries kit sizes through to the row, and leaves a lead's empty", () => {
+    const users = aggregate({
+      profiles: [profile({ user_id: "u1", gi_size: "4", belt_size: "3" })],
+      leads: [lead()],
+    });
+    const person = users.find((u) => u.user_id === "u1")!;
+    expect(person.gi_size).toBe("4");
+    expect(person.belt_size).toBe("3");
+    // A lead has given us an email and nothing else, so there is no profile to
+    // hold a size and nothing to show but a blank.
+    const l = users.find((u) => u.user_id === null)!;
+    expect(l.gi_size).toBeNull();
+    expect(l.belt_size).toBeNull();
   });
 
   it("carries the email confirmation stamp through to the row", () => {

--- a/src/lib/club-users.ts
+++ b/src/lib/club-users.ts
@@ -38,6 +38,8 @@ export type ClubUserProfile = {
   preferred_name: string | null;
   phone: string | null;
   uts_student_number: string | null;
+  gi_size: string | null;
+  belt_size: string | null;
   created_at: string;
 };
 
@@ -132,6 +134,9 @@ export type ClubUser = {
   waiver_signed_at: string | null;
   is_uts_student: boolean;
   uts_student_number: string | null;
+  /** Kit sizing, as size codes off the club's charts. Null when never given. */
+  gi_size: string | null;
+  belt_size: string | null;
   latest_plan_name: string | null;
   latest_membership_status: MembershipStatus | null;
   membership_count: number;
@@ -257,6 +262,8 @@ export function aggregateClubUsers(input: {
       waiver_signed_at: approvedSignedAt,
       is_uts_student,
       uts_student_number,
+      gi_size: p.gi_size,
+      belt_size: p.belt_size,
       latest_plan_name: latest ? (planById.get(latest.plan_id)?.name ?? null) : null,
       latest_membership_status: latest ? (latest.status as MembershipStatus) : null,
       membership_count: ms.length,
@@ -290,6 +297,9 @@ export function aggregateClubUsers(input: {
       waiver_signed_at: null,
       is_uts_student: false,
       uts_student_number: null,
+      // A lead has given us nothing but an email: no profile, no sizes.
+      gi_size: null,
+      belt_size: null,
       latest_plan_name: null,
       latest_membership_status: null,
       membership_count: 0,

--- a/src/lib/kit-sizes.test.ts
+++ b/src/lib/kit-sizes.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  BELT_LENGTH_CM,
+  GI_HEIGHT_CM,
+  beltSizeForGiSize,
+  beltSizeLabel,
+  beltSizes,
+  formatBeltSize,
+  formatGiSize,
+  giSizeLabel,
+  giSizes,
+  isBeltSize,
+  isGiSize,
+} from "./kit-sizes";
+
+describe("kit-sizes charts", () => {
+  // These two literals are duplicated in CHECK constraints on public.profiles
+  // (profiles_gi_size_check / profiles_belt_size_check). Nothing in the suite
+  // can read a CHECK, so pinning them here is the only thing that turns
+  // "widened the array, forgot the migration" into a failing test rather than a
+  // PostgREST 400 in production. Changing either list means writing a migration
+  // that replaces the matching constraint.
+  it("pins the gi size codes", () => {
+    expect([...giSizes]).toEqual(["000", "00", "0", "1", "2", "3", "4", "5", "6", "7"]);
+  });
+
+  it("pins the belt size codes, which start at 0 and not 000", () => {
+    expect([...beltSizes]).toEqual(["0", "1", "2", "3", "4", "5", "6", "7"]);
+  });
+
+  it("gives every gi size a height and nothing else one", () => {
+    expect(Object.keys(GI_HEIGHT_CM).sort()).toEqual([...giSizes].sort());
+  });
+
+  it("gives every belt size a length and nothing else one", () => {
+    expect(Object.keys(BELT_LENGTH_CM).sort()).toEqual([...beltSizes].sort());
+  });
+
+  it("runs both charts in ascending order", () => {
+    const heights = giSizes.map((s) => GI_HEIGHT_CM[s]);
+    const lengths = beltSizes.map((s) => BELT_LENGTH_CM[s]);
+    expect(heights).toEqual([...heights].sort((a, b) => a - b));
+    expect(lengths).toEqual([...lengths].sort((a, b) => a - b));
+  });
+
+  it("matches the club's charts at the ends", () => {
+    expect(GI_HEIGHT_CM["000"]).toBe(110);
+    expect(GI_HEIGHT_CM["7"]).toBe(200);
+    expect(BELT_LENGTH_CM["0"]).toBe(180);
+    expect(BELT_LENGTH_CM["7"]).toBe(320);
+  });
+});
+
+describe("kit-sizes labels", () => {
+  it("leads with the size code and keeps the measurement parenthetical", () => {
+    expect(giSizeLabel("000")).toBe("000 (110 cm)");
+    expect(giSizeLabel("1")).toBe("1 (140 cm)");
+    expect(giSizeLabel("3")).toBe("3 (160 cm)");
+    expect(giSizeLabel("7")).toBe("7 (200 cm)");
+  });
+
+  it("says 'belt' on every belt label, so the length is not read as a waist", () => {
+    for (const size of beltSizes) {
+      expect(beltSizeLabel(size)).toMatch(/^\d \(\d+ cm belt\)$/);
+    }
+    expect(beltSizeLabel("3")).toBe("3 (240 cm belt)");
+  });
+
+  it("formats a stored value, and returns null when there is nothing on file", () => {
+    expect(formatGiSize("2")).toBe("2 (150 cm)");
+    expect(formatBeltSize("2")).toBe("2 (220 cm belt)");
+    expect(formatGiSize(null)).toBeNull();
+    expect(formatBeltSize(undefined)).toBeNull();
+    expect(formatGiSize("")).toBeNull();
+    // A value the chart does not know about is not rendered as if it did.
+    expect(formatGiSize("XL")).toBeNull();
+    // "000" is a gi size but not a belt size, so it must not format as one.
+    expect(formatBeltSize("000")).toBeNull();
+  });
+});
+
+describe("beltSizeForGiSize", () => {
+  it("hands out the matching belt code wherever the charts overlap", () => {
+    for (const size of beltSizes) {
+      expect(beltSizeForGiSize(size)).toBe(size);
+    }
+  });
+
+  it("defaults the two kids' gi sizes to the shortest belt the club stocks", () => {
+    expect(beltSizeForGiSize("000")).toBe("0");
+    expect(beltSizeForGiSize("00")).toBe("0");
+  });
+
+  it("always returns a real belt size", () => {
+    for (const size of giSizes) {
+      expect(isBeltSize(beltSizeForGiSize(size))).toBe(true);
+    }
+  });
+});
+
+describe("kit-sizes guards", () => {
+  it("recognises only its own codes", () => {
+    expect(isGiSize("000")).toBe(true);
+    expect(isGiSize("7")).toBe(true);
+    expect(isGiSize("8")).toBe(false);
+    expect(isGiSize("")).toBe(false);
+    // The belt chart is the shorter of the two.
+    expect(isBeltSize("000")).toBe(false);
+    expect(isBeltSize("00")).toBe(false);
+    expect(isBeltSize("0")).toBe(true);
+  });
+});

--- a/src/lib/kit-sizes.ts
+++ b/src/lib/kit-sizes.ts
@@ -1,0 +1,107 @@
+// The club's gi and belt size charts.
+//
+// This module is the single home for both code sets, in the same spirit as
+// `kb.ts`: one exported const array feeds the Zod enums in `validation.ts`, the
+// pickers on `/account`, `/waiver` and the manager screens, and the labels the
+// manager list renders. Keeping them here is what stops the vocabulary drifting
+// into several disagreeing lists.
+//
+// Pure: no side effects, no server imports.
+//
+// ⚠️ The same two code sets are also written into CHECK constraints on
+// `public.profiles` (`profiles_gi_size_check`, `profiles_belt_size_check`, added
+// by `supabase/migrations/20260806000000_profile_kit_sizes.sql`). Nothing in the
+// test suite can see a CHECK constraint, so widening either array here without a
+// migration replacing the matching constraint turns into a PostgREST 400 at
+// runtime. `kit-sizes.test.ts` pins both literals for that reason.
+
+/**
+ * Gi sizes, smallest first. A gi size is a standard size code, and each code
+ * corresponds to a wearer height (see `GI_HEIGHT_CM`).
+ */
+export const giSizes = ["000", "00", "0", "1", "2", "3", "4", "5", "6", "7"] as const;
+export type GiSize = (typeof giSizes)[number];
+
+/**
+ * Belt sizes, smallest first. The club's belt chart starts at `0`, so it is a
+ * SHORTER list than the gi chart: there is no `000` or `00` belt.
+ */
+export const beltSizes = ["0", "1", "2", "3", "4", "5", "6", "7"] as const;
+export type BeltSize = (typeof beltSizes)[number];
+
+/** The wearer height, in centimetres, each gi size is cut for. */
+export const GI_HEIGHT_CM: Record<GiSize, number> = {
+  "000": 110,
+  "00": 120,
+  "0": 130,
+  "1": 140,
+  "2": 150,
+  "3": 160,
+  "4": 170,
+  "5": 180,
+  "6": 190,
+  "7": 200,
+};
+
+/**
+ * The length of the belt itself, in centimetres. This is the piece of fabric,
+ * not a waist measurement, which is why every label that shows it says "belt".
+ */
+export const BELT_LENGTH_CM: Record<BeltSize, number> = {
+  "0": 180,
+  "1": 200,
+  "2": 220,
+  "3": 240,
+  "4": 260,
+  "5": 280,
+  "6": 300,
+  "7": 320,
+};
+
+/**
+ * A gi size as it is shown to a person: the size code first, with the height as
+ * a parenthetical aid, e.g. `1 (140 cm)`. The code leads and is never replaced
+ * by the height, so somebody who already knows their size can pick it straight
+ * off and somebody who does not can find it from their height.
+ */
+export function giSizeLabel(size: GiSize): string {
+  return `${size} (${GI_HEIGHT_CM[size]} cm)`;
+}
+
+/**
+ * A belt size as it is shown to a person, e.g. `1 (200 cm belt)`. The trailing
+ * "belt" is load-bearing: without it the number reads as a body measurement.
+ */
+export function beltSizeLabel(size: BeltSize): string {
+  return `${size} (${BELT_LENGTH_CM[size]} cm belt)`;
+}
+
+/**
+ * The belt the club would hand out with a given gi size: the same code, except
+ * for the two kids' gi sizes below the belt chart's smallest entry, which get
+ * the shortest belt stocked. Used only to seed a belt size for somebody who has
+ * none; a member or manager can change it afterwards.
+ */
+export function beltSizeForGiSize(size: GiSize): BeltSize {
+  return (beltSizes as readonly string[]).includes(size) ? (size as BeltSize) : beltSizes[0];
+}
+
+/** Whether an arbitrary string is a gi size code. */
+export function isGiSize(value: string): value is GiSize {
+  return (giSizes as readonly string[]).includes(value);
+}
+
+/** Whether an arbitrary string is a belt size code. */
+export function isBeltSize(value: string): value is BeltSize {
+  return (beltSizes as readonly string[]).includes(value);
+}
+
+/** A stored gi size rendered for display, or `null` when there is none on file. */
+export function formatGiSize(value: string | null | undefined): string | null {
+  return value && isGiSize(value) ? giSizeLabel(value) : null;
+}
+
+/** A stored belt size rendered for display, or `null` when there is none on file. */
+export function formatBeltSize(value: string | null | undefined): string | null {
+  return value && isBeltSize(value) ? beltSizeLabel(value) : null;
+}

--- a/src/lib/membership.functions.ts
+++ b/src/lib/membership.functions.ts
@@ -867,7 +867,7 @@ export const listClubUsers = createServerFn({ method: "GET" })
       admin
         .from("profiles")
         .select(
-          "user_id, first_name, middle_name, last_name, preferred_name, phone, uts_student_number, created_at",
+          "user_id, first_name, middle_name, last_name, preferred_name, phone, uts_student_number, gi_size, belt_size, created_at",
         )
         .limit(5000),
       admin.from("memberships").select("*").order("created_at", { ascending: false }).limit(2000),

--- a/src/lib/profile.functions.ts
+++ b/src/lib/profile.functions.ts
@@ -1,20 +1,51 @@
-// A signed-in person's own account-level settings. Currently just the display
-// name shown on blog comments (see docs/blog.md); not the waiver/profile
-// person fields, which are only ever written by waiver submission or manager
-// approval (see docs/database.md's `profiles` section).
+// The details a signed-in person maintains about themselves, from `/account`.
+//
+// This is the self-serve write path onto `profiles`. It covers what somebody
+// goes by, their kit sizes, and how the club reaches them. It deliberately
+// cannot reach their legal name, date of birth, UTS student number, medical
+// notes, minor/guardian fields or email: those are either evidence a signed
+// waiver froze, something that changes what they pay, or their identity, and
+// `updateMyProfileSchema` is `.strict()` so an attempt to send one is an error
+// rather than a silently dropped key.
+//
+// ⚠️ Approving a waiver still promotes that submission's person fields onto the
+// profile (`waiverToProfileFields` in validation.ts), and that set overlaps with
+// the contact fields here. So a correction made on `/account` can be overwritten
+// later by a manager approving an older waiver. `/account` says so in as many
+// words; see docs/database.md's `profiles` section for the full writer list.
 import { createServerFn } from "@tanstack/react-start";
 import { requireSupabaseAuth } from "@/integrations/supabase/auth-middleware";
-import { updateDisplayNameSchema } from "@/lib/validation";
+import { updateMyProfileSchema } from "@/lib/validation";
+import type { UpdateMyProfileInput } from "@/lib/validation";
 
-export const updateMyDisplayName = createServerFn({ method: "POST" })
+export const updateMyProfile = createServerFn({ method: "POST" })
   .middleware([requireSupabaseAuth])
-  .inputValidator((d: unknown) => updateDisplayNameSchema.parse(d))
+  .inputValidator((d: unknown) => updateMyProfileSchema.parse(d))
   .handler(async ({ data, context }) => {
+    // Each card on /account sends only its own keys, so drop the absent ones:
+    // `undefined` means "leave it alone", while an explicit `null` on a
+    // nullable field means "clear it" and must survive to the UPDATE.
+    // Typed rather than left as a bare index signature: `.update()` is then
+    // still checked against the generated column list, so a key added to the
+    // schema that is not a profiles column fails the typecheck here.
+    const patch = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined),
+    ) as UpdateMyProfileInput;
+    // The schema's refine already rejects an empty patch; this keeps a future
+    // caller from turning that into a pointless round trip.
+    if (Object.keys(patch).length === 0) return { ok: true as const, fields: [] as string[] };
+
     const { supabaseAdmin } = await import("@/integrations/supabase/client.server");
-    const { error } = await supabaseAdmin
+    const { data: updated, error } = await supabaseAdmin
       .from("profiles")
-      .update({ display_name: data.display_name, updated_at: new Date().toISOString() })
-      .eq("user_id", context.userId);
+      .update({ ...patch, updated_at: new Date().toISOString() })
+      .eq("user_id", context.userId)
+      .select("user_id");
     if (error) throw new Error(error.message);
-    return { ok: true as const, display_name: data.display_name };
+    // PostgREST reports no error when the filter matched nothing, so without
+    // this the page would toast "Saved" over a write that never happened.
+    if (!updated || updated.length === 0) {
+      throw new Error("We couldn't find your record to update. Please contact the club.");
+    }
+    return { ok: true as const, fields: Object.keys(patch) };
   });

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -43,7 +43,8 @@ import {
   setCurrentTemplateSchema,
   splitFullName,
   stopRepeatingSchema,
-  updateDisplayNameSchema,
+  updateMyProfileSchema,
+  managerKitSizesSchema,
   waiverApprovalSchema,
   waiverPrefillSearchSchema,
   greetingName,
@@ -205,17 +206,88 @@ describe("blogCommentSchema", () => {
   });
 });
 
-describe("blockCommenterSchema / updateDisplayNameSchema", () => {
+describe("blockCommenterSchema", () => {
   it("requires a valid user id to block someone", () => {
     expect(() => blockCommenterSchema.parse({ user_id: "not-a-uuid" })).toThrow();
   });
+});
 
+describe("updateMyProfileSchema", () => {
+  // These two carried over from `updateDisplayNameSchema`, which this replaced.
+  // They are the interesting half of the display-name contract: null and blank
+  // are NOT the same thing, and the handler tells them apart.
   it("allows clearing a display name override with null", () => {
-    expect(updateDisplayNameSchema.parse({ display_name: null }).display_name).toBeNull();
+    expect(updateMyProfileSchema.parse({ display_name: null }).display_name).toBeNull();
   });
 
   it("rejects a blank (non-null) display name", () => {
-    expect(() => updateDisplayNameSchema.parse({ display_name: "" })).toThrow();
+    expect(() => updateMyProfileSchema.parse({ display_name: "" })).toThrow();
+  });
+
+  it("keeps an absent key distinct from an explicit null", () => {
+    // "leave it alone" vs "clear it". The handler filters on `undefined`, so
+    // collapsing these (with .nullish(), say) would make one impossible.
+    const patch = updateMyProfileSchema.parse({ gi_size: null });
+    expect(patch.gi_size).toBeNull();
+    expect("display_name" in patch).toBe(false);
+  });
+
+  it("saves one card's fields at a time", () => {
+    expect(updateMyProfileSchema.parse({ gi_size: "4", belt_size: "3" })).toEqual({
+      gi_size: "4",
+      belt_size: "3",
+    });
+  });
+
+  it("rejects an empty patch", () => {
+    expect(() => updateMyProfileSchema.parse({})).toThrow();
+  });
+
+  it("refuses fields this path does not own, rather than dropping them", () => {
+    // A caller that thought it was saving a legal name should hear that it was
+    // not. The schema is .strict() for exactly this.
+    expect(() => updateMyProfileSchema.parse({ first_name: "Ada" })).toThrow();
+    expect(() => updateMyProfileSchema.parse({ date_of_birth: "1990-01-01" })).toThrow();
+    expect(() => updateMyProfileSchema.parse({ medical_notes: "None" })).toThrow();
+    expect(() => updateMyProfileSchema.parse({ uts_student_number: "12345678" })).toThrow();
+    expect(() => updateMyProfileSchema.parse({ is_minor: true })).toThrow();
+    expect(() => updateMyProfileSchema.parse({ email: "ada@example.com" })).toThrow();
+  });
+
+  it("rejects a size that is not on the club's chart", () => {
+    expect(() => updateMyProfileSchema.parse({ gi_size: "8" })).toThrow();
+    // The belt chart is the shorter of the two: there is no 000 belt.
+    expect(() => updateMyProfileSchema.parse({ belt_size: "000" })).toThrow();
+    expect(updateMyProfileSchema.parse({ gi_size: "000" }).gi_size).toBe("000");
+  });
+
+  it("bounds the contact fields the same way the waiver does", () => {
+    expect(() => updateMyProfileSchema.parse({ phone: "x".repeat(31) })).toThrow();
+    expect(() => updateMyProfileSchema.parse({ address: "x".repeat(301) })).toThrow();
+    expect(() => updateMyProfileSchema.parse({ emergency_contact_name: "" })).toThrow();
+    expect(() => updateMyProfileSchema.parse({ emergency_contact_relationship: "" })).toThrow();
+  });
+});
+
+describe("managerKitSizesSchema", () => {
+  it("takes a person and both sizes, either of which may be cleared", () => {
+    expect(
+      managerKitSizesSchema.parse({
+        userId: "11111111-1111-4111-8111-111111111111",
+        gi_size: "5",
+        belt_size: null,
+      }),
+    ).toEqual({
+      userId: "11111111-1111-4111-8111-111111111111",
+      gi_size: "5",
+      belt_size: null,
+    });
+  });
+
+  it("requires a real user id", () => {
+    expect(() =>
+      managerKitSizesSchema.parse({ userId: "nope", gi_size: null, belt_size: null }),
+    ).toThrow();
   });
 });
 
@@ -254,6 +326,15 @@ describe("waiverToProfileFields", () => {
       email: "ada@example.com",
     } as never);
     expect(patch).toEqual(fields);
+  });
+
+  it("does not carry kit sizes, which no waiver records", () => {
+    // Sizing lives only on the profile, so approving a waiver must leave it
+    // alone. If these ever appeared here, approving an old waiver would undo a
+    // size a member or manager had since corrected.
+    const patch = waiverToProfileFields({ gi_size: "4", belt_size: "3" } as never);
+    expect("gi_size" in patch).toBe(false);
+    expect("belt_size" in patch).toBe(false);
   });
 });
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -10,6 +10,10 @@ import { z } from "zod";
 // permission rules are written in; importing it here keeps the wire schema and
 // those rules from drifting into two different lists of visibilities.
 import { annotationVisibilities, articleVisibilities } from "./kb";
+// Same idea for the gi/belt size charts: `kit-sizes.ts` owns the two code sets
+// (and the CHECK constraints on `profiles` mirror them), so the wire schemas
+// below enumerate them from there rather than repeating the lists.
+import { beltSizes, giSizes } from "./kit-sizes";
 // A dated plan's window is computed in the club's own timezone (its last day
 // must cover that evening's class, not cut off at UTC midnight), so this
 // module needs the same zoned-time helpers the calendar uses. `calendar.ts` is
@@ -390,6 +394,12 @@ export const waiverSubmitSchema = z
     // Consent to be contacted by SMS/WhatsApp and added to club WhatsApp groups.
     // Optional (not required to submit); defaults to no consent.
     sms_whatsapp_consent: z.boolean().optional().default(false),
+    // Optional gi size. NOT part of the waiver: it is never written to the
+    // `waivers` row and never printed on the PDF, because it is equipment
+    // sizing rather than anything the person is declaring or agreeing to. The
+    // handler writes it straight onto their profile, and a blank one writes
+    // nothing at all, so re-signing never clears a size already on file.
+    gi_size: z.enum(giSizes).optional().or(z.literal("")),
     // The emergency contact. For a participant under 18 this person IS the
     // parent/guardian who signs, which is why the relationship is required for
     // everyone and reused as the "relationship to minor" on the document.
@@ -2196,10 +2206,63 @@ export type BlockCommenterInput = z.infer<typeof blockCommenterSchema>;
 export const unblockCommenterSchema = z.object({ user_id: z.string().uuid() });
 export type UnblockCommenterInput = z.infer<typeof unblockCommenterSchema>;
 
-// ---- Account: display name (shown on blog comments) ----
+// ---- Account: the details a member maintains themselves ----
 
-/** `display_name: null` clears the override, reverting to the derived name. */
-export const updateDisplayNameSchema = z.object({
-  display_name: z.string().trim().min(1).max(60).nullable(),
+/**
+ * The patch `/account` sends when somebody edits their own record.
+ *
+ * Every key is optional because the page saves one card at a time, and each
+ * card sends only its own fields. An absent key means "leave it alone"; an
+ * explicit `null` on a nullable field means "clear it". The handler tells the
+ * two apart by checking for `undefined`, so nothing here may use `.nullish()`,
+ * which would collapse the distinction.
+ *
+ * What is deliberately NOT here, and cannot be reached through it: the legal
+ * name, date of birth, UTS student number, medical notes, the minor/guardian
+ * fields, and the email. Those are either evidence a waiver froze, a thing that
+ * changes what somebody pays, or the person's identity — see the note at the
+ * foot of `routes/_authenticated/account.tsx`. String bounds mirror
+ * `waiverSubmitSchema` field for field so the two write paths cannot disagree
+ * about what fits in a column.
+ */
+export const updateMyProfileSchema = z
+  .object({
+    // `null` clears the override and reverts to the derived name
+    // (`commentDisplayName`). `""` is rejected: blanking the box is expressed
+    // as null by the caller, not as an empty string in the column.
+    // Nullable below means "the member may clear this". Kit sizes and the two
+    // names can be cleared, because an absent one is a real state the app renders
+    // (a derived comment name, no size on file). The contact fields cannot: the
+    // club has to be able to reach somebody and to call someone if they get
+    // hurt, so those are editable but not erasable, which is also why the form
+    // marks them required.
+    display_name: z.string().trim().min(1).max(60).nullable().optional(),
+    // Same shape as `display_name` above: `null` clears it, `""` is rejected,
+    // so "no preferred name" has exactly one representation in the column.
+    preferred_name: z.string().trim().min(1).max(60).nullable().optional(),
+    phone: z.string().trim().min(1).max(30).optional(),
+    address: z.string().trim().min(1).max(300).optional(),
+    sms_whatsapp_consent: z.boolean().optional(),
+    emergency_contact_name: z.string().trim().min(1).max(120).optional(),
+    emergency_contact_relationship: z.string().trim().min(1).max(80).optional(),
+    emergency_contact_phone: z.string().trim().min(1).max(30).optional(),
+    gi_size: z.enum(giSizes).nullable().optional(),
+    belt_size: z.enum(beltSizes).nullable().optional(),
+  })
+  // Unknown keys are an attempt to write a field this path does not own (a
+  // legal name, a date of birth), not a harmless extra. Rejecting beats
+  // stripping: a caller that thought it was saving `first_name` should hear
+  // that it was not.
+  .strict()
+  .refine((patch) => Object.values(patch).some((v) => v !== undefined), {
+    message: "Nothing to update.",
+  });
+export type UpdateMyProfileInput = z.infer<typeof updateMyProfileSchema>;
+
+/** Manager: correct somebody's kit sizes from their detail page. */
+export const managerKitSizesSchema = z.object({
+  userId: z.string().uuid(),
+  gi_size: z.enum(giSizes).nullable(),
+  belt_size: z.enum(beltSizes).nullable(),
 });
-export type UpdateDisplayNameInput = z.infer<typeof updateDisplayNameSchema>;
+export type ManagerKitSizesInput = z.infer<typeof managerKitSizesSchema>;

--- a/src/lib/waiver-draft.test.ts
+++ b/src/lib/waiver-draft.test.ts
@@ -24,6 +24,7 @@ const blank: WaiverDraft = {
   address: "",
   utsStudentNumber: "",
   smsConsent: false,
+  giSize: "",
   ecName: "",
   ecRelationship: "",
   ecPhone: "",
@@ -47,6 +48,7 @@ const filled: WaiverDraft = {
   email: "ada@example.com",
   address: "1 Broadway, Ultimo NSW",
   smsConsent: true,
+  giSize: "4",
   ecName: "Charles Babbage",
   ecRelationship: "Colleague",
   ecPhone: "0400000001",
@@ -71,6 +73,21 @@ describe("serializeDraft / parseDraft", () => {
     // person has no way to tell. Starting clean is the honest failure.
     const stale = JSON.stringify({ ...filled, version: WAIVER_DRAFT_VERSION - 1 });
     expect(parseDraft(stale)).toBeNull();
+  });
+
+  it("restores a draft saved before an optional field existed, rather than binning it", () => {
+    // `giSize` was added without bumping the version, on purpose. A draft that
+    // predates it is not a stale shape: the field is optional, and restoring it
+    // as "" says exactly what is true, that nobody chose a size. Bumping would
+    // have thrown away every half-filled waiver, signature included, over a
+    // field none of them had.
+    const { giSize: _omitted, ...withoutGiSize } = filled;
+    const older = JSON.stringify({ ...withoutGiSize, version: WAIVER_DRAFT_VERSION });
+    const restored = parseDraft(older);
+    expect(restored).not.toBeNull();
+    expect(restored?.giSize).toBe("");
+    expect(restored?.firstName).toBe("Ada");
+    expect(restored?.signatureImage).toBe(filled.signatureImage);
   });
 
   it("ignores malformed or empty storage", () => {

--- a/src/lib/waiver-draft.ts
+++ b/src/lib/waiver-draft.ts
@@ -54,6 +54,8 @@ export type WaiverDraft = {
   address: string;
   utsStudentNumber: string;
   smsConsent: boolean;
+  /** A gi size code, or "" for not chosen. Optional on the form, so "" is normal. */
+  giSize: string;
   ecName: string;
   ecRelationship: string;
   ecPhone: string;
@@ -139,6 +141,13 @@ export function parseDraft(raw: string | null): WaiverDraft | null {
     address: text(draft.address),
     utsStudentNumber: text(draft.utsStudentNumber),
     smsConsent: draft.smsConsent === true,
+    // Deliberately does NOT bump WAIVER_DRAFT_VERSION: `giSize` is a new
+    // optional field, and a draft written before it existed restores with "",
+    // which is exactly what "did not choose one" means. The version bump is for
+    // renames and removals, where a silent half-restore would lose something.
+    // Bumping here would bin every half-filled waiver, signature included, over
+    // a field nobody had filled in.
+    giSize: text(draft.giSize),
     ecName: text(draft.ecName),
     ecRelationship: text(draft.ecRelationship),
     ecPhone: text(draft.ecPhone),

--- a/src/lib/waiver.functions.test.ts
+++ b/src/lib/waiver.functions.test.ts
@@ -335,6 +335,177 @@ const validInput: PaperWaiverUploadInput = {
   confirm_duplicate: false,
 };
 
+/**
+ * A profiles-table stub for `applyWaiverGiSize`: one read chain and one write
+ * chain, recording every patch so a test can assert what was (and was not)
+ * written. `row: null` is "no profile"; `readError`/`writeError` force the
+ * failure paths; `updatedRows` forces the zero-rows-matched case.
+ */
+function fakeProfilesAdmin(opts: {
+  row?: { gi_size: string | null; belt_size: string | null } | null;
+  readError?: string;
+  writeError?: string;
+  updatedRows?: unknown[];
+}) {
+  const patches: Record<string, unknown>[] = [];
+  const admin = {
+    from(_table: string) {
+      return {
+        select(_cols: string) {
+          return {
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: opts.row === undefined ? { gi_size: null, belt_size: null } : opts.row,
+                error: opts.readError ? { message: opts.readError } : null,
+              }),
+            }),
+          };
+        },
+        update(patch: Record<string, unknown>) {
+          patches.push(patch);
+          return {
+            eq: () => ({
+              select: async () => ({
+                data: opts.updatedRows ?? [{ user_id: "u1" }],
+                error: opts.writeError ? { message: opts.writeError } : null,
+              }),
+            }),
+          };
+        },
+      };
+    },
+  };
+  return { admin: admin as unknown as SupabaseClient<Database>, patches };
+}
+
+describe("applyWaiverGiSize", () => {
+  const PERSON = "u1";
+
+  it("refuses to touch an existing person without proof the submitter is them", async () => {
+    // THE security boundary. /waiver is public and unauthenticated, and
+    // resolvePersonId resolves any known email to that existing person, so
+    // without this anyone could POST a member's address and rewrite their
+    // record. Nothing may be written, and nothing may be read either.
+    const { admin, patches } = fakeProfilesAdmin({ row: { gi_size: "2", belt_size: "2" } });
+    const { applyWaiverGiSize } = await import("./waiver.functions");
+
+    const result = await applyWaiverGiSize(admin, {
+      userId: PERSON,
+      giSize: "7",
+      identityProven: false,
+    });
+
+    expect(result).toBe("skipped");
+    expect(patches).toHaveLength(0);
+  });
+
+  it("writes the size when the submitter is proven to be that person", async () => {
+    const { admin, patches } = fakeProfilesAdmin({ row: { gi_size: "2", belt_size: "3" } });
+    const { applyWaiverGiSize } = await import("./waiver.functions");
+
+    const result = await applyWaiverGiSize(admin, {
+      userId: PERSON,
+      giSize: "5",
+      identityProven: true,
+    });
+
+    expect(result).toBe("written");
+    expect(patches).toHaveLength(1);
+    expect(patches[0]).toMatchObject({ gi_size: "5" });
+    // A record that already carries sizing keeps the belt it has.
+    expect(patches[0]).not.toHaveProperty("belt_size");
+    expect(patches[0].updated_at).toEqual(expect.any(String));
+  });
+
+  it("writes nothing at all for a blank size, so re-signing never clears one", async () => {
+    const { admin, patches } = fakeProfilesAdmin({ row: { gi_size: "4", belt_size: "4" } });
+    const { applyWaiverGiSize } = await import("./waiver.functions");
+
+    for (const blank of ["", null, undefined]) {
+      expect(
+        await applyWaiverGiSize(admin, { userId: PERSON, giSize: blank, identityProven: true }),
+      ).toBe("skipped");
+    }
+    expect(patches).toHaveLength(0);
+  });
+
+  it("fills in the belt only when the record carries no sizing at all", async () => {
+    const { admin, patches } = fakeProfilesAdmin({ row: { gi_size: null, belt_size: null } });
+    const { applyWaiverGiSize } = await import("./waiver.functions");
+
+    await applyWaiverGiSize(admin, { userId: PERSON, giSize: "3", identityProven: true });
+
+    expect(patches[0]).toMatchObject({ gi_size: "3", belt_size: "3" });
+  });
+
+  it("sends a kids' gi size to the shortest belt the club stocks", async () => {
+    const { admin, patches } = fakeProfilesAdmin({ row: { gi_size: null, belt_size: null } });
+    const { applyWaiverGiSize } = await import("./waiver.functions");
+
+    await applyWaiverGiSize(admin, { userId: PERSON, giSize: "000", identityProven: true });
+
+    // There is no 000 or 00 belt on the club's chart.
+    expect(patches[0]).toMatchObject({ gi_size: "000", belt_size: "0" });
+  });
+
+  it("never puts back a belt somebody cleared on purpose", async () => {
+    // gi set, belt null = deliberately cleared on /account, NOT "never sized".
+    const { admin, patches } = fakeProfilesAdmin({ row: { gi_size: "4", belt_size: null } });
+    const { applyWaiverGiSize } = await import("./waiver.functions");
+
+    await applyWaiverGiSize(admin, { userId: PERSON, giSize: "5", identityProven: true });
+
+    expect(patches[0]).toMatchObject({ gi_size: "5" });
+    expect(patches[0]).not.toHaveProperty("belt_size");
+  });
+
+  it("refuses to guess when the read fails, rather than re-seeding a belt", async () => {
+    const { admin, patches } = fakeProfilesAdmin({ readError: "connection reset" });
+    const { applyWaiverGiSize } = await import("./waiver.functions");
+
+    await expect(
+      applyWaiverGiSize(admin, { userId: PERSON, giSize: "5", identityProven: true }),
+    ).rejects.toThrow("connection reset");
+    expect(patches).toHaveLength(0);
+  });
+
+  it("throws when there is no profile row to write to", async () => {
+    const { admin, patches } = fakeProfilesAdmin({ row: null });
+    const { applyWaiverGiSize } = await import("./waiver.functions");
+
+    await expect(
+      applyWaiverGiSize(admin, { userId: PERSON, giSize: "5", identityProven: true }),
+    ).rejects.toThrow(/No profile/);
+    expect(patches).toHaveLength(0);
+  });
+
+  it("does not report success when the update matched no rows", async () => {
+    // PostgREST returns no error when the filter matched nothing, so without
+    // checking the returned rows this would claim to have written.
+    const { admin } = fakeProfilesAdmin({
+      row: { gi_size: null, belt_size: null },
+      updatedRows: [],
+    });
+    const { applyWaiverGiSize } = await import("./waiver.functions");
+
+    await expect(
+      applyWaiverGiSize(admin, { userId: PERSON, giSize: "5", identityProven: true }),
+    ).rejects.toThrow(/No profile/);
+  });
+
+  it("surfaces a write error", async () => {
+    const { admin } = fakeProfilesAdmin({
+      row: { gi_size: null, belt_size: null },
+      writeError: "violates check constraint",
+    });
+    const { applyWaiverGiSize } = await import("./waiver.functions");
+
+    await expect(
+      applyWaiverGiSize(admin, { userId: PERSON, giSize: "5", identityProven: true }),
+    ).rejects.toThrow("violates check constraint");
+  });
+});
+
 describe("filePaperWaiver", () => {
   beforeEach(() => {
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/src/lib/waiver.functions.ts
+++ b/src/lib/waiver.functions.ts
@@ -24,6 +24,7 @@ import {
   waiverToProfileFields,
 } from "@/lib/validation";
 import type { PaperWaiverUploadInput, SignerMeta } from "@/lib/validation";
+import { beltSizeForGiSize, type GiSize } from "@/lib/kit-sizes";
 import {
   missingRequiredAcks,
   parseTemplateAcks,
@@ -161,7 +162,76 @@ type PersonSeed = {
   last_name: string;
   preferred_name: string | null;
   phone: string | null;
+  /** Optional kit sizing. Only ever seeds a person being created right now. */
+  gi_size?: string | null;
+  belt_size?: string | null;
 };
+
+/**
+ * Write the optional gi size a waiver submission carried onto the signer's
+ * profile.
+ *
+ * Sizing is equipment, not part of the waiver: no `waivers` column holds it and
+ * it never reaches the PDF. It lives only on the profile, so it is written here.
+ *
+ * ⚠️ `identityProven` is the security boundary, and it is not optional.
+ * `/waiver` is public and unauthenticated, and `resolvePersonId` resolves ANY
+ * email the club already knows to that existing person — its contract is that
+ * "resubmission is always allowed and never modifies the existing person".
+ * Without this gate anyone could POST a submission carrying a member's address
+ * and rewrite that member's record, with no login and no manager step. So an
+ * existing person's size moves only when the submitter is demonstrably them:
+ * signed in as them (already checked against the submitted address), or holding
+ * a link we emailed to that address. A brand-new person is handled by
+ * `PersonSeed` in `resolvePersonId` instead, where there is nothing to
+ * overwrite.
+ *
+ * Two further rules, both about not destroying something deliberate:
+ *
+ * - A BLANK size writes nothing at all. Leaving an optional field empty means
+ *   "nothing to say", so re-signing never clears a size already on file.
+ * - The belt is filled in from the gi size ONLY when the record carries no
+ *   sizing whatsoever. Once either size is set, a null belt is a belt somebody
+ *   cleared on purpose, and a later waiver must not quietly put it back.
+ *
+ * Takes `admin` as a parameter rather than lazy-importing it, for the same
+ * reason `signStoredPdf` and `filePaperWaiver` do: the createServerFn handler
+ * around it cannot run under the test runner, and this can.
+ */
+export async function applyWaiverGiSize(
+  admin: SupabaseClient<Database>,
+  opts: { userId: string; giSize: string | null | undefined; identityProven: boolean },
+): Promise<"written" | "skipped"> {
+  if (!opts.giSize) return "skipped";
+  if (!opts.identityProven) return "skipped";
+
+  // This read decides whether the belt gets filled in, so a FAILED read must
+  // not read as "no sizing on file" — that would let a transient error put back
+  // a belt somebody cleared. Throw rather than guess; the caller swallows it.
+  const { data: current, error: readErr } = await admin
+    .from("profiles")
+    .select("gi_size, belt_size")
+    .eq("user_id", opts.userId)
+    .maybeSingle();
+  if (readErr) throw new Error(readErr.message);
+  if (!current) throw new Error("No profile to write that size to.");
+
+  const neverSized = current.gi_size == null && current.belt_size == null;
+  const { data: updated, error: writeErr } = await admin
+    .from("profiles")
+    .update({
+      gi_size: opts.giSize,
+      ...(neverSized ? { belt_size: beltSizeForGiSize(opts.giSize as GiSize) } : {}),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("user_id", opts.userId)
+    .select("user_id");
+  if (writeErr) throw new Error(writeErr.message);
+  // PostgREST reports no error when the filter matched nothing, so "no rows"
+  // would otherwise be indistinguishable from a successful write.
+  if (!updated || updated.length === 0) throw new Error("No profile to write that size to.");
+  return "written";
+}
 
 /**
  * The person (auth user) an incoming waiver belongs to, creating them if this
@@ -347,6 +417,13 @@ export const submitWaiverWithPdf = createServerFn({ method: "POST" })
           // This retry didn't mint a token itself; the original attempt's
           // confirmation email already carries the working link.
           code_of_conduct_url: null,
+          // Nor does it re-apply the gi size. This return sits above the point
+          // where the email is normalized and identity is established, so
+          // `applyWaiverGiSize` has neither the person nor the proof it needs,
+          // and hoisting that work above the duplicate check would be a lot of
+          // machinery for a best-effort field. If the original attempt's size
+          // write failed, the size is simply not set, and the member or a
+          // manager sets it on /account. Deliberate, not an oversight.
         };
       }
     }
@@ -457,6 +534,12 @@ export const submitWaiverWithPdf = createServerFn({ method: "POST" })
             last_name: data.last_name,
             preferred_name: data.preferred_name || null,
             phone: data.phone || null,
+            // Only reached when this email is NEW to the club, so there is no
+            // existing record for these to overwrite. An existing person's
+            // sizes are handled further down, and only with proof of identity.
+            ...(data.gi_size
+              ? { gi_size: data.gi_size, belt_size: beltSizeForGiSize(data.gi_size) }
+              : {}),
           },
         });
 
@@ -571,6 +654,19 @@ export const submitWaiverWithPdf = createServerFn({ method: "POST" })
     // legally exists. Throwing would tell the person who just signed that it
     // failed, and the reliable thing they do next is sign again. So a failure
     // here comes back as `pdf_ready: false` and the page says so plainly.
+
+    // The optional gi size the form collected, onto the signer's profile.
+    // Extracted so it is reachable from a unit test (see applyWaiverGiSize);
+    // best-effort here because a size must never cost somebody a signature.
+    try {
+      await applyWaiverGiSize(admin, {
+        userId,
+        giSize: data.gi_size,
+        identityProven: Boolean(callerId || emailProven),
+      });
+    } catch (e) {
+      console.error("waiver: could not save gi size", e);
+    }
 
     /**
      * Tell the member and the managers, with or without a copy.

--- a/src/routes/_authenticated/account.test.tsx
+++ b/src/routes/_authenticated/account.test.tsx
@@ -1,0 +1,316 @@
+// `/account` is the only self-serve write path onto `profiles`, and the rules
+// worth pinning are about WHICH keys leave the page, not how it looks: each
+// card must send its own fields and nothing else, a blank display name must go
+// out as `null` (clearing the override) rather than `""` (which the schema
+// rejects), and an unset size must go out as `null` rather than "".
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const updateMyProfile = vi.fn().mockResolvedValue({ ok: true, fields: [] });
+
+const PROFILE = {
+  user_id: "u1",
+  first_name: "Ada",
+  middle_name: null,
+  last_name: "Lovelace",
+  preferred_name: null,
+  display_name: null,
+  date_of_birth: "1990-12-10",
+  address: "1 Broadway, Ultimo NSW",
+  phone: "0400000000",
+  uts_student_number: null,
+  emergency_contact_name: "Charles Babbage",
+  emergency_contact_relationship: "Colleague",
+  emergency_contact_phone: "0400000001",
+  medical_notes: null,
+  is_minor: false,
+  guardian_name: null,
+  guardian_relationship: null,
+  sms_whatsapp_consent: false,
+  gi_size: "4",
+  belt_size: "3",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => opts,
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+}));
+
+vi.mock("@tanstack/react-start", () => ({
+  useServerFn: (fn: unknown) => fn,
+}));
+
+vi.mock("@/lib/profile.functions", () => ({
+  updateMyProfile: (...args: unknown[]) => updateMyProfile(...args),
+}));
+
+vi.mock("@/lib/waiver.functions", () => ({
+  getMyProfile: vi.fn().mockResolvedValue(PROFILE),
+  listMyWaivers: vi.fn().mockResolvedValue([]),
+  getWaiverPdfUrl: vi.fn(),
+}));
+
+vi.mock("@/lib/code-of-conduct.functions", () => ({
+  getCodeOfConductSigner: vi.fn().mockResolvedValue({ status: null }),
+}));
+
+vi.mock("@/lib/email-verification.functions", () => ({
+  requestMyEmailVerification: vi.fn(),
+}));
+
+vi.mock("@/lib/google-drive.functions", () => ({
+  DEFAULT_FOLDER_NAME: "UTS Jitsu waivers",
+  getGoogleDriveStatus: vi.fn().mockResolvedValue({ connected: false }),
+  startGoogleDriveConnect: vi.fn(),
+  saveGoogleDriveConnection: vi.fn(),
+  disconnectGoogleDrive: vi.fn(),
+  setGoogleDriveFolder: vi.fn(),
+  setGoogleDriveFolderFromPicker: vi.fn(),
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: { auth: { updateUser: vi.fn() } },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({
+    user: { id: "u1", email: "ada@example.com", email_confirmed_at: "2026-01-01T00:00:00Z" },
+    session: null,
+    loading: false,
+  }),
+  useRoles: () => ({ roles: ["member"], loading: false, isManager: false }),
+}));
+
+const { Route } = await import("./account");
+const AccountPage = (Route as unknown as { component: () => ReactNode }).component;
+
+/**
+ * The card whose title is `title`. Three cards render a button labelled "Save",
+ * so every interaction below has to be scoped to one of them. `CardTitle` is a
+ * div rather than a heading, hence matching on text and walking up to the card
+ * wrapper (`rounded-xl` is the Card primitive's own class).
+ */
+const card = (title: string): HTMLElement =>
+  screen.getByText(title).closest("div.rounded-xl") as HTMLElement;
+
+async function renderLoaded() {
+  render(<AccountPage />);
+  // Every editable card renders "Loading..." until the one shared profile fetch
+  // resolves, so waiting for a field is waiting for all three.
+  await screen.findByLabelText("Gi size");
+}
+
+beforeEach(() => {
+  updateMyProfile.mockClear();
+});
+
+describe("/account", () => {
+  it("fetches the profile once for all three editable cards", async () => {
+    const { getMyProfile } = await import("@/lib/waiver.functions");
+    await renderLoaded();
+    expect(getMyProfile).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the sizes already on file, by code and measurement", async () => {
+    await renderLoaded();
+    expect(screen.getByLabelText("Gi size")).toHaveValue("4");
+    expect(screen.getByLabelText("Belt size")).toHaveValue("3");
+    // The code leads and the measurement is the parenthetical aid, never the
+    // other way round: somebody who knows their size must be able to find it.
+    expect(
+      within(screen.getByLabelText("Gi size")).getByRole("option", { name: "4 (170 cm)" }),
+    ).toBeInTheDocument();
+    // "belt" on the belt option, so 240 cm does not read as a waist.
+    expect(
+      within(screen.getByLabelText("Belt size")).getByRole("option", { name: "3 (240 cm belt)" }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers 000 and 00 gi sizes but no belt below 0", async () => {
+    await renderLoaded();
+    const belt = within(screen.getByLabelText("Belt size"));
+    expect(
+      within(screen.getByLabelText("Gi size")).getByRole("option", { name: "000 (110 cm)" }),
+    ).toBeInTheDocument();
+    expect(belt.queryByRole("option", { name: /^000/ })).toBeNull();
+    expect(belt.queryByRole("option", { name: /^00 / })).toBeNull();
+  });
+
+  it("sends only the sizing keys when the sizing card saves", async () => {
+    const user = userEvent.setup();
+    await renderLoaded();
+
+    await user.selectOptions(screen.getByLabelText("Gi size"), "5");
+    await user.click(within(card("Kit sizing")).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(updateMyProfile).toHaveBeenCalledTimes(1));
+    expect(updateMyProfile).toHaveBeenCalledWith({ data: { gi_size: "5", belt_size: "3" } });
+  });
+
+  it("clears a size with null rather than an empty string", async () => {
+    const user = userEvent.setup();
+    await renderLoaded();
+
+    await user.selectOptions(screen.getByLabelText("Belt size"), "");
+    await user.click(within(card("Kit sizing")).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(updateMyProfile).toHaveBeenCalledTimes(1));
+    expect(updateMyProfile).toHaveBeenCalledWith({ data: { gi_size: "4", belt_size: null } });
+  });
+
+  it("clears a blank display name with null, which is what reverts to the derived name", async () => {
+    const user = userEvent.setup();
+    await renderLoaded();
+
+    // `""` is rejected by the schema on purpose: blanking the box means "use
+    // the derived name", and that is expressed as null.
+    await user.type(screen.getByLabelText("Preferred name"), "Addy");
+    await user.click(within(card("About you")).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(updateMyProfile).toHaveBeenCalledTimes(1));
+    expect(updateMyProfile).toHaveBeenCalledWith({
+      data: { preferred_name: "Addy", display_name: null },
+    });
+  });
+
+  it("sends the contact card's own fields, and no others", async () => {
+    const user = userEvent.setup();
+    await renderLoaded();
+
+    await user.clear(screen.getByLabelText("Mobile", { selector: "#account-phone" }));
+    await user.type(screen.getByLabelText("Mobile", { selector: "#account-phone" }), "0411111111");
+    await user.click(within(card("Contact")).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(updateMyProfile).toHaveBeenCalledTimes(1));
+    expect(updateMyProfile).toHaveBeenCalledWith({
+      data: {
+        phone: "0411111111",
+        address: "1 Broadway, Ultimo NSW",
+        sms_whatsapp_consent: false,
+        emergency_contact_name: "Charles Babbage",
+        emergency_contact_relationship: "Colleague",
+        emergency_contact_phone: "0400000001",
+      },
+    });
+  });
+
+  it("keeps unsaved typing in one card when a different card is saved", async () => {
+    // Every card used to reset from the whole `profile` object, so saving any
+    // one of them replaced that object, re-ran all three effects, and silently
+    // discarded whatever the member had typed elsewhere but not yet saved.
+    // Fails before the effects were scoped to each card's own fields.
+    const user = userEvent.setup();
+    await renderLoaded();
+
+    const ecName = screen.getByLabelText("Name", { selector: "#account-ec-name" });
+    await user.clear(ecName);
+    await user.type(ecName, "Grace Hopper");
+    await user.selectOptions(screen.getByLabelText("Gi size"), "6");
+
+    // Save a card that owns neither of the fields touched above.
+    await user.type(screen.getByLabelText("Preferred name"), "Addy");
+    await user.click(within(card("About you")).getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(updateMyProfile).toHaveBeenCalledTimes(1));
+
+    expect(ecName).toHaveValue("Grace Hopper");
+    expect(screen.getByLabelText("Gi size")).toHaveValue("6");
+  });
+
+  it("keeps Save disabled until something actually differs from what is stored", async () => {
+    const user = userEvent.setup();
+    await renderLoaded();
+
+    const save = () => within(card("Kit sizing")).getByRole("button", { name: "Save" });
+    expect(save()).toBeDisabled();
+    expect(within(card("About you")).getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(within(card("Contact")).getByRole("button", { name: "Save" })).toBeDisabled();
+
+    await user.selectOptions(screen.getByLabelText("Gi size"), "5");
+    expect(save()).toBeEnabled();
+
+    // Only the card that changed wakes up.
+    expect(within(card("Contact")).getByRole("button", { name: "Save" })).toBeDisabled();
+
+    // Back to the stored value by hand: nothing differs, so nothing to save.
+    await user.selectOptions(screen.getByLabelText("Gi size"), "4");
+    expect(save()).toBeDisabled();
+  });
+
+  it("offers Revert only while there are unsaved changes, and puts the stored values back", async () => {
+    const user = userEvent.setup();
+    await renderLoaded();
+
+    const revert = () => within(card("Contact")).queryByRole("button", { name: "Revert" });
+    expect(revert()).toBeNull();
+
+    const phone = screen.getByLabelText("Mobile", { selector: "#account-phone" });
+    await user.clear(phone);
+    await user.type(phone, "0499999999");
+    expect(revert()).toBeInTheDocument();
+    expect(within(card("Contact")).getByText("Unsaved changes")).toBeInTheDocument();
+
+    await user.click(revert()!);
+
+    expect(phone).toHaveValue("0400000000");
+    expect(revert()).toBeNull();
+    expect(within(card("Contact")).getByRole("button", { name: "Save" })).toBeDisabled();
+    // Reverting is local: it must never write anything.
+    expect(updateMyProfile).not.toHaveBeenCalled();
+  });
+
+  it("does not offer empty editable cards when the profile could not be loaded", async () => {
+    // A dropped connection used to be indistinguishable from "you have no
+    // details": the cards rendered editable and blank, and one Save wrote those
+    // blanks over a record that was there all along.
+    const { getMyProfile } = await import("@/lib/waiver.functions");
+    vi.mocked(getMyProfile).mockRejectedValueOnce(new Error("network"));
+
+    render(<AccountPage />);
+
+    await screen.findByText("We couldn't load your details");
+    expect(screen.queryByLabelText("Gi size")).toBeNull();
+    expect(screen.queryByLabelText("Preferred name")).toBeNull();
+    expect(screen.queryByLabelText("Mobile", { selector: "#account-phone" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+    expect(updateMyProfile).not.toHaveBeenCalled();
+  });
+
+  it("recovers the editable cards when the retry succeeds", async () => {
+    const user = userEvent.setup();
+    const { getMyProfile } = await import("@/lib/waiver.functions");
+    vi.mocked(getMyProfile).mockRejectedValueOnce(new Error("network"));
+
+    render(<AccountPage />);
+    await screen.findByText("We couldn't load your details");
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(await screen.findByLabelText("Gi size")).toHaveValue("4");
+    expect(screen.queryByText("We couldn't load your details")).toBeNull();
+  });
+
+  it("offers nothing that would edit the legal name, date of birth or email", async () => {
+    await renderLoaded();
+    // These are evidence a signed waiver froze, or the person's identity. The
+    // page says who to ask instead of pretending they are editable here.
+    expect(screen.queryByLabelText(/first name/i)).toBeNull();
+    expect(screen.queryByLabelText(/date of birth/i)).toBeNull();
+    expect(screen.queryByLabelText(/^email$/i)).toBeNull();
+    expect(screen.queryByLabelText(/medical/i)).toBeNull();
+  });
+
+  it("tells a member their contact edits do not rewrite a signed waiver", async () => {
+    await renderLoaded();
+    expect(
+      within(card("Contact")).getByText(/does not change a waiver you have already signed/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/routes/_authenticated/account.tsx
+++ b/src/routes/_authenticated/account.tsx
@@ -1,13 +1,22 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Pill } from "@/components/site/StatusPill";
+import {
+  BELT_SIZE_HINT,
+  BeltSizeSelect,
+  GI_SIZE_HINT,
+  GiSizeSelect,
+} from "@/components/site/KitSizeSelect";
+import type { BeltSize, GiSize } from "@/lib/kit-sizes";
+import { isBeltSize, isGiSize } from "@/lib/kit-sizes";
 import { formatDate } from "@/lib/dates";
 import { waiverClass } from "@/lib/status-colours";
 import { useAuth, useRoles } from "@/hooks/useAuth";
@@ -26,8 +35,9 @@ import { getCodeOfConductSigner } from "@/lib/code-of-conduct.functions";
 import type { CodeOfConductState } from "@/lib/code-of-conduct";
 import { requestMyEmailVerification } from "@/lib/email-verification.functions";
 import { isEmailVerified } from "@/lib/email-verification";
-import { updateMyDisplayName } from "@/lib/profile.functions";
+import { updateMyProfile } from "@/lib/profile.functions";
 import { commentDisplayName } from "@/lib/validation";
+import type { UpdateMyProfileInput } from "@/lib/validation";
 
 export const Route = createFileRoute("/_authenticated/account")({
   head: () => ({
@@ -93,11 +103,50 @@ function EmailVerificationNote({
   );
 }
 
+/** A group heading, so eight cards stop reading as one undifferentiated stack. */
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="pt-4 text-xs font-bold uppercase tracking-wide text-muted-foreground">
+      {children}
+    </h2>
+  );
+}
+
+type Profile = Awaited<ReturnType<typeof getMyProfile>>;
+
 function AccountPage() {
   const { user } = useAuth();
   const { roles, isManager } = useRoles(user?.id);
+  const fetchProfile = useServerFn(getMyProfile);
+
+  // Fetched once here rather than per card: the three editable cards below all
+  // read the same row, and three identical round trips would only give them
+  // three chances to disagree about what is on file.
+  const [profile, setProfile] = useState<Profile>(null);
+  const [loading, setLoading] = useState(true);
+  // A failed fetch is NOT "you have no details". Conflating the two renders the
+  // cards editable and empty, and one Save then writes those blanks over a
+  // record that was there all along. Tracked separately so the page can say the
+  // honest thing and offer a retry instead.
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setLoadFailed(false);
+    fetchProfile()
+      .then((p) => setProfile(p))
+      .catch(() => {
+        setProfile(null);
+        setLoadFailed(true);
+      })
+      .finally(() => setLoading(false));
+  }, [fetchProfile]);
+
+  useEffect(load, [load]);
 
   if (!user) return null;
+
+  const details = { profile, loading, onSaved: setProfile };
 
   return (
     <section className="mx-auto max-w-2xl space-y-6 px-4 py-12">
@@ -140,73 +189,200 @@ function AccountPage() {
         </CardContent>
       </Card>
 
-      <DisplayNameCard />
+      <SectionHeading>Your details</SectionHeading>
+
+      {loadFailed ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>We couldn't load your details</CardTitle>
+            <CardDescription>
+              Nothing has changed, and nothing is lost. This is usually a dropped connection, so try
+              again in a moment.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button onClick={load}>Try again</Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          <AboutYouCard {...details} />
+
+          <KitSizingCard {...details} />
+
+          <ContactCard {...details} />
+        </>
+      )}
+
+      <p className="text-xs text-muted-foreground">
+        Your legal name and date of birth are not editable here, because a signed waiver records
+        them as they were given. Ask us and we will correct them. Your email is your login, so a
+        manager changes that one too.
+      </p>
+
+      <SectionHeading>Your records</SectionHeading>
 
       <WaiversCard />
 
       <CodeOfConductCard />
 
-      {isManager && <GoogleDriveCard />}
+      <SectionHeading>Sign-in</SectionHeading>
 
       <ChangePasswordCard />
+
+      {isManager && (
+        <>
+          <SectionHeading>Manager tools</SectionHeading>
+          <GoogleDriveCard />
+        </>
+      )}
     </section>
   );
 }
 
+/** What every editable card on this page is handed. */
+type DetailsCardProps = {
+  profile: Profile;
+  loading: boolean;
+  /** Called with the saved row so the page's copy of the profile stays true. */
+  onSaved: (profile: Profile) => void;
+};
+
 /**
- * The name shown on this person's blog and document comments. `getMyProfile`
- * doubles as the source for the derived-name placeholder
- * (`commentDisplayName`), so the field shows exactly what will be used if the
- * manager clears it.
+ * The shared save path for the three editable cards: send only this card's
+ * keys, fold them back into the page's profile, and say so.
+ *
+ * Returns the `busy` flag and a `save` the card calls with its own patch, so
+ * each card owns its fields and nothing else.
  */
-function DisplayNameCard() {
-  const fetchProfile = useServerFn(getMyProfile);
-  const save = useServerFn(updateMyDisplayName);
-  const [profile, setProfile] = useState<Awaited<ReturnType<typeof getMyProfile>>>(null);
-  const [displayName, setDisplayName] = useState("");
-  const [loading, setLoading] = useState(true);
+function useDetailsSave({ profile, onSaved }: Pick<DetailsCardProps, "profile" | "onSaved">) {
+  const update = useServerFn(updateMyProfile);
   const [busy, setBusy] = useState(false);
 
-  useEffect(() => {
-    fetchProfile()
-      .then((p) => {
-        setProfile(p);
-        setDisplayName(p?.display_name ?? "");
-      })
-      .catch(() => setProfile(null))
-      .finally(() => setLoading(false));
-  }, [fetchProfile]);
-
-  const placeholder = profile ? commentDisplayName(profile) : "";
-
-  async function onSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  async function save(patch: UpdateMyProfileInput, message: string, failure: string) {
     setBusy(true);
     try {
-      const trimmed = displayName.trim();
-      await save({ data: { display_name: trimmed || null } });
-      toast.success(trimmed ? "Display name updated" : "Display name reset");
+      await update({ data: patch });
+      if (profile) onSaved({ ...profile, ...patch } as Profile);
+      toast.success(message);
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Could not save your display name");
+      toast.error(err instanceof Error ? err.message : failure);
     } finally {
       setBusy(false);
     }
   }
 
+  return { busy, save };
+}
+
+/**
+ * The buttons under every editable card.
+ *
+ * Save stays disabled until something actually differs from what is stored, so
+ * the button tells the member whether they have unsaved work rather than
+ * inviting a no-op write. Revert only appears once there is something to
+ * revert: before this, the only way out of a half-typed change was reloading
+ * the page, which is not an affordance anybody should have to guess.
+ */
+function CardActions({
+  dirty,
+  busy,
+  onRevert,
+}: {
+  dirty: boolean;
+  busy: boolean;
+  onRevert: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button type="submit" disabled={busy || !dirty}>
+        {busy ? "Saving..." : "Save"}
+      </Button>
+      {dirty && !busy ? (
+        <Button type="button" variant="outline" onClick={onRevert}>
+          Revert
+        </Button>
+      ) : null}
+      {dirty ? <span className="text-xs text-muted-foreground">Unsaved changes</span> : null}
+    </div>
+  );
+}
+
+/**
+ * What the club calls this person, and what other members see next to their
+ * comments. `commentDisplayName` doubles as the placeholder, so the field shows
+ * exactly what will be used if they clear it.
+ */
+function AboutYouCard({ profile, loading, onSaved }: DetailsCardProps) {
+  const { busy, save } = useDetailsSave({ profile, onSaved });
+  const [preferredName, setPreferredName] = useState("");
+  const [displayName, setDisplayName] = useState("");
+
+  // What is on file for the fields THIS card owns. Memoised on those values
+  // alone, not on the whole `profile` object: saving any card replaces that
+  // object, and resetting on its identity would silently wipe whatever the
+  // member had typed into the other two cards but not yet saved.
+  const stored = useMemo(
+    () => ({
+      preferredName: profile?.preferred_name ?? "",
+      displayName: profile?.display_name ?? "",
+    }),
+    [profile?.preferred_name, profile?.display_name],
+  );
+
+  const revert = useMemo(
+    () => () => {
+      setPreferredName(stored.preferredName);
+      setDisplayName(stored.displayName);
+    },
+    [stored],
+  );
+
+  useEffect(revert, [revert]);
+
+  const dirty = preferredName !== stored.preferredName || displayName !== stored.displayName;
+
+  const placeholder = profile ? commentDisplayName(profile) : "";
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const name = displayName.trim();
+    await save(
+      {
+        preferred_name: preferredName.trim() || null,
+        display_name: name || null,
+      },
+      "Saved",
+      "Could not save those names",
+    );
+  }
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Display name</CardTitle>
+        <CardTitle>About you</CardTitle>
         <CardDescription>
-          Shown on your blog and document comments. Leave blank to use{" "}
-          {placeholder ? `"${placeholder}"` : "your first name and last initial"}.
+          What we call you in person, and the name other members see on your comments.
         </CardDescription>
       </CardHeader>
       <CardContent>
         {loading ? (
           <p className="text-sm text-muted-foreground">Loading...</p>
         ) : (
-          <form onSubmit={onSubmit} className="space-y-3">
+          <form onSubmit={onSubmit} className="space-y-4">
+            <div>
+              <Label htmlFor="preferred-name">Preferred name</Label>
+              <Input
+                id="preferred-name"
+                value={preferredName}
+                onChange={(e) => setPreferredName(e.target.value)}
+                maxLength={60}
+                className="mt-1.5"
+              />
+              <p className="mt-1.5 text-xs text-muted-foreground">
+                What you go by, if it is not your first name. We use it to greet you.
+              </p>
+            </div>
             <div>
               <Label htmlFor="display-name">Display name</Label>
               <Input
@@ -215,11 +391,272 @@ function DisplayNameCard() {
                 onChange={(e) => setDisplayName(e.target.value)}
                 maxLength={60}
                 placeholder={placeholder}
+                className="mt-1.5"
+              />
+              <p className="mt-1.5 text-xs text-muted-foreground">
+                Shown on your blog and document comments. Leave blank to use{" "}
+                {placeholder ? `"${placeholder}"` : "your first name and last initial"}.
+              </p>
+            </div>
+            <CardActions dirty={dirty} busy={busy} onRevert={revert} />
+          </form>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Gi and belt sizes. Kept apart from the contact card because it is the one
+ * group here a manager reads in bulk (ordering kit), and because it is the only
+ * one a waiver never overwrites.
+ */
+function KitSizingCard({ profile, loading, onSaved }: DetailsCardProps) {
+  const { busy, save } = useDetailsSave({ profile, onSaved });
+  const [giSize, setGiSize] = useState<GiSize | "">("");
+  const [beltSize, setBeltSize] = useState<BeltSize | "">("");
+
+  // See AboutYouCard: keyed on this card's own fields, never on `profile`.
+  const stored = useMemo(() => {
+    const gi = profile?.gi_size ?? "";
+    const belt = profile?.belt_size ?? "";
+    return {
+      giSize: (isGiSize(gi) ? gi : "") as GiSize | "",
+      beltSize: (isBeltSize(belt) ? belt : "") as BeltSize | "",
+    };
+  }, [profile?.gi_size, profile?.belt_size]);
+
+  const revert = useMemo(
+    () => () => {
+      setGiSize(stored.giSize);
+      setBeltSize(stored.beltSize);
+    },
+    [stored],
+  );
+
+  useEffect(revert, [revert]);
+
+  const dirty = giSize !== stored.giSize || beltSize !== stored.beltSize;
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await save(
+      { gi_size: giSize || null, belt_size: beltSize || null },
+      "Sizes saved",
+      "Could not save your sizes",
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Kit sizing</CardTitle>
+        <CardDescription>
+          So we can order the right gi and belt for you, and hand you the right loan gear. Both are
+          optional.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading...</p>
+        ) : (
+          <form onSubmit={onSubmit} className="space-y-4">
+            <div>
+              <Label htmlFor="gi-size">Gi size</Label>
+              <GiSizeSelect
+                id="gi-size"
+                value={giSize}
+                onChange={setGiSize}
+                disabled={busy}
+                className="mt-1.5"
+              />
+              <p className="mt-1.5 text-xs text-muted-foreground">
+                The number in brackets is the height the gi is cut for. {GI_SIZE_HINT}
+              </p>
+            </div>
+            <div>
+              <Label htmlFor="belt-size">Belt size</Label>
+              <BeltSizeSelect
+                id="belt-size"
+                value={beltSize}
+                onChange={setBeltSize}
+                disabled={busy}
+                className="mt-1.5"
+              />
+              <p className="mt-1.5 text-xs text-muted-foreground">{BELT_SIZE_HINT}</p>
+            </div>
+            <CardActions dirty={dirty} busy={busy} onRevert={revert} />
+          </form>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * How the club reaches this person, and who it calls if something happens.
+ *
+ * The warning in the description is not boilerplate: approving a waiver still
+ * promotes that submission's contact fields onto the profile
+ * (`waiverToProfileFields`), so a correction made here can be overwritten later
+ * by a manager working through a backlog of older waivers.
+ */
+function ContactCard({ profile, loading, onSaved }: DetailsCardProps) {
+  const { busy, save } = useDetailsSave({ profile, onSaved });
+  const [phone, setPhone] = useState("");
+  const [address, setAddress] = useState("");
+  const [smsConsent, setSmsConsent] = useState(false);
+  const [ecName, setEcName] = useState("");
+  const [ecRelationship, setEcRelationship] = useState("");
+  const [ecPhone, setEcPhone] = useState("");
+
+  // See AboutYouCard: keyed on this card's own fields, never on `profile`.
+  const stored = useMemo(
+    () => ({
+      phone: profile?.phone ?? "",
+      address: profile?.address ?? "",
+      smsConsent: profile?.sms_whatsapp_consent ?? false,
+      ecName: profile?.emergency_contact_name ?? "",
+      ecRelationship: profile?.emergency_contact_relationship ?? "",
+      ecPhone: profile?.emergency_contact_phone ?? "",
+    }),
+    [
+      profile?.phone,
+      profile?.address,
+      profile?.sms_whatsapp_consent,
+      profile?.emergency_contact_name,
+      profile?.emergency_contact_relationship,
+      profile?.emergency_contact_phone,
+    ],
+  );
+
+  const revert = useMemo(
+    () => () => {
+      setPhone(stored.phone);
+      setAddress(stored.address);
+      setSmsConsent(stored.smsConsent);
+      setEcName(stored.ecName);
+      setEcRelationship(stored.ecRelationship);
+      setEcPhone(stored.ecPhone);
+    },
+    [stored],
+  );
+
+  useEffect(revert, [revert]);
+
+  const dirty =
+    phone !== stored.phone ||
+    address !== stored.address ||
+    smsConsent !== stored.smsConsent ||
+    ecName !== stored.ecName ||
+    ecRelationship !== stored.ecRelationship ||
+    ecPhone !== stored.ecPhone;
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await save(
+      {
+        phone: phone.trim(),
+        address: address.trim(),
+        sms_whatsapp_consent: smsConsent,
+        emergency_contact_name: ecName.trim(),
+        emergency_contact_relationship: ecRelationship.trim(),
+        emergency_contact_phone: ecPhone.trim(),
+      },
+      "Contact details saved",
+      "Could not save your contact details",
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Contact</CardTitle>
+        <CardDescription>
+          How we reach you, and who we call if something happens in class. Saving here updates our
+          current record straight away. It does not change a waiver you have already signed, which
+          keeps what you typed at the time.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading...</p>
+        ) : (
+          <form onSubmit={onSubmit} className="space-y-4">
+            <div>
+              <Label htmlFor="account-phone">Mobile</Label>
+              <Input
+                id="account-phone"
+                type="tel"
+                required
+                maxLength={30}
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                className="mt-1.5"
+              />
+              <label className="mt-2 flex items-start gap-2 text-xs text-muted-foreground">
+                <Checkbox
+                  checked={smsConsent}
+                  onCheckedChange={(v) => setSmsConsent(v === true)}
+                  className="mt-0.5"
+                  aria-label="Consent to SMS or WhatsApp contact"
+                />
+                <span>
+                  I agree to be contacted by SMS or WhatsApp, and added to club WhatsApp groups.
+                </span>
+              </label>
+            </div>
+            <div>
+              <Label htmlFor="account-address">Address</Label>
+              <Input
+                id="account-address"
+                required
+                maxLength={300}
+                value={address}
+                onChange={(e) => setAddress(e.target.value)}
+                className="mt-1.5"
               />
             </div>
-            <Button type="submit" disabled={busy}>
-              {busy ? "Saving..." : "Save"}
-            </Button>
+
+            <fieldset className="space-y-4 rounded-md border p-4">
+              <legend className="px-1 text-sm font-medium">Emergency contact</legend>
+              <div>
+                <Label htmlFor="account-ec-name">Name</Label>
+                <Input
+                  id="account-ec-name"
+                  required
+                  maxLength={120}
+                  value={ecName}
+                  onChange={(e) => setEcName(e.target.value)}
+                  className="mt-1.5"
+                />
+              </div>
+              <div>
+                <Label htmlFor="account-ec-relationship">Relationship</Label>
+                <Input
+                  id="account-ec-relationship"
+                  required
+                  maxLength={80}
+                  value={ecRelationship}
+                  onChange={(e) => setEcRelationship(e.target.value)}
+                  className="mt-1.5"
+                />
+              </div>
+              <div>
+                <Label htmlFor="account-ec-phone">Mobile</Label>
+                <Input
+                  id="account-ec-phone"
+                  type="tel"
+                  required
+                  maxLength={30}
+                  value={ecPhone}
+                  onChange={(e) => setEcPhone(e.target.value)}
+                  className="mt-1.5"
+                />
+              </div>
+            </fieldset>
+
+            <CardActions dirty={dirty} busy={busy} onRevert={revert} />
           </form>
         )}
       </CardContent>

--- a/src/routes/_authenticated/manager.users.tsx
+++ b/src/routes/_authenticated/manager.users.tsx
@@ -210,6 +210,11 @@ function ManagerUsersPage() {
                     <th className="px-3 py-2">Status</th>
                     <th className="px-3 py-2">Roles</th>
                     <th className="px-3 py-2">UTS student</th>
+                    {/* Size codes off the club's charts, for ordering kit. The
+                        full label with the measurement is on the detail page;
+                        a directory column only has room for the code. */}
+                    <th className="px-3 py-2">Gi</th>
+                    <th className="px-3 py-2">Belt</th>
                     <th className="px-3 py-2">Waiver</th>
                     <th className="px-3 py-2">Sessions</th>
                     <th className="px-3 py-2">Latest membership</th>
@@ -274,6 +279,8 @@ function ManagerUsersPage() {
                       <td className="px-3 py-2">
                         {r.is_uts_student ? (r.uts_student_number ?? "Yes") : "No"}
                       </td>
+                      <td className="px-3 py-2">{r.gi_size ?? "—"}</td>
+                      <td className="px-3 py-2">{r.belt_size ?? "—"}</td>
                       <td className="px-3 py-2">{formatDate(r.waiver_signed_at)}</td>
                       {/* Classes trained, whatever paid for them. Not the same
                           as credits used, which lives on the membership. */}

--- a/src/routes/_authenticated/manager.users_.$userId.tsx
+++ b/src/routes/_authenticated/manager.users_.$userId.tsx
@@ -9,6 +9,15 @@ import { Label } from "@/components/ui/label";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Pill } from "@/components/site/StatusPill";
 import { formatDate, formatDateOnly, formatDateTime } from "@/lib/dates";
+import { BELT_SIZE_HINT, BeltSizeSelect, GiSizeSelect } from "@/components/site/KitSizeSelect";
+import {
+  type BeltSize,
+  type GiSize,
+  formatBeltSize,
+  formatGiSize,
+  isBeltSize,
+  isGiSize,
+} from "@/lib/kit-sizes";
 import {
   ROLE_CLASS,
   coverageClass,
@@ -31,6 +40,7 @@ import {
   getClubUser,
   resendClubUserVerification,
   setClubUserEmail,
+  setClubUserKitSizes,
 } from "@/lib/club-user.functions";
 import { attachCheckInCoverage } from "@/lib/checkin.functions";
 import { getWaiverPdfUrl, setWaiverApproval } from "@/lib/waiver.functions";
@@ -213,6 +223,134 @@ function EmailCard({
         Changing this moves their login too. Signed waivers keep the address as it was typed, as
         evidence, so an older submission below can legitimately show a different one.
       </p>
+    </div>
+  );
+}
+
+/**
+ * The person's gi and belt sizes, and the way a manager corrects them.
+ *
+ * Unlike everything in the Profile card above it, no waiver records sizing, so
+ * there is no frozen submission for a correction here to disagree with and
+ * nothing an approval will later overwrite. That is why this is editable and
+ * the rest of the profile is not.
+ *
+ * Same inline-edit shape as `EmailCard`: a read row with a button, swapped for
+ * a form on demand, so the page has one editing idiom rather than two.
+ */
+function KitSizesCard({
+  userId,
+  giSize,
+  beltSize,
+  onChanged,
+}: {
+  userId: string;
+  giSize: string | null;
+  beltSize: string | null;
+  onChanged: () => void;
+}) {
+  const saveSizes = useServerFn(setClubUserKitSizes);
+  const [editing, setEditing] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const storedGi = giSize && isGiSize(giSize) ? giSize : "";
+  const storedBelt = beltSize && isBeltSize(beltSize) ? beltSize : "";
+  const [giDraft, setGiDraft] = useState<GiSize | "">(storedGi);
+  const [beltDraft, setBeltDraft] = useState<BeltSize | "">(storedBelt);
+
+  // Follow the record while the form is closed, so opening it always starts
+  // from what is actually stored. A `useState` initialiser only runs on mount,
+  // so without this the draft would still hold whatever the page loaded first
+  // after a reload picked up somebody else's change.
+  useEffect(() => {
+    if (editing) return;
+    setGiDraft(storedGi);
+    setBeltDraft(storedBelt);
+  }, [editing, storedGi, storedBelt]);
+
+  const dirty = giDraft !== storedGi || beltDraft !== storedBelt;
+
+  function reset() {
+    setGiDraft(storedGi);
+    setBeltDraft(storedBelt);
+    setEditing(false);
+  }
+
+  async function save(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    try {
+      await saveSizes({
+        data: { userId, gi_size: giDraft || null, belt_size: beltDraft || null },
+      });
+      toast.success("Sizes updated.");
+      setEditing(false);
+      onChanged();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not update those sizes.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border p-4">
+      <h2 className="mb-3 text-lg font-bold">Kit sizing</h2>
+      <p className="mb-3 text-sm text-muted-foreground">
+        For ordering a gi and belt, and for sizing loan gear. Members can set these themselves, and
+        signing a waiver offers a gi size. No waiver records them, so approving one never changes
+        what is here.
+      </p>
+
+      {editing ? (
+        <form onSubmit={save} className="space-y-3">
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="min-w-[14rem] flex-1">
+              <Label htmlFor="member-gi-size">Gi size</Label>
+              <GiSizeSelect
+                id="member-gi-size"
+                value={giDraft}
+                onChange={setGiDraft}
+                disabled={busy}
+                emptyLabel="Not on file"
+                className="mt-1.5"
+              />
+            </div>
+            <div className="min-w-[14rem] flex-1">
+              <Label htmlFor="member-belt-size">Belt size</Label>
+              <BeltSizeSelect
+                id="member-belt-size"
+                value={beltDraft}
+                onChange={setBeltDraft}
+                disabled={busy}
+                emptyLabel="Not on file"
+                className="mt-1.5"
+              />
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground">{BELT_SIZE_HINT}</p>
+          <div className="flex flex-wrap gap-2">
+            <Button type="submit" disabled={busy || !dirty}>
+              {busy ? "Saving..." : "Save"}
+            </Button>
+            <Button type="button" variant="outline" disabled={busy} onClick={reset}>
+              Cancel
+            </Button>
+            {dirty ? <span className="text-xs text-muted-foreground">Unsaved changes</span> : null}
+          </div>
+        </form>
+      ) : (
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="text-sm">
+            Gi <strong>{formatGiSize(giSize) ?? "—"}</strong>
+          </span>
+          <span className="text-sm">
+            Belt <strong>{formatBeltSize(beltSize) ?? "—"}</strong>
+          </span>
+          <Button type="button" variant="outline" size="sm" onClick={() => setEditing(true)}>
+            Change sizes
+          </Button>
+        </div>
+      )}
     </div>
   );
 }
@@ -468,7 +606,9 @@ function ManagerUserPage() {
       <div className="rounded-lg border p-4">
         <h2 className="mb-3 text-lg font-bold">Profile</h2>
         <p className="mb-3 text-sm text-muted-foreground">
-          The club's current record. Approving a waiver copies that submission's details here.
+          The club's current record. Approving a waiver copies that submission's details here. The
+          two sizes are the exception: no waiver carries them, so they are only ever set by the
+          member or by you, in the card below.
         </p>
         <dl className="grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-3">
           <Field label="Preferred name" value={profile.preferred_name} />
@@ -491,9 +631,18 @@ function ManagerUserPage() {
             label="SMS / WhatsApp consent"
             value={profile.sms_whatsapp_consent ? "Yes" : "No"}
           />
+          <Field label="Gi size" value={formatGiSize(profile.gi_size)} />
+          <Field label="Belt size" value={formatBeltSize(profile.belt_size)} />
           <Field label="Record updated" value={formatDateTime(profile.updated_at)} />
         </dl>
       </div>
+
+      <KitSizesCard
+        userId={userId}
+        giSize={profile.gi_size}
+        beltSize={profile.belt_size}
+        onChanged={() => void load(false)}
+      />
 
       {/* House rules. Read-only on purpose: a manager cannot tick this on
           somebody's behalf, for the same reason there is no "mark as verified"

--- a/src/routes/api/manager/agent.ts
+++ b/src/routes/api/manager/agent.ts
@@ -257,7 +257,7 @@ async function handleListUsers(params: unknown) {
     pdb
       .from("profiles")
       .select(
-        "user_id, first_name, middle_name, last_name, preferred_name, phone, uts_student_number, created_at",
+        "user_id, first_name, middle_name, last_name, preferred_name, phone, uts_student_number, gi_size, belt_size, created_at",
       )
       .limit(5000),
     db.from("memberships").select("*").order("created_at", { ascending: false }).limit(2000),

--- a/src/routes/waiver.tsx
+++ b/src/routes/waiver.tsx
@@ -13,6 +13,8 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { CheckCircle2, Download } from "lucide-react";
 import { SignaturePad, type SignaturePadHandle } from "@/components/site/SignaturePad";
+import { GI_SIZE_HINT, GiSizeSelect } from "@/components/site/KitSizeSelect";
+import { type GiSize, isGiSize } from "@/lib/kit-sizes";
 import { SubmitStatus } from "@/components/site/SubmitStatus";
 import { WaiverDocument } from "@/components/site/WaiverDocument";
 import {
@@ -74,6 +76,7 @@ type Prefill = {
   phone?: string | null;
   uts_student_number?: string | null;
   sms_whatsapp_consent?: boolean | null;
+  gi_size?: string | null;
   emergency_contact_name?: string | null;
   emergency_contact_relationship?: string | null;
   emergency_contact_phone?: string | null;
@@ -134,6 +137,9 @@ function Waiver() {
   const [email, setEmail] = useState(search.email ?? "");
   const [address, setAddress] = useState("");
   const [utsStudentNumber, setUtsStudentNumber] = useState("");
+  // Equipment sizing, not part of the waiver. Optional, and it goes straight
+  // onto the profile rather than onto the signed document.
+  const [giSize, setGiSize] = useState<GiSize | "">("");
   // SMS/WhatsApp consent is a checkbox here (page 2). It defaults to checked
   // only when the phone number was already collected on the previous page —
   // i.e. the person already gave us their number (and saw the consent note)
@@ -203,6 +209,7 @@ function Waiver() {
         if (typeof r.sms_whatsapp_consent === "boolean") setSmsConsent(r.sms_whatsapp_consent);
         if (r.address) setAddress(r.address);
         if (r.uts_student_number) setUtsStudentNumber(r.uts_student_number);
+        if (r.gi_size && isGiSize(r.gi_size)) setGiSize(r.gi_size);
         if (r.emergency_contact_name) setEcName(r.emergency_contact_name);
         if (r.emergency_contact_relationship) setEcRelationship(r.emergency_contact_relationship);
         if (r.emergency_contact_phone) setEcPhone(r.emergency_contact_phone);
@@ -270,6 +277,7 @@ function Waiver() {
       setAddress(draft.address);
       setUtsStudentNumber(draft.utsStudentNumber);
       setSmsConsent(draft.smsConsent);
+      setGiSize(isGiSize(draft.giSize) ? draft.giSize : "");
       setEcName(draft.ecName);
       setEcRelationship(draft.ecRelationship);
       setEcPhone(draft.ecPhone);
@@ -321,6 +329,7 @@ function Waiver() {
       address,
       utsStudentNumber,
       smsConsent,
+      giSize,
       ecName,
       ecRelationship,
       ecPhone,
@@ -346,6 +355,7 @@ function Waiver() {
       address,
       utsStudentNumber,
       smsConsent,
+      giSize,
       ecName,
       ecRelationship,
       ecPhone,
@@ -438,6 +448,7 @@ function Waiver() {
             phone,
             email,
             uts_student_number: utsStudentNumber,
+            gi_size: giSize,
             sms_whatsapp_consent: smsConsent,
             emergency_contact_name: ecName,
             emergency_contact_relationship: ecRelationship,
@@ -808,6 +819,17 @@ function Waiver() {
                 <p className="mt-1.5 text-xs text-muted-foreground">
                   UTS students train at a discounted rate. Add your number here and the student rate
                   applies when you join.
+                </p>
+              </div>
+              <div>
+                <Label htmlFor="gi_size">
+                  Gi size <span className="text-muted-foreground">(optional)</span>
+                </Label>
+                <GiSizeSelect id="gi_size" value={giSize} onChange={setGiSize} className="mt-1.5" />
+                <p className="mt-1.5 text-xs text-muted-foreground">
+                  The number in brackets is the height the gi is cut for. {GI_SIZE_HINT} This is
+                  just so we can order kit that fits, and it is not part of the waiver. You can
+                  change it any time from your account.
                 </p>
               </div>
             </fieldset>

--- a/supabase/migrations/20260806000000_profile_kit_sizes.sql
+++ b/supabase/migrations/20260806000000_profile_kit_sizes.sql
@@ -1,0 +1,33 @@
+-- Gi and belt sizes on a person's record, so a manager ordering kit or sizing
+-- loan gear can see both at a glance.
+--
+-- Neither is a legal or identity field, so neither goes on a waiver submission
+-- or the signed PDF. The `/waiver` form asks for a gi size as an optional
+-- extra and writes it straight here; the club's record is the only place it
+-- lives. `waiverToProfileFields` (src/lib/validation.ts) deliberately does not
+-- carry these, so approving a waiver leaves them alone.
+--
+-- Both are size CODES off standard charts, not measurements. The two charts
+-- differ: gi sizes run 000..7, belts only 0..7 (there is no 000 or 00 belt), so
+-- the two CHECKs are deliberately not the same list.
+--
+-- ⚠️ The same two code sets live in `src/lib/kit-sizes.ts`, which feeds the Zod
+-- enums and every picker. Nothing in the test suite can read a CHECK, so
+-- `kit-sizes.test.ts` pins both literals: widening either array there means
+-- replacing the matching constraint here.
+--
+-- Additive (the EXPAND half of an expand/contract change), so per
+-- docs/database-changes.md this applies BEFORE the code that reads it merges.
+-- No grant work: ADD COLUMN inherits the table ACL, and `profiles` holds zero
+-- privileges for anon/authenticated (revoked in 20260728150000) — every read
+-- and write already goes through a service-role server function.
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS gi_size TEXT
+    CONSTRAINT profiles_gi_size_check
+    CHECK (gi_size IS NULL OR gi_size IN ('000', '00', '0', '1', '2', '3', '4', '5', '6', '7')),
+  ADD COLUMN IF NOT EXISTS belt_size TEXT
+    CONSTRAINT profiles_belt_size_check
+    CHECK (belt_size IS NULL OR belt_size IN ('0', '1', '2', '3', '4', '5', '6', '7'));
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What this is

A **port**, not new work. This is the net diff of `fryorcraken/swift-stance#156` (merged there as `31c9ef2`), applied to this repository now that Lovable treats it as the project's source of truth.

This repo's tree was **identical** to `swift-stance` at `dff015c` apart from its `README.md`, so the patch applied unchanged, and the resulting tree matches `swift-stance`'s `main` **byte for byte**. That tree is already green there on CI, Supabase lint and PR screenshots.

## ⚠️ The migration is already applied — do not run it again

`supabase/migrations/20260806000000_profile_kit_sizes.sql` went live before `swift-stance#156` merged, and is recorded in `supabase_migrations.schema_migrations` as version `20260806000000` / `profile_kit_sizes`. Verified at the time: both columns (`text`, nullable, no default), both CHECK constraints, `pg_class.relacl` unchanged with zero column-level grants for `anon`/`authenticated`, PostgREST reloaded.

The file is here so this repository's migration history is complete and the drift check has a file matching the existing ledger row. **Applying it again is unnecessary** (it is `ADD COLUMN IF NOT EXISTS`, so it would be a no-op, but there is no reason to run it).

## What changes for people

**Members** get a **Your details** group on `/account` they can keep current themselves, instead of signing a whole new waiver and waiting for approval:

- **About you** — preferred name, display name
- **Kit sizing** — gi size, belt size
- **Contact** — mobile, address, SMS/WhatsApp consent, emergency contact

Save stays **disabled until something actually differs** from what is stored, a **Revert** button appears while there are unsaved edits, and an "Unsaved changes" note says why.

**Signing a waiver** asks, optionally, for a gi size — only so the club can order kit that fits, and explicitly not part of the document.

**Managers** get **Gi** and **Belt** columns on `/manager/users`, both sizes on a person's page, and a card to correct either.

## The two charts

Different code sets, both owned by `src/lib/kit-sizes.ts`:

| Gi | `000` | `00` | `0` | `1` | `2` | `3` | `4` | `5` | `6` | `7` |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| height | 110 cm | 120 | 130 | 140 | 150 | 160 | 170 | 180 | 190 | 200 |

| Belt | | | `0` | `1` | `2` | `3` | `4` | `5` | `6` | `7` |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| fabric | | | 180 cm | 200 | 220 | 240 | 260 | 280 | 300 | 320 |

Options lead with the size **code**, with the measurement as a parenthetical aid (`000 (110 cm)`, `3 (240 cm belt)`). Belt labels say "belt" because a bare "240 cm" reads as a waist. A kids' gi size has no belt counterpart, so it defaults to belt `0`. `kit-sizes.test.ts` pins both code literals, because they are duplicated in CHECK constraints that no test can read.

## Rules worth knowing

- **Sizing never touches a waiver.** No `waivers` column holds it, it is not on the PDF, and `waiverToProfileFields` does not carry it, with a test asserting its absence.
- **The waiver-path write is gated on proof of identity.** `/waiver` is public and unauthenticated, and `resolvePersonId` resolves any known email to that existing person. Without the gate, anyone could POST a submission carrying a member's address and rewrite their record. `applyWaiverGiSize` carries the gate, with ten tests.
- **A blank gi size writes nothing**, so re-signing never clears a size on file.
- **The belt is filled in only when the record carries no sizing at all** — once either size is set, a null belt is one somebody cleared on purpose.
- **Both UPDATE paths detect a zero-row write**, since PostgREST reports no error when the filter matched nothing.
- **A failed profile load is its own state**, rather than rendering the cards editable and blank over a record that was there all along.
- **Contact fields still overlap with `waiverToProfileFields`**, so approving an *older* waiver can overwrite a correction a member made since. Documented rather than silently changed.

## Tests

1383 passing. New `kit-sizes.test.ts` and `account.test.tsx`; ten tests on `applyWaiverGiSize`; extended `validation.test.ts`, `club-users.test.ts` and `waiver-draft.test.ts`.

## Separate issue, not introduced here

`.env` is **tracked** in this repo — and it was tracked in `swift-stance` too, so it came across rather than starting here. It currently holds only publishable values (Supabase URL / project id / publishable key, the Google OAuth client id), all of which already ship in the client bundle, so nothing secret is exposed today. But `.gitignore` has no `.env` entry, so the first real secret added to that file gets committed. Worth fixing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rg4yjaiWfK3nZH5JX327Zc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rg4yjaiWfK3nZH5JX327Zc)_