### PR TITLE
Fill a blank blog excerpt from the post's own opening

### DIFF
--- a/docs/blog.md
+++ b/docs/blog.md
@@ -54,24 +54,32 @@ severities of moderation, not the same action.
    embedded player; any other link renders as a plain "Watch the video ↗"
    link. Photos are inserted as ordinary Markdown images pointing at the
    `blog-media` Storage bucket.
-8. **A comment's body is plain text**, not Markdown — no formatting, no
+8. **An excerpt is optional, and a blank one is derived from the body.** It is
+   what the blog list shows under a post's title and what the post page uses as
+   its meta description, so leaving it blank should not leave either empty.
+   `deriveExcerpt` takes the post's prose (headings, images, code, tables and
+   video lines dropped; links reduced to their text) and cuts it at a word
+   boundary. A post with no prose at all, one that is only a video, still
+   stores no excerpt: the list and the meta description each have their own
+   fallback for that.
+9. **A comment's body is plain text**, not Markdown — no formatting, no
    embedded photos or videos in comments. This is a deliberate scope line for
    now (see Future features).
-9. **A commenter's display name is their own choice, not their legal name.**
-   `profiles.display_name` is an optional override a person sets in their
-   account settings; when unset, the name shown is derived — first (or
-   preferred) name plus last initial (`commentDisplayName` in
-   `src/lib/validation.ts`), e.g. "Jane L." — never their full name pulled
-   from waiver data onto a public comment. Every person has a `profiles` row
-   with a non-blank `first_name` (NOT NULL, and `ensure_profile` seeds one for
-   an auth user created any other way), so the derived name is always
-   something. The bare word "Member" is what `ensure_profile` seeds when an
-   auth user arrives with no name on it at all — a dashboard-created or invited
-   account — and it stays until that person sets a display name. It is never
-   seeded from their email address: this name is public, and part of an email
-   address is not something they chose to publish. The name is resolved live at
-   read time, so changing it later re-labels their past comments too (it isn't
-   frozen at post time, unlike a waiver's evidence fields).
+10. **A commenter's display name is their own choice, not their legal name.**
+    `profiles.display_name` is an optional override a person sets in their
+    account settings; when unset, the name shown is derived — first (or
+    preferred) name plus last initial (`commentDisplayName` in
+    `src/lib/validation.ts`), e.g. "Jane L." — never their full name pulled
+    from waiver data onto a public comment. Every person has a `profiles` row
+    with a non-blank `first_name` (NOT NULL, and `ensure_profile` seeds one for
+    an auth user created any other way), so the derived name is always
+    something. The bare word "Member" is what `ensure_profile` seeds when an
+    auth user arrives with no name on it at all — a dashboard-created or invited
+    account — and it stays until that person sets a display name. It is never
+    seeded from their email address: this name is public, and part of an email
+    address is not something they chose to publish. The name is resolved live at
+    read time, so changing it later re-labels their past comments too (it isn't
+    frozen at post time, unlike a waiver's evidence fields).
 
 ## Flows
 
@@ -110,6 +118,11 @@ saving a currently-published post back to draft, and a live preview rendered
 the same styled way the public page renders it. Saving with no slug set
 derives one from the title (`slugify` in `src/lib/slug.ts`, normalized
 on blur too) and resolves a collision by appending `-2`, `-3`, and so on.
+An excerpt left blank is filled the same way, from the post's own opening
+(`deriveExcerpt` in `src/lib/blog-content.ts`): the composer shows the text it
+would use under the field and updates it as the body is typed, so what gets
+stored is what the manager was shown. Both the resolved slug and the resolved
+excerpt come back from the save and become the form's new baseline.
 `published_at` is stamped the first time a post goes live and **never changes
 again** — not on a later edit, and not on an unpublish/republish round trip —
 so a post's publish date and its position in the public list (sorted by

--- a/docs/database.md
+++ b/docs/database.md
@@ -706,7 +706,7 @@ RSVPs — and upvote a comment once (no downvote). Product spec:
 | `id`               | `uuid` PK     | no   | Default `gen_random_uuid()`.                                                                            |
 | `slug`             | `text`        | no   | `UNIQUE`. Lowercase/hyphenated, 1–200 chars.                                                            |
 | `title`            | `text`        | no   | 1–200 chars.                                                                                            |
-| `excerpt`          | `text`        | yes  | ≤ 500 chars. Shown on the list page.                                                                    |
+| `excerpt`          | `text`        | yes  | ≤ 500 chars. Shown on the list page. Derived from `body_md` on save when left blank (`deriveExcerpt`).  |
 | `body_md`          | `text`        | no   | 1–50,000 chars. Markdown; a `[[video:<url>]]` line embeds a video.                                      |
 | `cover_image_path` | `text`        | yes  | Object path in the `blog-media` Storage bucket.                                                         |
 | `status`           | `text`        | no   | `draft\|published`. Default `draft`.                                                                    |

--- a/src/components/site/BlogPostEditor.tsx
+++ b/src/components/site/BlogPostEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { toast } from "sonner";
 import { useServerFn } from "@tanstack/react-start";
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/dialog";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { uploadBlogImage } from "@/lib/blog.functions";
-import { extractYouTubeId, splitBlogContent } from "@/lib/blog-content";
+import { deriveExcerpt, extractYouTubeId, splitBlogContent } from "@/lib/blog-content";
 import { blogMarkdownComponents } from "@/lib/blog-markdown";
 import { BlogVideoBlock } from "@/components/site/BlogVideoBlock";
 import { slugify } from "@/lib/slug";
@@ -277,6 +277,9 @@ export function BlogPostEditor({
 
   const previewSlug = slug.trim() || slugify(title) || "your-post-title";
   const videoUrlIsYouTube = Boolean(videoUrl.trim() && extractYouTubeId(videoUrl.trim()));
+  // What the server will store if the excerpt is left blank. Memoised because
+  // it re-derives from the whole body, which changes on every keystroke.
+  const derivedExcerpt = useMemo(() => deriveExcerpt(body), [body]);
 
   const formFields = (
     <div className="space-y-4">
@@ -312,8 +315,16 @@ export function BlogPostEditor({
           onChange={(e) => setExcerpt(e.target.value)}
           rows={2}
           maxLength={500}
+          placeholder="Leave blank to use the opening of the post"
           className="mt-1.5"
         />
+        {!excerpt.trim() && (
+          <p className="mt-1 text-xs text-muted-foreground">
+            {derivedExcerpt
+              ? `Blank, so the blog list will show: ${derivedExcerpt}`
+              : "Blank, so the blog list will show the opening of the post once you write one."}
+          </p>
+        )}
       </div>
       <div>
         <Label htmlFor="post-cover-image">Cover image</Label>

--- a/src/lib/blog-content.test.ts
+++ b/src/lib/blog-content.test.ts
@@ -118,6 +118,12 @@ describe("deriveExcerpt", () => {
     expect(excerpt.length).toBeLessThanOrEqual(14);
   });
 
+  it("stays within the limit when the first word is longer than the whole budget", () => {
+    const excerpt = deriveExcerpt("Supercalifragilisticexpialidocious", 10);
+    expect(excerpt).toBe("Supercali…");
+    expect(excerpt.length).toBe(10);
+  });
+
   it("does not cut a body that fits", () => {
     const body = "Short enough.";
     expect(deriveExcerpt(body)).toBe(body);

--- a/src/lib/blog-content.test.ts
+++ b/src/lib/blog-content.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { extractYouTubeId, splitBlogContent } from "./blog-content";
+import {
+  deriveExcerpt,
+  EXCERPT_MAX_LENGTH,
+  extractYouTubeId,
+  splitBlogContent,
+} from "./blog-content";
 
 describe("splitBlogContent", () => {
   it("returns a single markdown block for plain text", () => {
@@ -57,5 +62,75 @@ describe("extractYouTubeId", () => {
 
   it("returns null for an unparseable URL", () => {
     expect(extractYouTubeId("not a url")).toBeNull();
+  });
+});
+
+describe("deriveExcerpt", () => {
+  it("uses the opening prose of the post", () => {
+    expect(deriveExcerpt("We ran a grading last Saturday.\n\nEveryone passed.")).toBe(
+      "We ran a grading last Saturday. Everyone passed.",
+    );
+  });
+
+  it("skips headings, which restate the title rather than open the post", () => {
+    expect(deriveExcerpt("# Grading day\n\nEveryone passed.")).toBe("Everyone passed.");
+  });
+
+  it("keeps a link's text and drops its URL", () => {
+    expect(deriveExcerpt("See the [timetable](https://jitsu.au/classes) for times.")).toBe(
+      "See the timetable for times.",
+    );
+  });
+
+  it("drops an image entirely rather than reading its alt text as prose", () => {
+    expect(
+      deriveExcerpt("![Two people training](https://example.com/a.png)\n\nWe train Mondays."),
+    ).toBe("We train Mondays.");
+  });
+
+  it("strips emphasis but leaves an underscore inside a word alone", () => {
+    expect(deriveExcerpt("A **big** _week_ for the snake_case club.")).toBe(
+      "A big week for the snake_case club.",
+    );
+  });
+
+  it("keeps list and blockquote text without their markers", () => {
+    expect(deriveExcerpt("- Gi\n- Mouthguard\n\n> Bring water.")).toBe(
+      "Gi Mouthguard Bring water.",
+    );
+  });
+
+  it("ignores fenced code, rules and table rows", () => {
+    expect(deriveExcerpt("```\nnpm install\n```\n\n---\n\n| a | b |\n\nReal words here.")).toBe(
+      "Real words here.",
+    );
+  });
+
+  it("skips video lines, which are not text", () => {
+    expect(deriveExcerpt("[[video:https://youtu.be/abc]]\n\nA throw from last week.")).toBe(
+      "A throw from last week.",
+    );
+  });
+
+  it("cuts at a word boundary and marks the cut", () => {
+    const excerpt = deriveExcerpt("alpha bravo charlie delta", 14);
+    expect(excerpt).toBe("alpha bravo…");
+    expect(excerpt.length).toBeLessThanOrEqual(14);
+  });
+
+  it("does not cut a body that fits", () => {
+    const body = "Short enough.";
+    expect(deriveExcerpt(body)).toBe(body);
+    expect(deriveExcerpt("x".repeat(EXCERPT_MAX_LENGTH))).toHaveLength(EXCERPT_MAX_LENGTH);
+  });
+
+  it("returns an empty string when there is no prose to summarise", () => {
+    expect(deriveExcerpt("")).toBe("");
+    expect(deriveExcerpt("[[video:https://youtu.be/abc]]")).toBe("");
+    expect(deriveExcerpt("## Just a heading")).toBe("");
+  });
+
+  it("stays inside the 500-character excerpt column limit", () => {
+    expect(deriveExcerpt("word ".repeat(500)).length).toBeLessThanOrEqual(EXCERPT_MAX_LENGTH);
   });
 });

--- a/src/lib/blog-content.ts
+++ b/src/lib/blog-content.ts
@@ -35,6 +35,82 @@ export function splitBlogContent(bodyMd: string): BlogContentBlock[] {
   return blocks;
 }
 
+/** How long a derived excerpt runs before it is cut at a word boundary. The
+ * excerpt doubles as the post page's meta description, so this is sized for a
+ * search result rather than for the blog list, which has room for more. */
+export const EXCERPT_MAX_LENGTH = 200;
+
+/**
+ * Strip the inline Markdown out of one line, leaving the words a reader sees.
+ *
+ * Images go entirely (their alt text describes a picture, not the post), links
+ * keep their label and lose their URL, and emphasis/code markers are dropped.
+ * A lone `_` is only removed at a word boundary, so `snake_case` survives while
+ * `_italic_` doesn't.
+ */
+function stripInlineMarkdown(line: string): string {
+  return line
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/`+/g, "")
+    .replace(/~~/g, "")
+    .replace(/\*\*|__/g, "")
+    .replace(/\*/g, "")
+    .replace(/(^|\s)_(\S)/g, "$1$2")
+    .replace(/(\S)_(\s|$)/g, "$1$2");
+}
+
+/**
+ * The prose of a Markdown block as one line of plain text.
+ *
+ * Headings are dropped rather than flattened in: they restate the title or
+ * label a section, and neither reads as the opening of the post. Fenced code,
+ * horizontal rules and table rows go for the same reason. Blockquote and list
+ * markers are stripped but their text is kept.
+ */
+function proseFromMarkdown(markdown: string): string {
+  const kept: string[] = [];
+  let inFence = false;
+  for (const raw of markdown.split("\n")) {
+    const line = raw.trim();
+    if (/^(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence || !line) continue;
+    if (/^#{1,6}\s/.test(line)) continue;
+    if (/^(\*{3,}|-{3,}|_{3,})$/.test(line)) continue;
+    if (line.startsWith("|")) continue;
+    const text = stripInlineMarkdown(
+      line.replace(/^>\s?/, "").replace(/^([-*+]|\d+[.)])\s+/, ""),
+    ).trim();
+    if (text) kept.push(text);
+  }
+  return kept.join(" ");
+}
+
+/**
+ * A one-line summary of a post, for when the manager leaves the excerpt blank.
+ *
+ * Returns "" when there is nothing to summarise — an empty body, or one made
+ * only of videos, images and headings — which callers treat as "no excerpt"
+ * rather than storing a blank string.
+ */
+export function deriveExcerpt(bodyMd: string, maxLength: number = EXCERPT_MAX_LENGTH): string {
+  const text = splitBlogContent(bodyMd)
+    .filter((block) => block.type === "markdown")
+    .map((block) => proseFromMarkdown(block.text))
+    .filter(Boolean)
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (text.length <= maxLength) return text;
+  const cut = text.slice(0, maxLength);
+  const lastSpace = cut.lastIndexOf(" ");
+  const head = (lastSpace > 0 ? cut.slice(0, lastSpace) : cut).replace(/[\s,;:.!?-]+$/, "");
+  return `${head}…`;
+}
+
 /**
  * Extract a YouTube video id from a watch/share/embed/shorts URL. Null for
  * anything else (including a well-formed link to another provider) — the

--- a/src/lib/blog-content.ts
+++ b/src/lib/blog-content.ts
@@ -107,7 +107,13 @@ export function deriveExcerpt(bodyMd: string, maxLength: number = EXCERPT_MAX_LE
   if (text.length <= maxLength) return text;
   const cut = text.slice(0, maxLength);
   const lastSpace = cut.lastIndexOf(" ");
-  const head = (lastSpace > 0 ? cut.slice(0, lastSpace) : cut).replace(/[\s,;:.!?-]+$/, "");
+  // No space to cut at means one word longer than the whole budget, so cut
+  // mid-word — one character short, to leave room for the ellipsis and keep
+  // the result inside `maxLength` either way.
+  const head = (lastSpace > 0 ? cut.slice(0, lastSpace) : cut.slice(0, maxLength - 1)).replace(
+    /[\s,;:.!?-]+$/,
+    "",
+  );
   return `${head}…`;
 }
 

--- a/src/lib/blog.functions.test.ts
+++ b/src/lib/blog.functions.test.ts
@@ -7,7 +7,7 @@
 import { describe, expect, it } from "vitest";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/integrations/supabase/types";
-import { resolvePostSlug, resolvePublishedAt } from "./blog.functions";
+import { resolveExcerpt, resolvePostSlug, resolvePublishedAt } from "./blog.functions";
 
 /**
  * A minimal chainable stub covering the one query shape `resolvePostSlug`
@@ -75,5 +75,24 @@ describe("resolvePublishedAt", () => {
     // would silently jump to the top of the public list on republish.
     expect(resolvePublishedAt(original, "draft", now)).toBe(original);
     expect(resolvePublishedAt(original, "published", now)).toBe(original);
+  });
+});
+
+describe("resolveExcerpt", () => {
+  it("keeps what the manager typed", () => {
+    expect(resolveExcerpt("Hand-written summary.", "Body text.")).toBe("Hand-written summary.");
+  });
+
+  it("derives one from the body when the field was left blank", () => {
+    expect(resolveExcerpt("", "# Grading day\n\nEveryone passed.")).toBe("Everyone passed.");
+    expect(resolveExcerpt(undefined, "Everyone passed.")).toBe("Everyone passed.");
+  });
+
+  it("treats a whitespace-only excerpt as blank rather than storing it", () => {
+    expect(resolveExcerpt("   ", "Everyone passed.")).toBe("Everyone passed.");
+  });
+
+  it("stores null when there is nothing to derive either", () => {
+    expect(resolveExcerpt("", "[[video:https://youtu.be/abc]]")).toBeNull();
   });
 });

--- a/src/lib/blog.functions.ts
+++ b/src/lib/blog.functions.ts
@@ -14,6 +14,7 @@ import {
   uploadBlogImageSchema,
 } from "@/lib/validation";
 import { slugify, uniqueSlug } from "@/lib/slug";
+import { deriveExcerpt } from "@/lib/blog-content";
 import { decodeBase64 } from "@/lib/waiver-scan";
 
 const BUCKET = "blog-media";
@@ -103,6 +104,19 @@ export function resolvePublishedAt(
   now: string,
 ): string | null {
   return existingPublishedAt ?? (newStatus === "published" ? now : null);
+}
+
+/**
+ * The excerpt to store: what the manager typed, or one derived from the body
+ * when they left the field blank. The composer previews the same derived text
+ * as they write, so what lands in the row is what they were shown.
+ *
+ * Null when there is nothing to derive either (a post that is only a video,
+ * say), which is what the blog list and the post page's meta description
+ * already fall back from. Exported for its test — plain, no server context.
+ */
+export function resolveExcerpt(excerpt: string | undefined, bodyMd: string): string | null {
+  return excerpt?.trim() || deriveExcerpt(bodyMd) || null;
 }
 
 // ---- Public: published posts ----
@@ -201,7 +215,7 @@ export const createBlogPost = createServerFn({ method: "POST" })
       .insert({
         slug,
         title: data.title,
-        excerpt: data.excerpt || null,
+        excerpt: resolveExcerpt(data.excerpt, data.body_md),
         body_md: data.body_md,
         cover_image_path: data.cover_image_path || null,
         status: data.status,
@@ -234,12 +248,13 @@ export const updateBlogPost = createServerFn({ method: "POST" })
       data.status,
       new Date().toISOString(),
     );
+    const excerpt = resolveExcerpt(data.excerpt, data.body_md);
     const { error } = await supabaseAdmin
       .from("blog_posts")
       .update({
         slug,
         title: data.title,
-        excerpt: data.excerpt || null,
+        excerpt,
         body_md: data.body_md,
         cover_image_path: data.cover_image_path || null,
         status: data.status,
@@ -248,7 +263,11 @@ export const updateBlogPost = createServerFn({ method: "POST" })
       })
       .eq("id", data.id);
     if (error) throw new Error(error.message);
-    return { ok: true as const, slug };
+    // `slug` and `excerpt` both come back because the server may have resolved
+    // either one (a slug collision, or an excerpt derived from the body): the
+    // edit page uses them as the new baseline so the form isn't left reading
+    // as dirty, and showing something other than what was stored.
+    return { ok: true as const, slug, excerpt };
   });
 
 export const deleteBlogPost = createServerFn({ method: "POST" })

--- a/src/routes/_authenticated/manager.blog_.$id.tsx
+++ b/src/routes/_authenticated/manager.blog_.$id.tsx
@@ -62,17 +62,17 @@ function EditBlogPostPage() {
       });
       toast.success(value.status === "published" ? "Post published" : "Draft saved");
       // Reflect exactly what was saved as the new baseline — including the
-      // slug the server actually resolved (a collision, or a re-derivation
-      // when the field was cleared) — so the "unsaved changes" comparison in
-      // BlogPostEditor resets instead of reading as dirty right after a
-      // successful save.
+      // slug and excerpt the server actually resolved (a slug collision or a
+      // re-derivation when either field was cleared) — so the "unsaved
+      // changes" comparison in BlogPostEditor resets instead of reading as
+      // dirty right after a successful save.
       setPost((prev) =>
         prev
           ? {
               ...prev,
               title: value.title,
               slug: res.slug,
-              excerpt: value.excerpt || null,
+              excerpt: res.excerpt,
               body_md: value.body_md,
               cover_image_path: value.cover_image_path || null,
               cover_image_url: value.cover_image_url,

--- a/src/routes/_authenticated/manager.blog_.new.test.tsx
+++ b/src/routes/_authenticated/manager.blog_.new.test.tsx
@@ -57,4 +57,29 @@ describe("/manager/blog/new", () => {
 
     expect(screen.getByLabelText(/Body/)).toHaveValue("Some post content");
   });
+
+  it("previews the excerpt derived from the body while the field is blank", async () => {
+    const user = userEvent.setup();
+    render(<NewBlogPostPage />);
+
+    expect(screen.getByText(/once you write one/)).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/Body/), "Everyone passed the grading.");
+
+    // Scoped to the hint's own wording: the live preview card renders the same
+    // sentence, so a bare text match would find either one.
+    expect(
+      screen.getByText(/blog list will show: Everyone passed the grading\./),
+    ).toBeInTheDocument();
+  });
+
+  it("drops the derived preview once the manager writes their own excerpt", async () => {
+    const user = userEvent.setup();
+    render(<NewBlogPostPage />);
+
+    await user.type(screen.getByLabelText(/Body/), "Everyone passed the grading.");
+    await user.type(screen.getByLabelText(/Excerpt/), "My own summary");
+
+    expect(screen.queryByText(/blog list will show/)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes fryorcraken/swift-stance#146.

## What changes for a manager

The **Excerpt** field in the post composer is still optional, but it is no longer a dead end. Leave it blank and a line appears under it showing exactly what the blog list will use, taken from the opening of the post and updating as the body is typed. Write your own and the line goes away.

Saving a post with the field blank stores that derived line, so it comes back filled in the next time the post is opened and can be edited like any other text. Nothing about the field is compulsory and nothing new is validated.

## What changes for a reader

A post whose author left the excerpt blank now shows a summary on `/blog` instead of just a title, and the post page's search-result description is the post's own first words rather than the site-wide fallback.

## What is deliberately left out

- **Posts already published with no excerpt are untouched.** The excerpt is resolved when a post is saved, not when it is read, so an old post picks one up the next time a manager saves it. Deriving on read instead would have meant fetching every listed post's full body to render the list.
- **A post that is only a video still stores no excerpt.** There is no prose to summarise, and both the list and the meta description already have their own fallback for that.

## Implementation

`deriveExcerpt` in `src/lib/blog-content.ts` (next to `splitBlogContent`, which it reuses) turns a body into one line of plain text and cuts it at a word boundary at 200 characters, sized for the meta description since the excerpt doubles as one:

- Headings are dropped rather than flattened in. They restate the title or label a section, and neither reads as the opening of the post. Fenced code, horizontal rules and table rows go for the same reason, as do `[[video:...]]` lines.
- Blockquote and list markers are stripped but their text is kept.
- Images go entirely (alt text describes a picture, not the post); links keep their label and lose their URL.
- Emphasis markers go, but a lone `_` is only removed at a word boundary, so `snake_case` survives while `_italic_` does not.

`resolveExcerpt` in `src/lib/blog.functions.ts` applies "typed, else derived, else NULL" on both create and update, mirroring `resolvePostSlug` / `resolvePublishedAt`. `updateBlogPost` now returns the resolved excerpt next to the resolved slug, and `manager.blog_.$id.tsx` uses it as the form's new baseline. Without that, the editor would sit reading as clean while showing a blank field over a row that has text in it.

In the composer the derived value is memoised on `body`, since it re-parses the whole body and the body changes on every keystroke.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (82 files, 1401 tests, 18 new) and `bun run build` all pass locally.

New coverage: the 11 derivation cases above in `blog-content.test.ts` (including the `snake_case` boundary, the word-boundary cut, and the three empty-result bodies); the typed / blank / whitespace-only / nothing-to-derive branches of `resolveExcerpt` in `blog.functions.test.ts`; and the live hint appearing, tracking the body, and disappearing once the manager types their own, in `manager.blog_.new.test.tsx`.

No database or schema changes. `docs/blog.md` updated in the same commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SygndsKXRHH4sBrUfXaNg)_