### PR TITLE
Rename empty gi/belt size label to "Not set", clarify gi height copy

### DIFF
--- a/src/components/site/KitSizeSelect.tsx
+++ b/src/components/site/KitSizeSelect.tsx
@@ -30,7 +30,7 @@ import {
 const selectClass =
   "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm";
 
-/** Shown under a gi picker. Sizes are cut for a height, so nobody is exactly one. */
+/** Shown under a gi picker. Sizes are cut for a wearer's height, so nobody is exactly one. */
 export const GI_SIZE_HINT = "Round up or down depending on your body build.";
 
 /**
@@ -54,7 +54,7 @@ export function GiSizeSelect({
   onChange,
   disabled,
   className,
-  emptyLabel = "Not sure / prefer not to say",
+  emptyLabel = "Not set",
 }: BaseProps & {
   value: GiSize | "";
   onChange: (value: GiSize | "") => void;
@@ -83,7 +83,7 @@ export function BeltSizeSelect({
   onChange,
   disabled,
   className,
-  emptyLabel = "Not sure / prefer not to say",
+  emptyLabel = "Not set",
 }: BaseProps & {
   value: BeltSize | "";
   onChange: (value: BeltSize | "") => void;

--- a/src/routes/_authenticated/account.tsx
+++ b/src/routes/_authenticated/account.tsx
@@ -471,7 +471,8 @@ function KitSizingCard({ profile, loading, onSaved }: DetailsCardProps) {
                 className="mt-1.5"
               />
               <p className="mt-1.5 text-xs text-muted-foreground">
-                The number in brackets is the height the gi is cut for. {GI_SIZE_HINT}
+                The number in brackets is the wearer's height that gi size is cut for.{" "}
+                {GI_SIZE_HINT}
               </p>
             </div>
             <div>

--- a/src/routes/waiver.tsx
+++ b/src/routes/waiver.tsx
@@ -827,9 +827,9 @@ function Waiver() {
                 </Label>
                 <GiSizeSelect id="gi_size" value={giSize} onChange={setGiSize} className="mt-1.5" />
                 <p className="mt-1.5 text-xs text-muted-foreground">
-                  The number in brackets is the height the gi is cut for. {GI_SIZE_HINT} This is
-                  just so we can order kit that fits, and it is not part of the waiver. You can
-                  change it any time from your account.
+                  The number in brackets is the wearer's height that gi size is cut for.{" "}
+                  {GI_SIZE_HINT} This is just so we can order kit that fits, and it is not part of
+                  the waiver. You can change it any time from your account.
                 </p>
               </div>
             </fieldset>


### PR DESCRIPTION
## Summary
- The empty option in the gi/belt size pickers (`/account`, `/waiver`) read "Not sure / prefer not to say" — replaced with "Not set", since these are optional fields rather than a survey question.
- The gi-size hint text said "the height the gi is cut for", which could be misread as a garment measurement. Reworded to "the wearer's height that gi size is cut for" on `/waiver` and `/account` so it's clear the number refers to the person's own height.

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`


---
_Generated by [Claude Code](https://claude.ai/code/session_01K9PgMchDuMfwGLkMXsaeQf)_