### PR TITLE
Replace the approval magic link with an account-activated email

### DIFF
--- a/.claude/skills/uts-manager-agent/SKILL.md
+++ b/.claude/skills/uts-manager-agent/SKILL.md
@@ -244,7 +244,8 @@ scripts/agent.sh file_waiver '{
 >
 > - **It never approves, emails, or verifies.** Filing is not approving:
 >   approval is what promotes the record onto the person's profile, unlocks
->   their login, **emails them a sign-in link**, and **assigns the free trial**.
+>   their login, **emails them that their account is active**, and **assigns
+>   the free trial**.
 >   `file_waiver` does none of that — every row lands pending, exactly like a
 >   manager's own upload. Approving hundreds of migrated people would email all
 >   of them and hand out that many trials; that decision belongs to the manager

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,8 @@ driven directly by the bundled skill.
     agent-filed waiver and a manager's own upload are identical. Always lands
     **pending**: it never approves, emails anyone, or marks the email verified
     — approving is a separate, deliberate manager action because it promotes
-    the record, unlocks the login, emails a sign-in link and assigns the free
-    trial (docs/waivers.md rule 6). `uploaded_by` on the filed row is the
+    the record, unlocks the login, emails them that their account is active and
+    assigns the free trial (docs/waivers.md rule 6). `uploaded_by` on the filed row is the
     token's owner, or the `AGENT_ENV_KEY_UPLOADER` sentinel for the break-glass
     env key, which has no owner to resolve. Filing a waiver the person already
     has for the same `signed_on` is refused with `409 duplicate_waiver` (the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ Core tables:
   i.e. banned/no-credentials) auth user + their profile, created at waiver
   submission (interest registrations are leads only — just rows). A **manager
   approving a waiver** copies the submission's details onto the profile, lifts
-  the ban, emails a sign-in link, and assigns the free trial. The funnel phase
+  the ban, emails them that their account is active, and assigns the free trial. The funnel phase
   (`lead | applicant | visitor | member | lapsed`) is always derived
   (`deriveLifecycleStatus`). There is no self-serve sign-up.
 - `waivers` — frozen submissions: the person fields **as submitted** (email

--- a/docs/database.md
+++ b/docs/database.md
@@ -171,7 +171,7 @@ store) + a **`profiles` row keyed by that user id** (the person fields; no
 email column anywhere in `public`). An applicant is a **locked** auth user
 (banned, no credentials) created at first waiver submission; a manager's
 **approval** copies the submission's details onto the profile, lifts the ban,
-and emails a sign-in link (see `docs/waivers.md`). A waiver is a **frozen
+and emails them that their account is active (see `docs/waivers.md`). A waiver is a **frozen
 submission**: exactly what was typed, the signed PDF, template version, real
 signer IP and signing context, and its approval state.
 
@@ -253,7 +253,7 @@ inside the waiver PDF), and no `full_name`.
   `interest_registrations`.)
 - Manager approval (`setWaiverApproval`): copies the approved submission's
   person fields onto the profile (`waiverToProfileFields`); on first approval
-  lifts the ban, sends a sign-in email, and assigns the free trial
+  lifts the ban, sends the account-activated email, and assigns the free trial
   (`assignTrialMembership`, one per person ever, activation email suppressed).
   `media_consent` is the one field the patch can OMIT rather than set: a
   submission carrying NULL was signed on a template that never asked, and must

--- a/docs/knowledge-base.md
+++ b/docs/knowledge-base.md
@@ -192,9 +192,10 @@ From the member area: the sidebar's first item, and a card at the top of
 
 The waiver-confirmation email **mentions** the knowledge base and deliberately
 does not link to it. Whoever is reading that email cannot sign in yet: their
-account is created locked, and a manager approving the waiver is what sends the
-sign-in link. A link there would land a brand-new person on a sign-in screen
-they have no password for.
+account is created locked, and a manager approving the waiver is what opens it.
+A link there would land a brand-new person on a sign-in screen they have no
+account for. The **account-activated** email sent at approval does link it, by
+which point they can get in.
 
 ## Private notes and shared threads
 

--- a/docs/waivers.md
+++ b/docs/waivers.md
@@ -12,7 +12,8 @@ their email (the only place any email lives) plus a **profile** carrying their
 person fields. A waiver is a **frozen submission**: exactly what was typed, the
 signed PDF, and the signer's IP and browser context. Nothing becomes official
 until a **manager approves** a submission: approval copies its details onto the
-profile, unlocks the login, emails a sign-in link, and assigns the free trial.
+profile, unlocks the login, emails them that their account is active, and
+assigns the free trial.
 The **active waiver** is the latest approved one; everything else is history.
 
 ## The funnel
@@ -26,8 +27,8 @@ records, never stored.
    record (their email, no way to sign in) plus a profile, with the
    submission(s) pending a manager's review.
 3. **Visitor** — a manager approved their waiver: details promoted onto the
-   profile, login unlocked (sign-in link emailed), and the free trial assigned
-   automatically on the first approval.
+   profile, login unlocked (account-activated email sent), and the free trial
+   assigned automatically on the first approval.
 4. **Member** — holds an active paid membership (semester, yearly insurance,
    or a paid casual session).
 5. **Lapsed** — their trial or membership ended and nothing is active: the
@@ -88,11 +89,16 @@ system. (The contact form stores a message, not a person.)
    stored.
 6. **Approval promotes, unlocks, and assigns the trial.** Approving a waiver
    copies its details onto the profile; on the person's first approval it also
-   lifts the ban on their login, emails them a sign-in link, and assigns the
-   club's free trial (one per person, ever — no activation email, they already
-   got the sign-in one). Approving a newer waiver later refreshes the profile
-   again (no repeat sign-in email, no second trial). Unapprove only reverts
-   the waiver's status; profile, login and trial stay as they are.
+   lifts the ban on their login, emails them to say their account is active,
+   and assigns the club's free trial (one per person, ever — no membership
+   activation email, the account one covers it). That email carries **no
+   sign-in link**: it names the address their login is keyed on and sends them
+   to `/auth` to request a link themselves. An unrequested magic link expires
+   in an hour, so it is usually dead by the time it is read, while this one
+   still works whenever they get to it. Approving a newer waiver later
+   refreshes the profile again (no repeat activation email, no second trial).
+   Unapprove only reverts the waiver's status; profile, login and trial stay
+   as they are.
 7. **Full name is never stored**; it is composed from first/middle/last. The
    optional **preferred name** is stored separately (on the submission and, once
    approved, on the profile). One rule governs it everywhere: **address a person
@@ -279,14 +285,17 @@ would only mean "a manager believed this".
 
 It gates **nothing**. An unverified person can sign, be approved, be assigned a
 membership, and train. The badge exists so a manager can see the risk at the
-moment it matters (approval emails a sign-in link to that address), not to put a
+moment it matters (approval emails their account details to that address, and
+it is the address they sign in with), not to put a
 wall at the door.
 
 How people get verified, in descending order of how many it catches:
 
 - **Signing in with a login link.** Supabase stamps the confirmation natively, so
   nearly everyone who becomes an active member is verified without anyone doing
-  anything. Same for password resets.
+  anything. Same for password resets. The activation email no longer carries a
+  link, so this now happens on the link they request themselves at `/auth`,
+  one step later and just as reliably.
 - **The waiver link in their interest confirmation email.** That link carries an
   unguessable token (`?vt=`); the name/email params alone prove nothing, since
   the in-app success screen builds the same URL. Opening it verifies them, and
@@ -438,8 +447,8 @@ exists. The button stays because the next seeded draft needs it.
 
 ### Visitor or member uses the member area
 
-Login exists only via approval (sign-in link email; magic link or password
-thereafter). They see: the waiver form prefilled from their profile, their
+Login exists only via approval (account-activated email, then a magic link they
+request at `/auth`, or a password they set). They see: the waiver form prefilled from their profile, their
 waiver history with the active one marked and PDFs downloadable, and
 memberships (buying a paid plan makes a visitor a member).
 

--- a/src/lib/email-templates/account-activated.test.tsx
+++ b/src/lib/email-templates/account-activated.test.tsx
@@ -57,13 +57,30 @@ describe("AccountActivatedEmail", () => {
   it("invites them into the rest of the member area", async () => {
     const html = await renderHtml();
     const text = visibleText(html);
-    expect(text).toContain("knowledge base");
     expect(text).toContain("code of conduct");
     expect(text).toMatch(/invoices/i);
     expect(text).toContain("blog");
-    for (const url of [PROPS.kbUrl, PROPS.codeOfConductUrl, PROPS.membershipUrl, PROPS.blogUrl]) {
+    expect(text).toContain("knowledge base");
+    for (const url of [PROPS.codeOfConductUrl, PROPS.membershipUrl, PROPS.blogUrl, PROPS.kbUrl]) {
       expect(html).toContain(`href="${url}"`);
     }
+  });
+
+  // Deliberate running order, not incidental. The code of conduct is the one
+  // thing this email asks of them, so it leads; the membership is what they
+  // will come back for; the blog is the invitation to stick around. The
+  // knowledge base is mentioned last and without a heading of its own, because
+  // it is the biggest thing back there and would swamp the two that matter on
+  // day one.
+  it("keeps the code of conduct first and the knowledge base a passing mention", async () => {
+    const text = visibleText(await renderHtml());
+    const order = ["code of conduct", "membership", "blog", "knowledge base"].map((phrase) =>
+      text.toLowerCase().indexOf(phrase),
+    );
+    expect(order).not.toContain(-1);
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+    // A passing mention: no "What's waiting" style heading introduces it.
+    expect(text).not.toMatch(/The knowledge base\./);
   });
 
   it("greets someone with no name on file without leaving a gap", async () => {

--- a/src/lib/email-templates/account-activated.test.tsx
+++ b/src/lib/email-templates/account-activated.test.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { render } from "@react-email/render";
+import { describe, expect, it } from "vitest";
+
+import { AccountActivatedEmail } from "./account-activated";
+
+const PROPS = {
+  siteName: "UTS Jitsu",
+  siteUrl: "https://jitsu.au",
+  memberName: "Thirteen",
+  loginEmail: "sensei+13@sydneyjitsu.com.au",
+  signInUrl: "https://jitsu.au/auth",
+  kbUrl: "https://jitsu.au/kb",
+  codeOfConductUrl: "https://jitsu.au/code-of-conduct",
+  membershipUrl: "https://jitsu.au/membership",
+  blogUrl: "https://jitsu.au/blog",
+};
+
+// react-dom/server splits interpolated text with <!-- --> markers, so compare
+// against the visible copy rather than the raw markup.
+const visibleText = (html: string) =>
+  html
+    .replace(/<!--.*?-->/g, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const renderHtml = (props: object = PROPS) =>
+  render(React.createElement(AccountActivatedEmail, { ...PROPS, ...props }));
+
+describe("AccountActivatedEmail", () => {
+  it("tells them the account is open and names the address to sign in with", async () => {
+    const text = visibleText(await renderHtml());
+    expect(text).toContain("Your account is active");
+    expect(text).toContain("Hi Thirteen");
+    expect(text).toContain("sensei+13@sydneyjitsu.com.au");
+    expect(text).toMatch(/your login is/i);
+  });
+
+  it("points at the sign-in page", async () => {
+    expect(await renderHtml()).toContain('href="https://jitsu.au/auth"');
+  });
+
+  // The whole reason this email replaced the magic link: an unrequested
+  // one-time link expires in an hour, so it is usually dead by the time a new
+  // member reads it. Every URL here has to be a plain page that still works
+  // next week. A token creeping back in would silently restore the old
+  // failure, and it would only ever be noticed by the member who got locked out.
+  it("carries no single-use sign-in token", async () => {
+    const html = await renderHtml();
+    expect(html).not.toMatch(/token|access_token|otp|magiclink|confirmation_url/i);
+    for (const href of html.match(/href="[^"]*"/g) ?? []) {
+      expect(href).not.toContain("?");
+    }
+  });
+
+  it("invites them into the rest of the member area", async () => {
+    const html = await renderHtml();
+    const text = visibleText(html);
+    expect(text).toContain("knowledge base");
+    expect(text).toContain("code of conduct");
+    expect(text).toMatch(/invoices/i);
+    expect(text).toContain("blog");
+    for (const url of [PROPS.kbUrl, PROPS.codeOfConductUrl, PROPS.membershipUrl, PROPS.blogUrl]) {
+      expect(html).toContain(`href="${url}"`);
+    }
+  });
+
+  it("greets someone with no name on file without leaving a gap", async () => {
+    const text = visibleText(await renderHtml({ memberName: "" }));
+    expect(text).toContain("Hi there,");
+  });
+
+  // House style for member-facing copy (AGENTS.md): no em dashes in prose.
+  it("keeps em dashes out of the copy", async () => {
+    expect(visibleText(await renderHtml())).not.toContain("—");
+  });
+});

--- a/src/lib/email-templates/account-activated.test.tsx
+++ b/src/lib/email-templates/account-activated.test.tsx
@@ -14,6 +14,7 @@ const PROPS = {
   codeOfConductUrl: "https://jitsu.au/code-of-conduct",
   membershipUrl: "https://jitsu.au/membership",
   blogUrl: "https://jitsu.au/blog",
+  contactUrl: "https://jitsu.au/contact",
 };
 
 // react-dom/server splits interpolated text with <!-- --> markers, so compare
@@ -81,6 +82,15 @@ describe("AccountActivatedEmail", () => {
     expect(order).toEqual([...order].sort((a, b) => a - b));
     // A passing mention: no "What's waiting" style heading introduces it.
     expect(text).not.toMatch(/The knowledge base\./);
+  });
+
+  // Every email here goes out from noreply@ with no reply-to header, so the
+  // "just reply" sign-off other templates use would swallow the one message
+  // that matters most: a new member saying they cannot get in.
+  it("offers a route back that actually reaches the club", async () => {
+    const html = await renderHtml();
+    expect(html).toContain('href="https://jitsu.au/contact"');
+    expect(visibleText(html)).not.toMatch(/reply to this email/i);
   });
 
   it("greets someone with no name on file without leaving a gap", async () => {

--- a/src/lib/email-templates/account-activated.tsx
+++ b/src/lib/email-templates/account-activated.tsx
@@ -1,0 +1,154 @@
+import * as React from "react";
+
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Link,
+  Preview,
+  Text,
+} from "@react-email/components";
+
+interface AccountActivatedEmailProps {
+  siteName: string;
+  siteUrl: string;
+  /** What to call them to their face: preferred name, else first name. */
+  memberName: string;
+  /**
+   * The address their account is keyed on, shown so they know what to type on
+   * the sign-in page. It is the only identifier they have: there is no username
+   * and, on first activation, no password either.
+   */
+  loginEmail: string;
+  /** The sign-in page. Deliberately the only call to action in this email. */
+  signInUrl: string;
+  kbUrl: string;
+  codeOfConductUrl: string;
+  membershipUrl: string;
+  blogUrl: string;
+}
+
+/**
+ * Sent once a manager approves someone's first waiver and their login is
+ * unlocked.
+ *
+ * This email carries NO sign-in link, on purpose. It used to send a magic link
+ * nobody had asked for, which reads as odd on arrival and is worse an hour
+ * later when it has quietly expired. Instead it says the account is open,
+ * names the address to sign in with, and points at the sign-in page, where
+ * they request a link themselves (or set a password). One extra step, and it
+ * still works whenever they get round to reading it.
+ */
+export const AccountActivatedEmail = ({
+  siteName,
+  siteUrl,
+  memberName,
+  loginEmail,
+  signInUrl,
+  kbUrl,
+  codeOfConductUrl,
+  membershipUrl,
+  blogUrl,
+}: AccountActivatedEmailProps) => (
+  <Html lang="en" dir="ltr">
+    <Head />
+    <Preview>Your {siteName} account is active</Preview>
+    <Body style={main}>
+      <Container style={container}>
+        <Heading style={h1}>Your account is active</Heading>
+        <Text style={text}>
+          Hi {memberName || "there"}, your waiver has been approved and your account at{" "}
+          <Link href={siteUrl} style={link}>
+            <strong>{siteName}</strong>
+          </Link>{" "}
+          is now open. You&apos;re cleared to train.
+        </Text>
+        <Text style={text}>
+          Your login is <strong>{loginEmail}</strong>
+        </Text>
+        <Button style={button} href={signInUrl}>
+          Sign in
+        </Button>
+        <Text style={text}>
+          Enter that address on the sign-in page and we&apos;ll email you a link to get in. You can
+          set a password once you&apos;re there, if you&apos;d rather sign in that way.
+        </Text>
+        <Text style={h2}>What&apos;s waiting for you</Text>
+        <Text style={item}>
+          <Link href={kbUrl} style={itemLink}>
+            The knowledge base
+          </Link>
+          . What happens in your first session, how our belts and grading work, and how the club
+          runs. Worth a read before you turn up.
+        </Text>
+        <Text style={item}>
+          <Link href={codeOfConductUrl} style={itemLink}>
+            The code of conduct
+          </Link>
+          . How we train together: hygiene, mat etiquette, gear, and keeping each other safe. Please
+          read it and agree when you have a minute.
+        </Text>
+        <Text style={item}>
+          <Link href={membershipUrl} style={itemLink}>
+            Your membership
+          </Link>
+          . What you&apos;re on, what&apos;s been paid, and any invoices waiting on you.
+        </Text>
+        <Text style={item}>
+          <Link href={blogUrl} style={itemLink}>
+            The blog
+          </Link>
+          . Club news and write-ups, and you can join the conversation in the comments once
+          you&apos;re signed in.
+        </Text>
+        <Text style={footer}>
+          See you on the mat. Reply to this email if anything looks off, or if you can&apos;t get
+          in.
+        </Text>
+      </Container>
+    </Body>
+  </Html>
+);
+
+export default AccountActivatedEmail;
+
+const main = { backgroundColor: "#ffffff", fontFamily: "Arial, sans-serif" };
+const container = { padding: "20px 25px" };
+const h1 = {
+  fontSize: "22px",
+  fontWeight: "bold" as const,
+  color: "#008eaa",
+  margin: "0 0 20px",
+};
+const h2 = {
+  fontSize: "16px",
+  fontWeight: "bold" as const,
+  color: "#55575d",
+  margin: "30px 0 15px",
+};
+const text = {
+  fontSize: "14px",
+  color: "#55575d",
+  lineHeight: "1.5",
+  margin: "0 0 25px",
+};
+const item = {
+  fontSize: "14px",
+  color: "#55575d",
+  lineHeight: "1.5",
+  margin: "0 0 15px",
+};
+const link = { color: "inherit", textDecoration: "underline" };
+const itemLink = { color: "#008eaa", textDecoration: "underline", fontWeight: "bold" as const };
+const button = {
+  backgroundColor: "#008eaa",
+  color: "#ffffff",
+  fontSize: "14px",
+  borderRadius: "8px",
+  padding: "12px 20px",
+  textDecoration: "none",
+};
+const footer = { fontSize: "12px", color: "#999999", margin: "30px 0 0" };

--- a/src/lib/email-templates/account-activated.tsx
+++ b/src/lib/email-templates/account-activated.tsx
@@ -29,6 +29,15 @@ interface AccountActivatedEmailProps {
   codeOfConductUrl: string;
   membershipUrl: string;
   blogUrl: string;
+  /**
+   * The contact form, offered instead of "reply to this email".
+   *
+   * Everything here is sent from `noreply@`, with no reply-to header, so a
+   * reply goes nowhere. That is a small thing to get wrong in most emails and
+   * a large one here: this is the email a person reads when they cannot get
+   * in, and the reply we invited would be their attempt to say so.
+   */
+  contactUrl: string;
 }
 
 /**
@@ -52,6 +61,7 @@ export const AccountActivatedEmail = ({
   codeOfConductUrl,
   membershipUrl,
   blogUrl,
+  contactUrl,
 }: AccountActivatedEmailProps) => (
   <Html lang="en" dir="ltr">
     <Head />
@@ -111,8 +121,11 @@ export const AccountActivatedEmail = ({
           how the club runs.
         </Text>
         <Text style={footer}>
-          See you on the mat. Reply to this email if anything looks off, or if you can&apos;t get
-          in.
+          See you on the mat. If anything looks off, or you can&apos;t get in,{" "}
+          <Link href={contactUrl} style={link}>
+            get in touch
+          </Link>{" "}
+          and we&apos;ll sort it out.
         </Text>
       </Container>
     </Body>

--- a/src/lib/email-templates/account-activated.tsx
+++ b/src/lib/email-templates/account-activated.tsx
@@ -78,13 +78,6 @@ export const AccountActivatedEmail = ({
         </Text>
         <Text style={h2}>What&apos;s waiting for you</Text>
         <Text style={item}>
-          <Link href={kbUrl} style={itemLink}>
-            The knowledge base
-          </Link>
-          . What happens in your first session, how our belts and grading work, and how the club
-          runs. Worth a read before you turn up.
-        </Text>
-        <Text style={item}>
           <Link href={codeOfConductUrl} style={itemLink}>
             The code of conduct
           </Link>
@@ -103,6 +96,19 @@ export const AccountActivatedEmail = ({
           </Link>
           . Club news and write-ups, and you can join the conversation in the comments once
           you&apos;re signed in.
+        </Text>
+        {/* The knowledge base gets a passing mention rather than a slot of its
+            own. It is the biggest thing in the member area and the easiest to
+            over-sell here: a new member has two jobs in this email, agreeing to
+            the code of conduct and knowing where their membership lives, and a
+            fourth heading competing with those buries both. */}
+        <Text style={item}>
+          There&apos;s also our{" "}
+          <Link href={kbUrl} style={itemLink}>
+            knowledge base
+          </Link>{" "}
+          when you want it: what happens in your first session, how our belts and grading work, and
+          how the club runs.
         </Text>
         <Text style={footer}>
           See you on the mat. Reply to this email if anything looks off, or if you can&apos;t get

--- a/src/lib/email-templates/waiver-confirmation.tsx
+++ b/src/lib/email-templates/waiver-confirmation.tsx
@@ -72,14 +72,14 @@ export const WaiverConfirmationEmail = ({
         </Text>
         {/* Told about, deliberately NOT linked. The knowledge base is signed-in
             only, and nobody reading this email can sign in yet: their account is
-            created locked and a manager approving the waiver is what sends the
-            sign-in link. A link here would land a brand-new person on a sign-in
-            screen they have no password for, which reads as the club being
-            broken on their first click. */}
+            created locked, and a manager approving the waiver is what opens it.
+            A link here would land a brand-new person on a sign-in screen they
+            have no account for, which reads as the club being broken on their
+            first click. */}
         <Text style={text}>
-          Once you&apos;re approved you&apos;ll get a link to sign in, and your member area has our
-          knowledge base in it: what happens in your first session, how our belts and grading work,
-          and how the club runs.
+          Once you&apos;re approved we&apos;ll email you to say your account is open, and your
+          member area has our knowledge base in it: what happens in your first session, how our
+          belts and grading work, and how the club runs.
         </Text>
         {codeOfConductUrl ? (
           <>
@@ -97,7 +97,7 @@ export const WaiverConfirmationEmail = ({
           <>
             <Text style={text}>
               One last thing. Tap below so we know we can reach you at this address. That&apos;s
-              where your approval and sign-in link will go.
+              where your approval will go, and it becomes your login.
             </Text>
             <Button style={button} href={verifyUrl}>
               Confirm your email address

--- a/src/lib/membership.functions.ts
+++ b/src/lib/membership.functions.ts
@@ -192,7 +192,7 @@ async function activateMembershipRow(
   // Confirmation email (best-effort — never fail activation on a send error).
   // The email lives on the auth user (the one email store); the name on the
   // profile. Suppressed via opts.sendEmail for the auto-assigned trial, whose
-  // approval already emails a sign-in link.
+  // approval already emails them that their account is active.
   if (membership.user_id && opts.sendEmail !== false) {
     try {
       const [{ data: profile }, emails] = await Promise.all([

--- a/src/lib/status-colours.ts
+++ b/src/lib/status-colours.ts
@@ -45,7 +45,7 @@ const MEMBERSHIP: Record<MembershipStatus, string> = {
 
 // Verified means someone opened a link we sent to that address. Amber rather
 // than red: an unverified address is a thing to notice before emailing someone
-// a sign-in link, not a fault.
+// their account details, not a fault.
 const VERIFICATION: Record<VerificationLabel, string> = {
   verified: "bg-green-100 text-green-800",
   unverified: "bg-amber-100 text-amber-800",

--- a/src/lib/waiver-approval.test.ts
+++ b/src/lib/waiver-approval.test.ts
@@ -40,7 +40,7 @@ describe("runApproval", () => {
 
   // The regression #70 was filed for. Before the split, this case produced
   // "Failed to update approval" even though the approval had committed: the
-  // profile was updated, the login unbanned, a sign-in link emailed and the
+  // profile was updated, the login unbanned, the activation email sent and the
   // free trial assigned. The manager's next move was to click Approve again.
   it("says the save worked when only the refresh fails", async () => {
     const outcome = await runApproval({

--- a/src/lib/waiver-approval.ts
+++ b/src/lib/waiver-approval.ts
@@ -2,8 +2,7 @@
 //
 // Approving is not a repaint: `setWaiverApproval` copies the submission onto
 // the profile, lifts the applicant's login ban, emails them that their account
-// is active and
-// assigns the free trial. The refresh that follows only decides what the screen
+// is active, and assigns the free trial. The refresh that follows only decides what the screen
 // shows. Running them in one try/catch reported a refresh that failed as an
 // approval that failed, which is the one message that makes a manager click
 // Approve again on work that already went through.

--- a/src/lib/waiver-approval.ts
+++ b/src/lib/waiver-approval.ts
@@ -1,7 +1,8 @@
 // Approving or unapproving a waiver, and what the manager is told about it.
 //
 // Approving is not a repaint: `setWaiverApproval` copies the submission onto
-// the profile, lifts the applicant's login ban, emails a sign-in link and
+// the profile, lifts the applicant's login ban, emails them that their account
+// is active and
 // assigns the free trial. The refresh that follows only decides what the screen
 // shows. Running them in one try/catch reported a refresh that failed as an
 // approval that failed, which is the one message that makes a manager click

--- a/src/lib/waiver-email.server.ts
+++ b/src/lib/waiver-email.server.ts
@@ -275,8 +275,14 @@ export interface AccountActivatedEmailParams {
  *
  * Best-effort, like every other send here: a failure is logged, never thrown.
  * The approval it follows is already committed, and losing this email must not
- * roll back a member's access. Re-approving retries it while they are still
- * locked.
+ * roll back a member's access.
+ *
+ * Note what a failure leaves behind: the ban is lifted before this is called,
+ * so someone whose email did not go out has a working account and no idea it
+ * exists. Re-approving will NOT resend (the caller only emails while they are
+ * still locked). Recovering that person means telling them out of band, and
+ * they can sign in from `/auth` with no help from us, which is precisely
+ * because this email never carried a link only we could mint.
  */
 export async function sendAccountActivatedEmail({
   waiverId,

--- a/src/lib/waiver-email.server.ts
+++ b/src/lib/waiver-email.server.ts
@@ -33,9 +33,16 @@ export const WAIVER_REVIEW_URL = `${SITE_URL}/manager/waivers`;
  *
  * Every one of these is a plain page URL with nothing single-use in it, which
  * is the point of this email: it is as valid a week from now as it is on
- * arrival. `/kb` and `/membership` bounce a signed-out visitor to the sign-in
- * page and carry them back afterwards, so they are safe to link even though
- * the reader cannot be signed in yet.
+ * arrival.
+ *
+ * `/kb` and `/membership` need a session, and a signed-out reader clicking
+ * either is bounced to `/auth`. They do NOT come back to the page they
+ * clicked: the sign-in page passes its `redirect` to the password form only,
+ * while the magic-link form (the sole route in for someone who has never set a
+ * password, which is everyone reading this) hardcodes `/account`. So these
+ * links are safe but blunt, landing a new member on their account page with
+ * the knowledge base and membership one click away. Worth linking anyway: the
+ * alternative is naming pages and making them go looking.
  */
 const ACTIVATION_LINKS = {
   signInUrl: `${SITE_URL}/auth`,
@@ -43,6 +50,7 @@ const ACTIVATION_LINKS = {
   codeOfConductUrl: `${SITE_URL}/code-of-conduct`,
   membershipUrl: `${SITE_URL}/membership`,
   blogUrl: `${SITE_URL}/blog`,
+  contactUrl: `${SITE_URL}/contact`,
 } as const;
 
 type AdminClient = SupabaseClient<Database>;

--- a/src/lib/waiver-email.server.ts
+++ b/src/lib/waiver-email.server.ts
@@ -1,4 +1,6 @@
-// Server-only helper for the transactional emails sent when a waiver is signed.
+// Server-only helper for the transactional emails sent as a waiver moves
+// through its life: signed (confirmation + manager prompt), then approved
+// (the account-activated email that hands the member their access).
 //
 // This module pulls in server-only dependencies (the Lovable send API, the
 // React-email renderer, the service-role admin client's types) so it must never
@@ -10,6 +12,7 @@ import { sendLovableEmail } from "@lovable.dev/email-js";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/integrations/supabase/types";
 import { buildCodeOfConductUrl } from "@/lib/code-of-conduct";
+import { AccountActivatedEmail } from "@/lib/email-templates/account-activated";
 import { WaiverConfirmationEmail } from "@/lib/email-templates/waiver-confirmation";
 import { WaiverNotificationEmail } from "@/lib/email-templates/waiver-notification";
 
@@ -24,6 +27,23 @@ const FROM = `${SITE_NAME} <noreply@${FROM_DOMAIN}>`;
 
 /** Manager dashboard where waivers are reviewed and approved. */
 export const WAIVER_REVIEW_URL = `${SITE_URL}/manager/waivers`;
+
+/**
+ * Where a newly activated member goes to get in for the first time.
+ *
+ * Every one of these is a plain page URL with nothing single-use in it, which
+ * is the point of this email: it is as valid a week from now as it is on
+ * arrival. `/kb` and `/membership` bounce a signed-out visitor to the sign-in
+ * page and carry them back afterwards, so they are safe to link even though
+ * the reader cannot be signed in yet.
+ */
+const ACTIVATION_LINKS = {
+  signInUrl: `${SITE_URL}/auth`,
+  kbUrl: `${SITE_URL}/kb`,
+  codeOfConductUrl: `${SITE_URL}/code-of-conduct`,
+  membershipUrl: `${SITE_URL}/membership`,
+  blogUrl: `${SITE_URL}/blog`,
+} as const;
 
 type AdminClient = SupabaseClient<Database>;
 
@@ -231,4 +251,65 @@ export async function sendWaiverEmails({
   }
 
   return { sent, skipped: false };
+}
+
+export interface AccountActivatedEmailParams {
+  /** The approved waiver, used to key idempotency so a retry cannot double-send. */
+  waiverId: string;
+  /** What to call them to their face: preferred name, else first name. */
+  memberGreetingName: string;
+  /** The address their login is keyed on, taken from the auth user. */
+  memberEmail: string;
+}
+
+/**
+ * Tell someone their account is open, now that a manager has approved their
+ * first waiver and their login has been unlocked.
+ *
+ * Sent in place of the magic link this step used to fire off. The link was
+ * unrequested (odd to receive) and single-use with an hour on it (broken by
+ * the time most people read their email), and it left the club with no way to
+ * say anything else at the one moment a new member is paying attention. This
+ * says the account is open, names the address to sign in with, and points at
+ * the rest of the member area.
+ *
+ * Best-effort, like every other send here: a failure is logged, never thrown.
+ * The approval it follows is already committed, and losing this email must not
+ * roll back a member's access. Re-approving retries it while they are still
+ * locked.
+ */
+export async function sendAccountActivatedEmail({
+  waiverId,
+  memberGreetingName,
+  memberEmail,
+}: AccountActivatedEmailParams): Promise<{ sent: boolean; skipped: boolean }> {
+  const apiKey = process.env.LOVABLE_API_KEY;
+  if (!apiKey) {
+    console.warn("[waiver-email] LOVABLE_API_KEY not set — skipping account activated email");
+    return { sent: false, skipped: true };
+  }
+
+  const el = React.createElement(AccountActivatedEmail, {
+    siteName: SITE_NAME,
+    siteUrl: SITE_URL,
+    memberName: memberGreetingName,
+    loginEmail: memberEmail,
+    ...ACTIVATION_LINKS,
+  });
+
+  try {
+    await sendOne({
+      apiKey,
+      sendUrl: process.env.LOVABLE_SEND_URL,
+      to: memberEmail,
+      subject: `Your ${SITE_NAME} account is active`,
+      html: await render(el),
+      text: await render(el, { plainText: true }),
+      idempotencyKey: `account-activated-${waiverId}`,
+    });
+    return { sent: true, skipped: false };
+  } catch (e) {
+    console.error(`[waiver-email] failed to email activated member ${memberEmail}:`, e);
+    return { sent: false, skipped: false };
+  }
 }

--- a/src/lib/waiver.functions.ts
+++ b/src/lib/waiver.functions.ts
@@ -1648,8 +1648,12 @@ export const setWaiverApproval = createServerFn({ method: "POST" })
       // Provision access on FIRST approval: an applicant's auth user is banned
       // (no login). Lift the ban and tell them their account is open. Skipped
       // for people who can already log in, so re-approvals don't spam them.
-      // Best-effort — a hiccup must not undo the approval; re-approving
-      // retries it (the user is still banned).
+      // Best-effort — a hiccup must not undo the approval. A failed UNBAN is
+      // retried by re-approving (they are still locked, so this block runs
+      // again); a failed SEND is not, since the unban above already went
+      // through. That person has an account and has not been told, and the
+      // fix is a word out of band: nothing in the email was single-use, so
+      // they can sign in at /auth whenever they hear.
       //
       // The email deliberately carries no sign-in link: it names the address
       // their login is keyed on and sends them to /auth to ask for a link

--- a/src/lib/waiver.functions.ts
+++ b/src/lib/waiver.functions.ts
@@ -1133,7 +1133,7 @@ export const listWaivers = createServerFn({ method: "GET" })
 //
 // What it deliberately does NOT do:
 //   - approve anything. Approval promotes the details onto the profile, unlocks
-//     the login, emails a sign-in link and assigns the trial (docs/waivers.md
+//     the login, emails the account-activated notice and assigns the trial (docs/waivers.md
 //     rule 6). Those are the same consequences whatever the waiver arrived on,
 //     so a manager takes that step by hand, from the same button as always.
 //   - email anybody. Nobody just pressed submit: the signer is not sitting at a
@@ -1557,7 +1557,7 @@ export const uploadPaperWaiver = createServerFn({ method: "POST" })
 // Approval is the promotion step: the approved submission's details are copied
 // onto the person's profile (the club's current record), and if they are still
 // a locked applicant (banned auth user, no credentials) the ban is lifted and
-// they're emailed a sign-in link to set up access (applicant -> visitor).
+// they're emailed to say their account is active (applicant -> visitor).
 // Unapprove only reverts the waiver's status; the profile and login are left
 // as they are.
 export const setWaiverApproval = createServerFn({ method: "POST" })
@@ -1646,10 +1646,16 @@ export const setWaiverApproval = createServerFn({ method: "POST" })
       if (pErr) throw new Error(pErr.message);
 
       // Provision access on FIRST approval: an applicant's auth user is banned
-      // (no login). Lift the ban and email a sign-in link. Skipped for people
-      // who can already log in, so re-approvals don't spam sign-in emails.
+      // (no login). Lift the ban and tell them their account is open. Skipped
+      // for people who can already log in, so re-approvals don't spam them.
       // Best-effort — a hiccup must not undo the approval; re-approving
       // retries it (the user is still banned).
+      //
+      // The email deliberately carries no sign-in link: it names the address
+      // their login is keyed on and sends them to /auth to ask for a link
+      // themselves. A magic link nobody requested expires in an hour, so it is
+      // usually dead by the time it is read, and this email needs to stay good
+      // for as long as it takes a new member to get round to it.
       try {
         const { data: got, error: getErr } = await admin.auth.admin.getUserById(waiver.user_id);
         if (getErr) throw getErr;
@@ -1663,15 +1669,12 @@ export const setWaiverApproval = createServerFn({ method: "POST" })
           // The canonical email lives on the auth user.
           const authEmail = got.user?.email;
           if (authEmail) {
-            const { getRequestHeader } = await import("@tanstack/react-start/server");
-            const origin = getRequestHeader("origin") || "https://jitsu.au";
-            // Magic-link sign-in email (rendered by the Lovable auth-email
-            // webhook). The user always exists here, so never auto-create.
-            const { error: otpErr } = await serverSupabase().auth.signInWithOtp({
-              email: authEmail,
-              options: { emailRedirectTo: `${origin}/account`, shouldCreateUser: false },
+            const { sendAccountActivatedEmail } = await import("./waiver-email.server");
+            await sendAccountActivatedEmail({
+              waiverId: waiver.id,
+              memberGreetingName: greetingName(waiver),
+              memberEmail: authEmail,
             });
-            if (otpErr) throw otpErr;
           }
         }
       } catch (e) {

--- a/src/routes/_authenticated/account.tsx
+++ b/src/routes/_authenticated/account.tsx
@@ -53,7 +53,8 @@ export const Route = createFileRoute("/_authenticated/account")({
  *
  * `email_confirmed_at` is already on the session user, so this needs no server
  * round trip to render. Most people reading this page arrived by clicking a
- * sign-in link, which is itself the proof, so for them it is just reassurance.
+ * sign-in link they requested, which is itself the proof, so for them it is
+ * just reassurance.
  */
 function EmailVerificationNote({
   email,

--- a/src/routes/_authenticated/manager.users_.$userId.tsx
+++ b/src/routes/_authenticated/manager.users_.$userId.tsx
@@ -249,7 +249,7 @@ function EmailCard({
       <p className="mb-3 text-sm text-muted-foreground">
         {verified
           ? `Confirmed on ${formatDate(emailConfirmedAt)}, when they opened a link we sent here.`
-          : "Nobody has opened a link we sent to this address yet. Approving a waiver emails a sign-in link here, so a typo means it goes nowhere."}
+          : "Nobody has opened a link we sent to this address yet. Approving a waiver emails their account details here, and it is the address they sign in with, so a typo locks them out."}
       </p>
 
       {editing ? (


### PR DESCRIPTION
## What changes for members

When a manager approves someone's **first** waiver, they used to get an email titled "Your login link" containing a magic link nobody had asked for. Two problems: it reads as odd on arrival, and the link is single-use with an hour on it, so for anyone who does not check email straight away it is already dead by the time they click it.

They now get an **account-activated** email instead:

- Says the waiver was approved and the account is open, so they are cleared to train.
- Names the address their login is keyed on (they have no username, and no password yet, so this is the one thing they need to know).
- A single **Sign in** button to `/auth`, where they ask for a login link themselves or set a password.
- Then walks them into the member area: the knowledge base, the code of conduct, their membership and invoices, and the blog.

Every URL in the email is a plain page with nothing single-use in it, so the email still works whenever they get round to reading it. The trade is one extra step before they are in: they request their own link rather than clicking one that was waiting.

## What is unchanged

- The ban lift on first approval. The only difference is what gets emailed afterwards.
- The **first approval only** guard. Approving a waiver for someone who can already log in still emails nothing, so re-approving or filing a paper waiver for an existing member is silent, as before.
- The self-requested magic link at `/auth`. That email is untouched, and it is now what stamps email confirmation on first sign-in, one step later than before and just as reliably.

## Screens and copy also updated

- **Waiver confirmation email**: "Once you're approved you'll get a link to sign in" is no longer true, now "we'll email you to say your account is open".
- **Manager's member detail page**: the note under an unverified address said approval emails a sign-in link there. It now says approval emails their account details there, and that the address is the one they sign in with, so a typo locks them out.

## Checks

`bun run lint`, `bun run typecheck`, `bun run test` (1454 passing) and `bun run build` all green. New tests cover the copy, the member-area links, the empty-name greeting, the house no-em-dash rule, and an assertion that no single-use token can creep back into the email. Docs (`waivers.md`, `database.md`, `knowledge-base.md`), `CLAUDE.md`, `AGENTS.md` and the manager-agent skill are updated to describe the new behaviour.

No database changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoDgGA8tYDjRtATftgx6Cd)_