### PR TITLE
Drop email column, link name to profile on check-in screen

### DIFF
--- a/src/routes/_authenticated/manager.check-in.tsx
+++ b/src/routes/_authenticated/manager.check-in.tsx
@@ -379,7 +379,6 @@ function CheckInPage() {
             <thead className="bg-muted/50 text-left">
               <tr>
                 <th className="px-3 py-2">Person</th>
-                <th className="px-3 py-2">Email</th>
                 <th className="px-3 py-2">What pays for it</th>
                 <th className="px-3 py-2" />
               </tr>
@@ -387,7 +386,7 @@ function CheckInPage() {
             <tbody>
               {matches.length === 0 && (
                 <tr>
-                  <td className="px-3 py-6 text-muted-foreground" colSpan={4}>
+                  <td className="px-3 py-6 text-muted-foreground" colSpan={3}>
                     {search.trim()
                       ? "Nobody by that name has a waiver on file."
                       : "Everyone is checked in."}
@@ -396,8 +395,15 @@ function CheckInPage() {
               )}
               {matches.slice(0, MATCH_LIMIT).map((r) => (
                 <tr key={r.user_id} className="border-t">
-                  <td className="px-3 py-2 font-medium">{r.name ?? "Unknown"}</td>
-                  <td className="px-3 py-2 text-muted-foreground">{r.email ?? "—"}</td>
+                  <td className="px-3 py-2 font-medium">
+                    <Link
+                      className="hover:underline"
+                      to="/manager/users/$userId"
+                      params={{ userId: r.user_id }}
+                    >
+                      {r.name ?? "Unknown"}
+                    </Link>
+                  </td>
                   <td className="px-3 py-2">
                     <Pill
                       label={coveragePreviewLabel(r)}


### PR DESCRIPTION
## Summary
- Removes the Email column from the "Check someone in" table on `/manager/check-in`
- Makes the person's name a link to their profile page, matching the "Here now" and "Needs attention" tables on the same screen

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`

---
_Generated by [Claude Code](https://claude.ai/code/session_012oV3ah96yy8FficMg8Wgob)_