### PR TITLE
Waiver: let a signed-in person switch identity on the locked email field

### DIFF
--- a/src/routes/waiver.tsx
+++ b/src/routes/waiver.tsx
@@ -12,6 +12,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { CheckCircle2, Download } from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
 import { SignaturePad, type SignaturePadHandle } from "@/components/site/SignaturePad";
 import { GI_SIZE_HINT, GiSizeSelect } from "@/components/site/KitSizeSelect";
 import { type GiSize, isGiSize } from "@/lib/kit-sizes";
@@ -233,6 +234,15 @@ function Waiver() {
   useEffect(() => {
     if (user?.email) setEmail(user.email);
   }, [user]);
+
+  // Lets someone on a shared/previously-signed-in device sign under a
+  // different address without leaving the page. Falls back to whatever
+  // prefill came in on the URL, since that's the address they were trying to
+  // sign under in the first place.
+  async function signOutToSignAsSomeoneElse() {
+    await supabase.auth.signOut();
+    setEmail(search.email ?? "");
+  }
 
   // Arriving from the link in an interest confirmation email is itself proof
   // that the address is real, so redeem it on open rather than waiting for a
@@ -797,8 +807,21 @@ function Waiver() {
                 />
                 {user && (
                   <p className="mt-1.5 text-xs text-muted-foreground">
-                    You're signed in, so the waiver uses your account email. To sign for someone
-                    else, log out first.
+                    You're signed in, so the waiver uses your account email.
+                    <br />
+                    Wrong email?{" "}
+                    <button
+                      type="button"
+                      onClick={signOutToSignAsSomeoneElse}
+                      className="underline hover:text-foreground"
+                    >
+                      Log out
+                    </button>{" "}
+                    to sign under a different address, or{" "}
+                    <Link to="/contact" className="underline hover:text-foreground">
+                      contact us
+                    </Link>{" "}
+                    to change the email on your account.
                   </p>
                 )}
               </div>


### PR DESCRIPTION
## Summary

Reported as "the `+13` in my email got stripped out" when testing the waiver flow with a plus-addressed email. Turned out to be by design, not a bug: when someone is already signed in, `/waiver` locks the email field to their account's login email (the server enforces the match), silently overriding whatever address is in the URL/prefill. That's correct behavior, but there was no way out of it short of knowing to manually log out first.

- Verified only **visitor / member / lapsed** accounts can ever be signed in and hit this code path — a **lead** has no auth account yet, and an **applicant** is banned (~100 years, no credentials) until a manager approves their waiver, so neither can be authenticated in the first place. One fix covers all the reachable cases.
- Added a line under the locked email field: a **"Log out"** action (signs out in place and refills the field from the URL prefill, no page leave) and a **"contact us"** link to `/contact`, since there's no self-serve email change — only a manager can correct the email on an account.

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [ ] Manual: sign in as an existing member, open `/waiver?email=someone-else%2Btag%40example.com`, confirm the field is locked to the account email, click "Log out", confirm the field repopulates with the prefilled address and becomes editable.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R5Rfv8PovYoQJMwL5AKVQt

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5Rfv8PovYoQJMwL5AKVQt)_