### PR TITLE
Jump to the first unanswered health question on submit

### DIFF
--- a/src/routes/waiver.tsx
+++ b/src/routes/waiver.tsx
@@ -163,6 +163,7 @@ function Waiver() {
 
   const sigPadRef = useRef<SignaturePadHandle | null>(null);
   const gSigPadRef = useRef<SignaturePadHandle | null>(null);
+  const healthQuestionRefs = useRef<Partial<Record<HealthQuestionId, HTMLDivElement | null>>>({});
 
   const fullName = useMemo(
     () =>
@@ -539,8 +540,15 @@ function Waiver() {
    * instead of the plain sentence they get here.
    */
   function readyToSend(): boolean {
-    if (missingHealthAnswers(health).length > 0) {
+    const missingHealth = missingHealthAnswers(health);
+    if (missingHealth.length > 0) {
       toast.error("Please answer yes or no to every health question.");
+      const firstMissing = missingHealth[0];
+      healthQuestionRefs.current[firstMissing.id]?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+      document.getElementById(`${firstMissing.id}_yes`)?.focus();
       return false;
     }
     if (anyHealthConcern(health) && !medical.trim()) {
@@ -914,7 +922,13 @@ function Waiver() {
                 Please answer all five. Your instructors read these before you train.
               </p>
               {healthQuestions.map((q) => (
-                <div key={q.id} className="space-y-2">
+                <div
+                  key={q.id}
+                  ref={(el) => {
+                    healthQuestionRefs.current[q.id] = el;
+                  }}
+                  className="space-y-2"
+                >
                   <p className="text-sm">{q.question}</p>
                   <RadioGroup
                     className="flex gap-6"


### PR DESCRIPTION
## Summary
- When the waiver form's "Please answer yes or no to every health question" toast fires, the form now scrolls to and focuses the first unanswered question instead of leaving the signer to scroll and hunt for it among the five.

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [ ] Manual check in a browser: leave a health question unanswered, submit, confirm the page scrolls to it and focuses the "Yes" radio

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRJ1dPKaDZQmD3ohGRyaS2)_