### PR TITLE
Show who approved a waiver on the manager user page

### DIFF
--- a/docs/waivers.md
+++ b/docs/waivers.md
@@ -316,8 +316,11 @@ For one person there is a user page (`/manager/users/:userId`, reached from the
 directory), which is where a review normally happens: the profile (the club's
 current record), their memberships, and every submission they ever made, newest
 first. Each submission is a collapsible panel holding the frozen submission in
-full, the signing record (IP + browser context), Approve / Unapprove, and the
-signed PDF embedded inline. The submissions themselves load with the page; the
+full, the signing record (IP + browser context), when it was approved and by
+whom, Approve / Unapprove, and the signed PDF embedded inline. The approver is
+shown by name, or by their login address if they have no profile of their own;
+an approval recorded before the club started keeping that (or one whose
+approver's account is gone) reads as unknown rather than as nobody. The submissions themselves load with the page; the
 PDFs do not, since each needs a short-lived signed URL, so one is signed when a
 panel is opened or its PDF button is used, and re-signed once it goes stale.
 Exactly one panel opens by itself: the newest

--- a/src/lib/club-user.functions.ts
+++ b/src/lib/club-user.functions.ts
@@ -16,7 +16,7 @@ import {
 } from "@/lib/validation";
 import { CODE_OF_CONDUCT_VERSION, codeOfConductState } from "@/lib/code-of-conduct";
 import type { MembershipClient } from "@/lib/membership-types";
-import type { ClubUserEmail } from "@/lib/club-users";
+import { personLabelsById, type ClubUserEmail } from "@/lib/club-users";
 import { userEmails, userIdByEmail } from "@/lib/supabase-rpc";
 
 /** Max waiver / membership rows one person's page pulls. */
@@ -193,6 +193,40 @@ export const getClubUser = createServerFn({ method: "POST" })
       ? await admin.from("calendar_events").select("id, title, starts_at").in("id", eventIds)
       : { data: [] };
     const eventById = new Map((events ?? []).map((e) => [e.id, e]));
+
+    // Who approved each waiver. `waivers.approved_by` is a bare user id, and
+    // the approver is a manager, who may well have no `profiles` row of their
+    // own — so resolve the name where there is one and fall back to the login
+    // address, the same two sources the memberships list uses for member names.
+    // A second round-trip because the ids only exist once the waivers are read.
+    const approverIds = [...new Set(waiverRows.map((w) => w.approved_by).filter(Boolean))].filter(
+      (id): id is string => typeof id === "string",
+    );
+    const [approverProfiles, approverEmails] = approverIds.length
+      ? await Promise.all([
+          admin
+            .from("profiles")
+            .select("user_id, first_name, middle_name, last_name, preferred_name")
+            .in("user_id", approverIds),
+          userEmails(admin, approverIds),
+        ])
+      : [
+          { data: [], error: null },
+          { data: [], error: null },
+        ];
+    // Non-fatal, like the person's own email lookup above: an unresolved
+    // approver shows as "—" next to a real approval date, which is the honest
+    // reading. Taking the page down over it would block the decision it exists
+    // to support.
+    if (approverProfiles.error)
+      console.error("[getClubUser] approver profile lookup failed:", approverProfiles.error);
+    if (approverEmails.error)
+      console.error("[getClubUser] approver email lookup failed:", approverEmails.error);
+    const approverLabels = personLabelsById({
+      profiles: approverProfiles.data ?? [],
+      emails: approverEmails.data ?? [],
+    });
+
     const planNameByMembership = new Map(
       membershipRows.map((m) => [m.id, planById.get(m.plan_id)?.name ?? null]),
     );
@@ -293,6 +327,10 @@ export const getClubUser = createServerFn({ method: "POST" })
         template_version: w.template_version,
         has_pdf: Boolean(w.pdf_path),
         approved_at: w.approved_at ?? null,
+        // Who signed off. Null both while pending and for an approval recorded
+        // before the column existed, so the screen shows it as unknown rather
+        // than claiming nobody approved it.
+        approved_by_name: w.approved_by ? (approverLabels.get(w.approved_by) ?? null) : null,
         signer_ip: w.signer_ip,
         signer_meta: w.signer_meta,
         status: statuses.get(w.id) ?? ("pending" as const),

--- a/src/lib/club-user.functions.ts
+++ b/src/lib/club-user.functions.ts
@@ -189,31 +189,30 @@ export const getClubUser = createServerFn({ method: "POST" })
     if (checkinRows.length >= CHECKINS_LIMIT)
       console.warn(`[getClubUser] check-ins capped at ${CHECKINS_LIMIT}; older ones truncated`);
     const eventIds = [...new Set(checkinRows.map((c) => c.event_id))];
-    const { data: events } = eventIds.length
-      ? await admin.from("calendar_events").select("id, title, starts_at").in("id", eventIds)
-      : { data: [] };
-    const eventById = new Map((events ?? []).map((e) => [e.id, e]));
 
     // Who approved each waiver. `waivers.approved_by` is a bare user id, and
     // the approver is a manager, who may well have no `profiles` row of their
     // own — so resolve the name where there is one and fall back to the login
     // address, the same two sources the memberships list uses for member names.
-    // A second round-trip because the ids only exist once the waivers are read.
-    const approverIds = [...new Set(waiverRows.map((w) => w.approved_by).filter(Boolean))].filter(
-      (id): id is string => typeof id === "string",
+    const approverIds = [...new Set(waiverRows.map((w) => w.approved_by))].filter(
+      (id): id is string => Boolean(id),
     );
-    const [approverProfiles, approverEmails] = approverIds.length
-      ? await Promise.all([
-          admin
+
+    // Everything whose keys only exist once the first round came back, in one
+    // second round rather than one round each.
+    const [{ data: events }, approverProfiles, approverEmails] = await Promise.all([
+      eventIds.length
+        ? admin.from("calendar_events").select("id, title, starts_at").in("id", eventIds)
+        : { data: [] },
+      approverIds.length
+        ? admin
             .from("profiles")
             .select("user_id, first_name, middle_name, last_name, preferred_name")
-            .in("user_id", approverIds),
-          userEmails(admin, approverIds),
-        ])
-      : [
-          { data: [], error: null },
-          { data: [], error: null },
-        ];
+            .in("user_id", approverIds)
+        : { data: [], error: null },
+      approverIds.length ? userEmails(admin, approverIds) : { data: [], error: null },
+    ]);
+    const eventById = new Map((events ?? []).map((e) => [e.id, e]));
     // Non-fatal, like the person's own email lookup above: an unresolved
     // approver shows as "—" next to a real approval date, which is the honest
     // reading. Taking the page down over it would block the decision it exists

--- a/src/lib/club-users.test.ts
+++ b/src/lib/club-users.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   aggregateClubUsers,
+  personLabelsById,
   profileUserIds,
   type ClubUserEmail,
   type ClubUserLead,
@@ -8,6 +9,7 @@ import {
   type ClubUserPlan,
   type ClubUserProfile,
   type ClubUserWaiver,
+  type PersonNameRow,
 } from "./club-users";
 
 const plans: ClubUserPlan[] = [
@@ -87,6 +89,73 @@ describe("profileUserIds", () => {
   it("collects distinct user ids", () => {
     const ids = profileUserIds([{ user_id: "a" }, { user_id: "b" }, { user_id: "a" }]);
     expect(ids.sort()).toEqual(["a", "b"]);
+  });
+});
+
+describe("personLabelsById", () => {
+  function nameRow(over: Partial<PersonNameRow> = {}): PersonNameRow {
+    return {
+      user_id: "m1",
+      first_name: "Grace",
+      middle_name: null,
+      last_name: "Hopper",
+      preferred_name: null,
+      ...over,
+    };
+  }
+
+  it("labels a person by their name when they have a profile", () => {
+    const labels = personLabelsById({
+      profiles: [nameRow()],
+      emails: [{ user_id: "m1", email: "grace@example.com" }],
+    });
+    expect(labels.get("m1")).toBe("Grace Hopper");
+  });
+
+  it("quotes in a preferred name, like every other screen", () => {
+    const labels = personLabelsById({
+      profiles: [nameRow({ preferred_name: "Amazing" })],
+      emails: [],
+    });
+    expect(labels.get("m1")).toBe('Grace "Amazing" Hopper');
+  });
+
+  it("falls back to the login address for a manager with no profile row", () => {
+    const labels = personLabelsById({
+      profiles: [],
+      emails: [{ user_id: "m1", email: "grace@example.com" }],
+    });
+    expect(labels.get("m1")).toBe("grace@example.com");
+  });
+
+  it("falls back to the email when the profile has no name at all", () => {
+    const labels = personLabelsById({
+      profiles: [nameRow({ first_name: null, last_name: null })],
+      emails: [{ user_id: "m1", email: "grace@example.com" }],
+    });
+    expect(labels.get("m1")).toBe("grace@example.com");
+  });
+
+  it("omits anyone who resolves to neither a name nor an email", () => {
+    const labels = personLabelsById({
+      profiles: [nameRow({ first_name: null, last_name: null })],
+      emails: [{ user_id: "m1", email: "   " }],
+    });
+    expect(labels.has("m1")).toBe(false);
+  });
+
+  it("labels each id independently", () => {
+    const labels = personLabelsById({
+      profiles: [nameRow({ user_id: "m2", first_name: "Ada", last_name: "Lovelace" })],
+      emails: [
+        { user_id: "m1", email: "grace@example.com" },
+        { user_id: "m2", email: "ada@example.com" },
+      ],
+    });
+    expect([...labels.entries()].sort()).toEqual([
+      ["m1", "grace@example.com"],
+      ["m2", "Ada Lovelace"],
+    ]);
   });
 });
 

--- a/src/lib/club-users.ts
+++ b/src/lib/club-users.ts
@@ -17,7 +17,12 @@ import {
   nameWithPreferred,
   normalizeEmail,
 } from "./validation";
-import type { LifecycleStatus, MembershipPlanKind, MembershipStatus } from "./validation";
+import type {
+  LifecycleStatus,
+  MembershipPlanKind,
+  MembershipStatus,
+  PersonNameParts,
+} from "./validation";
 
 /** Max interest-registration (lead) rows the directory pulls in one page. */
 export const LEADS_LIMIT = 2000;
@@ -156,13 +161,7 @@ export function profileUserIds(profiles: Pick<ClubUserProfile, "user_id">[]): st
 }
 
 /** The name parts a person is displayed by when all a screen has is their id. */
-export type PersonNameRow = {
-  user_id: string;
-  first_name: string | null;
-  middle_name: string | null;
-  last_name: string | null;
-  preferred_name: string | null;
-};
+export type PersonNameRow = PersonNameParts & { user_id: string };
 
 /**
  * Label people by id, for the places that store a bare `user_id` and have to

--- a/src/lib/club-users.ts
+++ b/src/lib/club-users.ts
@@ -155,6 +155,40 @@ export function profileUserIds(profiles: Pick<ClubUserProfile, "user_id">[]): st
   return [...new Set(profiles.map((p) => p.user_id))];
 }
 
+/** The name parts a person is displayed by when all a screen has is their id. */
+export type PersonNameRow = {
+  user_id: string;
+  first_name: string | null;
+  middle_name: string | null;
+  last_name: string | null;
+  preferred_name: string | null;
+};
+
+/**
+ * Label people by id, for the places that store a bare `user_id` and have to
+ * show a human: who approved a waiver, who filed one.
+ *
+ * The name wins; the email is the fallback for somebody with no profile row (a
+ * manager account that never signed a waiver has none). Anyone who resolves to
+ * neither is simply absent from the map — the caller decides what an
+ * unresolvable id reads as, rather than being handed a raw uuid to render.
+ */
+export function personLabelsById(input: {
+  profiles: PersonNameRow[];
+  emails: { user_id: string; email: string }[];
+}): Map<string, string> {
+  const labels = new Map<string, string>();
+  for (const e of input.emails) {
+    const email = (e.email || "").trim();
+    if (email) labels.set(e.user_id, email);
+  }
+  for (const p of input.profiles) {
+    const name = nameWithPreferred(p).trim();
+    if (name) labels.set(p.user_id, name);
+  }
+  return labels;
+}
+
 /**
  * Aggregate profiles + emails + waivers + memberships + roles + leads into one
  * row per person, sorted by name (A–Z). A lead whose email already belongs to

--- a/src/routes/_authenticated/manager.users_.$userId.tsx
+++ b/src/routes/_authenticated/manager.users_.$userId.tsx
@@ -883,6 +883,7 @@ function ManagerUserPage() {
                         value={w.sms_whatsapp_consent ? "Yes" : "No"}
                       />
                       <Field label="Approved" value={formatDateTime(w.approved_at)} />
+                      <Field label="Approved by" value={w.approved_by_name} />
                     </dl>
 
                     {!w.has_pdf ? (


### PR DESCRIPTION
Closes fryorcraken/swift-stance#73

## What changes for the club

A manager opening someone's page at `/manager/users/:userId` and expanding a waiver now sees **Approved by**, right next to the date it was approved. Approving a waiver is the step that promotes the submission onto the person's profile, unlocks their login and gives them their free trial, so with more than one manager on the club account, "who signed off on this, and when" is the question that page exists to answer. The club has been recording the answer all along, it just was not being shown.

The approver appears by name. A manager who has never signed a waiver themselves has no profile of their own, and shows by their login address instead. An approval where neither can be found reads as unknown ("—") rather than as nobody, which is the honest answer: it can happen for an approval recorded before the club started keeping the name, or for a manager whose account has since been removed.

Nothing else on the page moves, no new step or friction, and nothing is emailed.

### Deliberately not in this change

`/manager/waivers`, the list of every submission, still does not show the approver. Unlike the user page it has no "Approved" column at all, so putting it there is a decision about what that table should show and how wide it can get, not the same one-line fix. Happy to do it as a follow-up if you want it.

## Technical notes

- `getClubUser` now returns `approved_by_name` per waiver. `approved_by` is a bare `auth.users` id, so it is resolved the way `listMemberships` resolves member names: a `profiles` read for the name, with the service-role `user_emails` RPC as the fallback.
- Both approver reads are non-fatal and logged, matching the posture the same handler already takes for the person's own email lookup. This is the screen an approval is decided from; a failed nice-to-know must not replace it with an error page.
- The name-or-email resolution is extracted as a pure `personLabelsById` helper in `src/lib/club-users.ts`, unit-tested in `club-users.test.ts` (name wins, email fallback, unresolvable ids omitted rather than rendered as a raw uuid).
- No schema change, no migration. The column has existed since `20260721120000_waiver_approval.sql`.
- `docs/waivers.md` updated to describe the panel as it now is.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (1389 passing), and `bun run build` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyDy8BeXkpqir1AFR3zS28

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyDy8BeXkpqir1AFR3zS28)_