### PR TITLE
Remove "not ready" fallback sentence from registration confirmation email

### DIFF
--- a/src/lib/email-templates/interest-confirmation.tsx
+++ b/src/lib/email-templates/interest-confirmation.tsx
@@ -50,10 +50,6 @@ export const InterestConfirmationEmail = ({
         <Button style={button} href={waiverUrl}>
           Sign my waiver
         </Button>
-        <Text style={text}>
-          Not ready? No problem. Just turn up to any beginners class (Mon or Wed) and we&apos;ll
-          sort it at the gym.
-        </Text>
         <Text style={footer}>
           You&apos;re receiving this because you registered your interest at {siteName}.
         </Text>


### PR DESCRIPTION
## Summary
- Removes the "Not ready? No problem. Just turn up to any beginners class (Mon or Wed) and we'll sort it at the gym." paragraph from the registration confirmation email (`InterestConfirmationEmail`), so the email focuses on the prefilled waiver link as the next step.

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BhjVLDd9jvtjnv3wbM9Mqm)_