### PR TITLE
Prefix default blog post slugs with today's date

### DIFF
--- a/docs/blog.md
+++ b/docs/blog.md
@@ -108,8 +108,10 @@ formatting toolbar (bold/italic/heading/list/link), an "Insert image" button
 cover-image uploader, a status picker (draft/published) that warns before
 saving a currently-published post back to draft, and a live preview rendered
 the same styled way the public page renders it. Saving with no slug set
-derives one from the title (`slugify` in `src/lib/slug.ts`, normalized
-on blur too) and resolves a collision by appending `-2`, `-3`, and so on.
+derives one from the title, prefixed with today's date in `YYYY-MM-DD-`
+format (`defaultBlogSlug` in `src/lib/slug.ts`; a manually typed slug is
+still normalized with `slugify` on blur, with no date prefix added) and
+resolves a collision by appending `-2`, `-3`, and so on.
 `published_at` is stamped the first time a post goes live and **never changes
 again** — not on a later edit, and not on an unpublish/republish round trip —
 so a post's publish date and its position in the public list (sorted by

--- a/src/components/site/BlogPostEditor.tsx
+++ b/src/components/site/BlogPostEditor.tsx
@@ -26,7 +26,7 @@ import { uploadBlogImage } from "@/lib/blog.functions";
 import { extractYouTubeId, splitBlogContent } from "@/lib/blog-content";
 import { blogMarkdownComponents } from "@/lib/blog-markdown";
 import { BlogVideoBlock } from "@/components/site/BlogVideoBlock";
-import { slugify } from "@/lib/slug";
+import { defaultBlogSlug, slugify } from "@/lib/slug";
 import {
   blogImageMimeTypes,
   blogPostSchema,
@@ -275,7 +275,7 @@ export function BlogPostEditor({
     onSave(value);
   }
 
-  const previewSlug = slug.trim() || slugify(title) || "your-post-title";
+  const previewSlug = slug.trim() || defaultBlogSlug(title) || "your-post-title";
   const videoUrlIsYouTube = Boolean(videoUrl.trim() && extractYouTubeId(videoUrl.trim()));
 
   const formFields = (

--- a/src/lib/blog.functions.test.ts
+++ b/src/lib/blog.functions.test.ts
@@ -26,24 +26,32 @@ function fakeAdmin(existingSlugs: string[]) {
 }
 
 describe("resolvePostSlug", () => {
-  it("derives a slug from the title when none is given", async () => {
+  const now = new Date("2026-07-31T00:00:00.000Z");
+
+  it("derives a slug from the title, prefixed with today's date, when none is given", async () => {
     const admin = fakeAdmin([]);
-    expect(await resolvePostSlug(admin, "Hello World", undefined)).toBe("hello-world");
+    expect(await resolvePostSlug(admin, "Hello World", undefined, undefined, now)).toBe(
+      "2026-07-31-hello-world",
+    );
   });
 
-  it("uses the manager's own slug when given", async () => {
+  it("uses the manager's own slug when given, with no date prefix added", async () => {
     const admin = fakeAdmin([]);
-    expect(await resolvePostSlug(admin, "Hello World", "custom-url")).toBe("custom-url");
+    expect(await resolvePostSlug(admin, "Hello World", "custom-url", undefined, now)).toBe(
+      "custom-url",
+    );
   });
 
   it("resolves a collision against another post's slug", async () => {
-    const admin = fakeAdmin(["hello-world"]);
-    expect(await resolvePostSlug(admin, "Hello World", undefined)).toBe("hello-world-2");
+    const admin = fakeAdmin(["2026-07-31-hello-world"]);
+    expect(await resolvePostSlug(admin, "Hello World", undefined, undefined, now)).toBe(
+      "2026-07-31-hello-world-2",
+    );
   });
 
   it("throws when the title has no usable characters and no slug was given", async () => {
     const admin = fakeAdmin([]);
-    await expect(resolvePostSlug(admin, "!!!", undefined)).rejects.toThrow();
+    await expect(resolvePostSlug(admin, "!!!", undefined, undefined, now)).rejects.toThrow();
   });
 });
 

--- a/src/lib/blog.functions.ts
+++ b/src/lib/blog.functions.ts
@@ -13,7 +13,7 @@ import {
   listBlogPostsSchema,
   uploadBlogImageSchema,
 } from "@/lib/validation";
-import { slugify, uniqueSlug } from "@/lib/slug";
+import { defaultBlogSlug, uniqueSlug } from "@/lib/slug";
 import { decodeBase64 } from "@/lib/waiver-scan";
 
 const BUCKET = "blog-media";
@@ -58,18 +58,20 @@ function serverSupabase() {
 
 /**
  * Resolve the slug a post will be saved under: the manager's own, or one
- * derived from the title, made unique against every OTHER post's slug that
- * shares the same base (so "hello-world" collides into "hello-world-2", not a
- * database error). Exported for its test — plain, taking the admin client as
- * a parameter, unlike the `createServerFn` handlers around it.
+ * derived from the title and today's date (`defaultBlogSlug`), made unique
+ * against every OTHER post's slug that shares the same base (so
+ * "2026-08-06-hello-world" collides into "...-2", not a database error).
+ * Exported for its test — plain, taking the admin client and `now` as
+ * parameters, unlike the `createServerFn` handlers around it.
  */
 export async function resolvePostSlug(
   admin: SupabaseClient<Database>,
   title: string,
   provided: string | undefined,
   excludeId?: string,
+  now: Date = new Date(),
 ): Promise<string> {
-  const base = (provided || "").trim() || slugify(title);
+  const base = (provided || "").trim() || defaultBlogSlug(title, now);
   if (!base) {
     throw new Error("Could not turn that title into a URL. Set a URL slug by hand.");
   }

--- a/src/lib/slug.test.ts
+++ b/src/lib/slug.test.ts
@@ -33,6 +33,22 @@ describe("defaultBlogSlug", () => {
   it("returns an empty string for a title with no alphanumeric characters", () => {
     expect(defaultBlogSlug("!!!", now)).toBe("");
   });
+
+  it("truncates a near-max-length title so the date-prefixed slug still fits blog_posts' 200-char limit", () => {
+    const title = "a".repeat(200);
+    const slug = defaultBlogSlug(title, now);
+    expect(slug.length).toBe(200);
+    expect(slug).toBe(`2026-08-06-${"a".repeat(189)}`);
+  });
+
+  it("trims a trailing hyphen left by truncation, rather than producing an invalid slug", () => {
+    // Slugified title is 190 chars with a hyphen right where the 189-char
+    // truncation point falls, so a naive slice would end in "-".
+    const title = `${"a".repeat(188)} b`;
+    const slug = defaultBlogSlug(title, now);
+    expect(slug.endsWith("-")).toBe(false);
+    expect(slug).toBe(`2026-08-06-${"a".repeat(188)}`);
+  });
 });
 
 describe("uniqueSlug", () => {

--- a/src/lib/slug.test.ts
+++ b/src/lib/slug.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { slugify, uniqueSlug } from "./slug";
+import { defaultBlogSlug, slugify, uniqueSlug } from "./slug";
 
 describe("slugify", () => {
   it("lowercases and hyphenates spaces", () => {
@@ -20,6 +20,18 @@ describe("slugify", () => {
 
   it("returns an empty string for a title with no alphanumeric characters", () => {
     expect(slugify("!!!")).toBe("");
+  });
+});
+
+describe("defaultBlogSlug", () => {
+  const now = new Date("2026-08-06T03:00:00.000Z");
+
+  it("prefixes the slugified title with today's date", () => {
+    expect(defaultBlogSlug("Hello World", now)).toBe("2026-08-06-hello-world");
+  });
+
+  it("returns an empty string for a title with no alphanumeric characters", () => {
+    expect(defaultBlogSlug("!!!", now)).toBe("");
   });
 });
 

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -17,6 +17,19 @@ export function slugify(title: string): string {
 }
 
 /**
+ * The default slug for a new blog post: today's date (`YYYY-MM-DD`) prefixed
+ * onto the slugified title, so a post's URL reads chronologically even before
+ * anyone sets a slug by hand. Empty when the title has no usable characters,
+ * same as `slugify`, so callers can still treat that as "could not derive a
+ * slug" rather than publish a bare date.
+ */
+export function defaultBlogSlug(title: string, now: Date = new Date()): string {
+  const base = slugify(title);
+  if (!base) return base;
+  return `${now.toISOString().slice(0, 10)}-${base}`;
+}
+
+/**
  * The first candidate slug (`base`, `base-2`, `base-3`, ...) not already in
  * `taken`. Pure so collision resolution is unit-testable without a database.
  */

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -16,17 +16,26 @@ export function slugify(title: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
+/** Matches `blog_posts`' `char_length(slug) BETWEEN 1 AND 200` CHECK
+ * constraint (`supabase/migrations/20260731100000_blog_posts.sql`). */
+const BLOG_SLUG_MAX_LENGTH = 200;
+
 /**
  * The default slug for a new blog post: today's date (`YYYY-MM-DD`) prefixed
  * onto the slugified title, so a post's URL reads chronologically even before
  * anyone sets a slug by hand. Empty when the title has no usable characters,
  * same as `slugify`, so callers can still treat that as "could not derive a
- * slug" rather than publish a bare date.
+ * slug" rather than publish a bare date. The title alone can be as long as
+ * the slug's own DB limit (both cap at 200), so the slugified title is
+ * truncated to make room for the date prefix — otherwise a near-max-length
+ * title would produce a slug the database rejects.
  */
 export function defaultBlogSlug(title: string, now: Date = new Date()): string {
   const base = slugify(title);
   if (!base) return base;
-  return `${now.toISOString().slice(0, 10)}-${base}`;
+  const prefix = `${now.toISOString().slice(0, 10)}-`;
+  const truncatedBase = base.slice(0, BLOG_SLUG_MAX_LENGTH - prefix.length).replace(/-+$/g, "");
+  return `${prefix}${truncatedBase}`;
 }
 
 /**

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -2092,8 +2092,9 @@ const blogSlug = z
 
 /**
  * Manager: create or edit a post. `slug` is optional — when blank, the server
- * derives one from the title (`slugify` in `src/lib/slug.ts`) and resolves any
- * collision by appending `-2`, `-3`, etc.
+ * derives one from the title prefixed with today's date, `YYYY-MM-DD-...`
+ * (`defaultBlogSlug` in `src/lib/slug.ts`) and resolves any collision by
+ * appending `-2`, `-3`, etc.
  */
 export const blogPostSchema = z.object({
   id: z.string().uuid().optional(),


### PR DESCRIPTION
## Summary

- When a manager leaves the URL slug field blank while writing a blog post, the auto-generated slug now starts with today's date in `YYYY-MM-DD-` format (e.g. `2026-08-06-hello-world`) instead of just the slugified title.
- A manually typed slug is untouched — the date prefix only applies to the auto-derived default, both in the composer's live preview and on the server when actually saving the post.
- Collision handling (`-2`, `-3`, ...) still applies against the date-prefixed base.

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (added/updated cases in `src/lib/slug.test.ts` and `src/lib/blog.functions.test.ts`)
- [x] `bun run build`

Closes fryorcraken/swift-stance#145


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmnoPzevZAzezgTjEcMgW2)_