### PR TITLE
Date the free trial from the waiver's signing day, not its approval

### DIFF
--- a/docs/check-in.md
+++ b/docs/check-in.md
@@ -44,6 +44,12 @@ In order, highest first:
 - **Yearly insurance never covers a class.** It buys affiliation and cover, not
   mat time.
 - A **pending** membership never covers anything: the money has not landed.
+- A membership that **had not begun** when the class ran covers nothing either.
+  For the free trial this is the "no waiver, no mat time" rule: the trial starts
+  at the beginning of the day its waiver was **signed**, never the day a manager
+  approved it. Someone can sign at the door minutes after a class starts and
+  still be covered for it, but a class held the day _before_ they signed is not
+  covered, however quickly the approval follows.
 
 Between two memberships in the same tier, the one that **runs out soonest** is
 used, so nothing expires unspent.
@@ -102,8 +108,15 @@ people in to a class that did not run.
 5. **Never refuse someone at the door.** No cover is a flag, not a rejection.
 6. **Coverage is resolved against the class's start time**, not the current time,
    so a manager checking people in ten minutes late (or fixing yesterday's roster
-   this morning) gets the same answer they would have got at the door.
-7. **Sessions attended is not credits used.** It counts classes trained,
+   this morning) gets the same answer they would have got at the door. This is
+   why memberships that begin on a day are dated to the **start** of that day:
+   measured to the minute, a trial signed at 18:05 would miss the 18:00 class it
+   was signed for, purely because of the order the paperwork happened in.
+7. **No cover always says why.** "Nothing covers this class" is a dead end;
+   "a membership starts after this class" or "waiting on a payment" is something
+   a manager can act on. Every reason coverage resolution knows is surfaced on
+   the roster and in the attach list, rather than logged and swallowed.
+8. **Sessions attended is not credits used.** It counts classes trained,
    including uncovered ones. How many credits a membership has left is a separate
    number and lives on the membership.
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -255,6 +255,9 @@ inside the waiver PDF), and no `full_name`.
   person fields onto the profile (`waiverToProfileFields`); on first approval
   lifts the ban, sends a sign-in email, and assigns the free trial
   (`assignTrialMembership`, one per person ever, activation email suppressed).
+  That trial's `starts_at` is the start of the club day the waiver was **signed**
+  (`signed_at`), not the approval instant, so approving late does not uncover the
+  class it was signed for (`docs/check-in.md`).
   `media_consent` is the one field the patch can OMIT rather than set: a
   submission carrying NULL was signed on a template that never asked, and must
   not erase a consent the club already holds. When it does carry one, and that

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -29,6 +29,15 @@ approved a waiver and the club's free trial was assigned automatically.
 | `2026-s2`, …       | `period`    | Training period            | fixed dates (`starts_on`/`ends_on`) | Unlimited classes for that training period.       |
 | `insurance_yearly` | `insurance` | Yearly insurance           | rolling (`duration_days`)           | Club affiliation & insurance, 12 months from pay. |
 
+A plan that ends with its credits rather than on a date still has to start
+somewhere, and it starts at **00:00 Australia/Sydney on the day it was granted**
+rather than at the instant it was granted. Check-in resolves cover against the
+class's own start time (`docs/check-in.md`), so the finer grain would mean a
+trial handed out at 18:05 could not pay for the 18:00 class it was handed out
+for. The auto-assigned trial goes one step further and dates itself from the day
+its **waiver was signed**, not the day a manager approved it: signing has to
+happen before someone trains, approving does not.
+
 The kind is the **only** control over how a plan runs: picking one on
 `/manager/membership-plans` shows just that kind's fields and clears the
 others, so a plan can never carry both a date range and a rolling duration

--- a/docs/waivers.md
+++ b/docs/waivers.md
@@ -93,6 +93,12 @@ system. (The contact form stores a message, not a person.)
    got the sign-in one). Approving a newer waiver later refreshes the profile
    again (no repeat sign-in email, no second trial). Unapprove only reverts
    the waiver's status; profile, login and trial stay as they are.
+   **The trial is dated from the day the waiver was SIGNED, not the day it was
+   approved.** Signing has to happen before anyone steps on the mat, but a form
+   filled in at the gym may not be approved until hours or days later; dating
+   the trial from the approval would leave the very class it was signed for
+   uncovered at check-in. A manager can therefore take as long as they like
+   over approval without costing anyone a free session.
 7. **Full name is never stored**; it is composed from first/middle/last. The
    optional **preferred name** is stored separately (on the submission and, once
    approved, on the profile). One rule governs it everywhere: **address a person

--- a/src/lib/checkin.test.ts
+++ b/src/lib/checkin.test.ts
@@ -118,9 +118,42 @@ describe("resolveCoverage", () => {
     expect(d.warnings).toContain("credits_exhausted");
   });
 
-  it("does not cover with a membership that has not started yet", () => {
+  it("does not cover with a membership that has not started yet, and says so", () => {
     const future = membership({ starts_at: "2026-09-01T00:00:00.000Z" });
-    expect(resolveCoverage({ memberships: [future], at: AT }).coverage).toBe("none");
+    const d = resolveCoverage({ memberships: [future], at: AT });
+    expect(d.coverage).toBe("none");
+    expect(d.warnings).toContain("not_started");
+  });
+
+  // The trial runs from the START OF THE DAY its waiver was signed, not from the
+  // instant a manager approved it (assignTrialMembership -> planMembershipWindow).
+  // A waiver has to be signed before anyone trains, but it is often signed at the
+  // gym and approved later, so the raw approval instant lands after the very
+  // class it was signed for. Exercises the real activation dates rather than
+  // hand-picked ISO strings.
+  it("covers the class its waiver was signed for, whenever it was approved", () => {
+    const signedAtTheDoor = "2026-08-05T08:05:00.000Z"; // 18:05 Sydney, class started 18:00
+    const window = planMembershipWindow(
+      { starts_on: null, ends_on: null, duration_days: null },
+      signedAtTheDoor,
+    );
+    const d = resolveCoverage({ memberships: [trial({ ...window })], at: AT });
+    expect(d.coverage).toBe("trial");
+    expect(d.sessions_remaining_after).toBe(1);
+    expect(d.warnings).not.toContain("not_started");
+  });
+
+  // The other half of that rule: no waiver, no mat time. Signing the day AFTER a
+  // class cannot pay for it, however generous the day-grain start is.
+  it("does not cover a class held before its waiver was signed", () => {
+    const signedTheNextDay = "2026-08-06T12:13:20.000Z";
+    const window = planMembershipWindow(
+      { starts_on: null, ends_on: null, duration_days: null },
+      signedTheNextDay,
+    );
+    const d = resolveCoverage({ memberships: [trial({ ...window })], at: AT });
+    expect(d.coverage).toBe("none");
+    expect(d.warnings).toContain("not_started");
   });
 
   // Exercises the actual dates activateMembershipRow writes for a dated plan
@@ -255,6 +288,14 @@ describe("attachableMemberships", () => {
     expect(by("spent")).toMatchObject({ usable: false, reason: "no credits left" });
     expect(by("cancelled")).toMatchObject({ usable: false, reason: "cancelled" });
     expect(by("old")).toMatchObject({ usable: false, reason: "not valid for this class" });
+  });
+
+  it("says when a membership starts after the class rather than just refusing it", () => {
+    const rows = attachableMemberships(
+      [membership({ id: "later", starts_at: "2026-09-01T00:00:00.000Z" })],
+      AT,
+    );
+    expect(rows[0]).toMatchObject({ usable: false, reason: "starts after this class" });
   });
 
   it("never claims a membership is usable when attaching it would cover nothing", () => {

--- a/src/lib/checkin.test.ts
+++ b/src/lib/checkin.test.ts
@@ -143,6 +143,21 @@ describe("resolveCoverage", () => {
     expect(d.warnings).not.toContain("not_started");
   });
 
+  // Pre-buying the next training period is normal (`sellablePlans` offers a plan
+  // before its start date), so holding a membership that begins later is not by
+  // itself worth saying. Warned about beside a green pill it is noise, and it
+  // would be frozen into `session_checkins.warnings` for good.
+  it("does not warn about a later membership when something already covers the class", () => {
+    const nextPeriod = semester({
+      id: "next",
+      starts_at: "2026-09-01T00:00:00.000Z",
+      ends_at: "2026-12-14T00:00:00.000Z",
+    });
+    const d = resolveCoverage({ memberships: [nextPeriod, trial()], at: AT });
+    expect(d.coverage).toBe("trial");
+    expect(d.warnings).not.toContain("not_started");
+  });
+
   // The other half of that rule: no waiver, no mat time. Signing the day AFTER a
   // class cannot pay for it, however generous the day-grain start is.
   it("does not cover a class held before its waiver was signed", () => {

--- a/src/lib/checkin.ts
+++ b/src/lib/checkin.ts
@@ -149,7 +149,6 @@ export function resolveCoverage(input: {
     warnings.push("credits_exhausted");
   if (input.memberships.some((m) => m.status === "pending" && m.price_cents > 0))
     warnings.push("payment_pending");
-  if (input.memberships.some((m) => startsAfter(m, atMs))) warnings.push("not_started");
 
   const tiers: { source: CoverageSource; pool: CoverageCandidate[] }[] = [
     { source: "trial", pool: live.filter((m) => m.kind === "trial" && hasCredits(m)) },
@@ -195,6 +194,12 @@ export function resolveCoverage(input: {
     };
   }
 
+  // Purely a DIAGNOSIS of "no cover", which is why it is pushed here and not up
+  // with the others: holding a membership that starts later is perfectly normal
+  // (pre-buying next training period does exactly that), so saying so beside a
+  // green covered pill — and freezing it into `session_checkins.warnings` — would
+  // be noise. It only ever earns its place when nothing paid for the class.
+  if (input.memberships.some((m) => startsAfter(m, atMs))) warnings.push("not_started");
   warnings.push("no_cover");
   return {
     membership_id: null,

--- a/src/lib/checkin.ts
+++ b/src/lib/checkin.ts
@@ -53,6 +53,24 @@ function endsAtMs(m: CoverageCandidate): number | null {
 }
 
 /**
+ * Active, but the class ran before this membership began. Kept as its own
+ * predicate because it is also a DIAGNOSIS: a manager staring at "No cover"
+ * needs to be told the membership starts later, not left to work it out.
+ *
+ * For the free trial this is what enforces "no waiver, no mat time" — the trial
+ * begins on the day its waiver was SIGNED (`assignTrialMembership`), so a class
+ * held before the person signed anything is correctly uncovered, however long
+ * the manager took to approve it afterwards.
+ */
+function startsAfter(m: CoverageCandidate, atMs: number): boolean {
+  return (
+    m.status === "active" &&
+    Boolean(m.starts_at) &&
+    new Date(m.starts_at as string).getTime() > atMs
+  );
+}
+
+/**
  * Is this membership live at instant `atMs`? Active status is not enough: there
  * is no expiry job anywhere in this app, so a semester that finished in June
  * still reads `status = 'active'` today. Trusting the status alone would keep
@@ -60,7 +78,7 @@ function endsAtMs(m: CoverageCandidate): number | null {
  */
 function isLive(m: CoverageCandidate, atMs: number): boolean {
   if (m.status !== "active") return false;
-  if (m.starts_at && new Date(m.starts_at).getTime() > atMs) return false;
+  if (startsAfter(m, atMs)) return false;
   const ends = endsAtMs(m);
   return ends === null || ends >= atMs;
 }
@@ -131,6 +149,7 @@ export function resolveCoverage(input: {
     warnings.push("credits_exhausted");
   if (input.memberships.some((m) => m.status === "pending" && m.price_cents > 0))
     warnings.push("payment_pending");
+  if (input.memberships.some((m) => startsAfter(m, atMs))) warnings.push("not_started");
 
   const tiers: { source: CoverageSource; pool: CoverageCandidate[] }[] = [
     { source: "trial", pool: live.filter((m) => m.kind === "trial" && hasCredits(m)) },
@@ -230,6 +249,7 @@ export function coveragePreviewLabel(input: {
  * when attaching it would resolve to nothing.
  */
 export function attachableMemberships(candidates: CoverageCandidate[], at: string) {
+  const atMs = new Date(at).getTime();
   return candidates.map((m) => {
     const decision = resolveCoverage({ memberships: candidates, at, only: m.id });
     return {
@@ -245,7 +265,9 @@ export function attachableMemberships(candidates: CoverageCandidate[], at: strin
             ? m.status
             : m.sessions_remaining === 0
               ? "no credits left"
-              : "not valid for this class",
+              : startsAfter(m, atMs)
+                ? "starts after this class"
+                : "not valid for this class",
     };
   });
 }

--- a/src/lib/membership.functions.test.ts
+++ b/src/lib/membership.functions.test.ts
@@ -85,10 +85,13 @@ vi.mock("@/integrations/supabase/client.server", () => ({
   },
 }));
 
-async function assignTrial(fake: ReturnType<typeof fakeAdmin>) {
+/** 18:05 Sydney on 5 Aug: signed at the door, minutes after the class began. */
+const SIGNED_AT = "2026-08-05T08:05:00.000Z";
+
+async function assignTrial(fake: ReturnType<typeof fakeAdmin>, signedAt = SIGNED_AT) {
   currentAdmin = fake.admin;
   const { assignTrialMembership } = await import("./membership.functions");
-  return assignTrialMembership("user-1");
+  return assignTrialMembership("user-1", signedAt);
 }
 
 describe("assignTrialMembership", () => {
@@ -105,6 +108,20 @@ describe("assignTrialMembership", () => {
     expect(fake.inserts).toHaveLength(1);
     expect(fake.inserts[0]).toMatchObject({ user_id: "user-1", plan_id: TRIAL_PLAN.id });
     expect(fake.updates[0]).toMatchObject({ status: "active" });
+  });
+
+  // A waiver must be signed before anyone trains, but it is often signed at the
+  // gym and approved hours or days later. Dating the trial from the approval
+  // would leave the very class it was signed for uncovered, so it runs from the
+  // start of the SIGNING day (00:00 Sydney on 5 Aug = 4 Aug 14:00 UTC).
+  it("runs the trial from the day the waiver was signed, not the day it was approved", async () => {
+    const fake = fakeAdmin({});
+    await assignTrial(fake);
+    expect(fake.updates[0]).toMatchObject({
+      status: "active",
+      starts_at: "2026-08-04T14:00:00.000Z",
+      ends_at: null,
+    });
   });
 
   it("skips someone who has already had a trial", async () => {

--- a/src/lib/membership.functions.ts
+++ b/src/lib/membership.functions.ts
@@ -144,16 +144,27 @@ async function activateMembershipRow(
   admin: MembershipClient,
   membership: MembershipRow,
   plan: MembershipPlanRow,
-  opts: { paymentMethod: MembershipRow["payment_method"]; sendEmail?: boolean },
+  opts: {
+    paymentMethod: MembershipRow["payment_method"];
+    sendEmail?: boolean;
+    /**
+     * The instant the membership should be treated as beginning from, when that
+     * is not "right now". Only the auto-assigned trial passes one: it runs from
+     * the day its waiver was SIGNED, not the day a manager got round to
+     * approving it. `paid_at` still records the real clock.
+     */
+    effectiveFrom?: string;
+  },
 ): Promise<void> {
   const nowIso = new Date().toISOString();
+  const fromIso = opts.effectiveFrom ?? nowIso;
 
   // The plan resolves its own dates — a dated plan runs exactly the window it
   // was set up with, a rolling plan (yearly insurance) runs from this instant,
   // and trial/casual plans end with their credits, not a date. No branch on
   // `plan.kind` here: `planMembershipWindow` reads `starts_on`/`ends_on`/
   // `duration_days` directly, so a brand-new plan shape needs no new code path.
-  const { starts_at: startsAt, ends_at: endsAt } = planMembershipWindow(plan, nowIso);
+  const { starts_at: startsAt, ends_at: endsAt } = planMembershipWindow(plan, fromIso);
 
   const patch: Partial<MembershipRow> = {
     status: "active",
@@ -227,8 +238,15 @@ async function activateMembershipRow(
  * silently if they ever had a trial membership or no trial plan exists. The
  * activation email is suppressed — the approval already sends their sign-in
  * link. Not a server function: a server-side helper for the approval flow.
+ *
+ * `signedAt` is the waiver's own signing time, and the trial runs from the start
+ * of that day (`planMembershipWindow`) rather than from this instant. The rule
+ * it encodes: a waiver must be signed BEFORE someone steps on the mat, but a
+ * manager may not approve it until hours or days later — often it is signed at
+ * the gym, at the door. Dating the trial from the approval would leave the class
+ * they signed for uncovered, which is the wrong end of the process to measure.
  */
-export async function assignTrialMembership(userId: string): Promise<void> {
+export async function assignTrialMembership(userId: string, signedAt: string): Promise<void> {
   const admin = await adminClient();
 
   // Every read throws rather than returning early: "the query failed" and "this
@@ -281,7 +299,11 @@ export async function assignTrialMembership(userId: string): Promise<void> {
     .select("*")
     .single();
   if (error || !inserted) throw new Error(error?.message || "Could not create trial membership.");
-  await activateMembershipRow(admin, inserted, plan, { paymentMethod: "manual", sendEmail: false });
+  await activateMembershipRow(admin, inserted, plan, {
+    paymentMethod: "manual",
+    sendEmail: false,
+    effectiveFrom: signedAt,
+  });
 }
 
 // ---- Member: list active plans ----

--- a/src/lib/membership.test.ts
+++ b/src/lib/membership.test.ts
@@ -443,9 +443,15 @@ describe("planMembershipWindow", () => {
     expect(w.ends_at).toBe("2027-05-01T00:00:00.000Z");
   });
 
-  it("has no expiry at all with neither dates nor a duration", () => {
+  // Undated plans (the free trial, casual classes) run from the START OF THE
+  // CLUB DAY, not from the instant they were granted. Coverage is resolved
+  // against the class's start time, so a credit granted at 18:05 that kept the
+  // raw instant would not pay for the 18:00 class it was granted for -- which is
+  // exactly the trial-at-the-door case. NOW is 10:00 Sydney on 1 May, so the
+  // day's midnight is the previous afternoon in UTC.
+  it("runs an undated plan from the start of the club day, with no expiry", () => {
     const w = planMembershipWindow({ starts_on: null, ends_on: null, duration_days: null }, NOW);
-    expect(w.starts_at).toBe(NOW);
+    expect(w.starts_at).toBe("2026-04-30T14:00:00.000Z");
     expect(w.ends_at).toBeNull();
   });
 });

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1751,6 +1751,7 @@ describe("check-in schemas", () => {
       "membership_ended",
       "credits_exhausted",
       "payment_pending",
+      "not_started",
       "coverage_race",
     ]);
   });

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1053,8 +1053,14 @@ function addCalendarDays(dateStr: string, days: number): string {
  *     join — there is no pro rata.
  *   - a rolling plan (`duration_days` set): `now` through `now + duration_days`
  *     (this is how yearly insurance has always worked).
- *   - neither: `ends_at` is null — the plan ends with its session credits
- *     instead of a date (the free trial, casual classes).
+ *   - neither: 00:00 Australia/Sydney on the day of `now`, and `ends_at` is
+ *     null — the plan ends with its session credits instead of a date (the free
+ *     trial, casual classes). Snapped to the start of the day for the same
+ *     reason the dated branch is: coverage is resolved against the CLASS's start
+ *     instant, so a credit granted at 18:05 that kept the raw instant would not
+ *     pay for the 18:00 class it was granted for. A whole-day grain is the
+ *     coarsest thing that cannot be beaten by the clock, and credits — not
+ *     dates — are what limit these plans anyway.
  * A plan never has both set (a DB CHECK enforces it), so these are exhaustive.
  */
 export function planMembershipWindow(
@@ -1077,7 +1083,12 @@ export function planMembershipWindow(
     ).toISOString();
     return { starts_at: now, ends_at };
   }
-  return { starts_at: now, ends_at: null };
+  const startOfDay = zonedWallTimeToUtc(
+    clubLocalDate(new Date(now), CLUB_TIME_ZONE),
+    "00:00",
+    CLUB_TIME_ZONE,
+  ).toISOString();
+  return { starts_at: startOfDay, ends_at: null };
 }
 
 /**
@@ -1796,6 +1807,8 @@ export const checkInWarnings = [
   "credits_exhausted",
   /** A membership is waiting on payment: the money has not landed yet. */
   "payment_pending",
+  /** They hold a membership that had not begun when this class ran. */
+  "not_started",
   /** A concurrent check-in took the credit first; this one needs attaching. */
   "coverage_race",
 ] as const;

--- a/src/lib/waiver.functions.ts
+++ b/src/lib/waiver.functions.ts
@@ -1681,9 +1681,14 @@ export const setWaiverApproval = createServerFn({ method: "POST" })
       // Approved = visitor = trial assigned: give them the free trial on
       // first approval (one per person, ever; skipped for later approvals).
       // Best-effort like provisioning — re-approving retries it.
+      //
+      // Dated from the waiver's OWN signing time, not from this approval. The
+      // waiver has to be signed before anyone trains, but it is often signed at
+      // the gym and approved hours or days later; running the trial from the
+      // approval would leave the very class it was signed for uncovered.
       try {
         const { assignTrialMembership } = await import("./membership.functions");
-        await assignTrialMembership(waiver.user_id);
+        await assignTrialMembership(waiver.user_id, waiver.signed_at);
       } catch (e) {
         console.error("[setWaiverApproval] trial assignment failed:", e);
       }

--- a/src/routes/_authenticated/manager.check-in.tsx
+++ b/src/routes/_authenticated/manager.check-in.tsx
@@ -408,6 +408,14 @@ function CheckInPage() {
                       className={coverageClass(r.coverage)}
                       preserveCase
                     />
+                    {/* Only when nothing pays for it: "No cover" on its own is a
+                        dead end, and this is the row a manager is looking at
+                        while the person stands in front of them. */}
+                    {r.coverage === "none" && (
+                      <div className="mt-1">
+                        <Warnings codes={r.warnings} />
+                      </div>
+                    )}
                   </td>
                   <td className="px-3 py-2 text-right">
                     <Button

--- a/src/routes/_authenticated/manager.check-in.tsx
+++ b/src/routes/_authenticated/manager.check-in.tsx
@@ -45,6 +45,7 @@ const WARNING_TEXT: Record<string, string> = {
   credits_exhausted: "a membership has no sessions left",
   payment_pending: "waiting on a payment",
   coverage_race: "another check-in took the session first",
+  not_started: "a membership starts after this class",
 };
 
 const selectClass =
@@ -69,11 +70,14 @@ function fmtTime(iso: string): string {
   });
 }
 
+// `no_cover` is dropped when something more specific explains it, since the row
+// already carries a red "No cover" pill. When it is all we have, say it anyway:
+// a bare dash under "No cover" is what makes an uncovered check-in impossible to
+// diagnose from this screen.
 function Warnings({ codes }: { codes: string[] }) {
-  const text = codes
-    .filter((c) => c !== "no_cover")
-    .map((c) => WARNING_TEXT[c] ?? c)
-    .join("; ");
+  const explained = codes.filter((c) => c !== "no_cover");
+  const shown = explained.length ? explained : codes;
+  const text = shown.map((c) => WARNING_TEXT[c] ?? c).join("; ");
   if (!text) return <span className="text-muted-foreground">—</span>;
   return <span className="text-xs text-muted-foreground">{text}</span>;
 }


### PR DESCRIPTION
## What prompted this

A manager approved a waiver, the users page showed the free trial as active, and the check-in screen still said **No cover** with a bare dash where the explanation should be.

The trial was being assigned correctly. The problem was *when* it started.

## What was wrong

The trial's clock started at the exact instant a manager pressed Approve. Check-in judges cover against the **class's** start time, so the trial never paid for the class it was signed for.

That is the club's normal shape: the waiver has to be signed before anyone steps on the mat, but it is often filled in at the gym and approved hours or days later. Approving on Thursday morning left Wednesday night's class uncovered. There was also a same-day version of it: signing at the door at 18:05 missed the 18:00 class by five minutes.

## What changes for managers

On `/manager/check-in`:

- A newly approved person's free trial covers the class they signed up for, whatever time you got round to approving the waiver. You can take as long as you like over approvals without costing anyone a free session.
- Signing at the door still counts for the class that has already started.
- A class held **before** the waiver was signed is still uncovered. That is the "no waiver, no mat time" rule, and it is deliberate.
- When something genuinely isn't covered, the screen now says why: a membership that starts after the class, credits used up, waiting on a payment, membership finished. Previously an uncovered check-in showed a red pill and a dash, which was impossible to diagnose from the screen.

Members see nothing new. No emails change.

## What changed in the code

- `assignTrialMembership` takes the waiver's `signed_at` and activates the trial from it, via a new `effectiveFrom` option on `activateMembershipRow`. `paid_at` still records the real clock.
- `planMembershipWindow` starts an undated plan (trial, casual) at 00:00 Australia/Sydney on its day rather than at the raw instant, matching what the dated branch already does.
- New `not_started` warning code, a "starts after this class" reason in the attach list, and the roster no longer collapses a lone `no_cover` into a dash.
- Docs updated in the same change: `docs/check-in.md`, `docs/memberships.md`, `docs/waivers.md`, `docs/database.md`.

**No migration.** `session_checkins.warnings` is a `TEXT[]` with no CHECK constraint, so the new code needs no schema change. Existing trial rows keep their current `starts_at`; there is no backfill.

## Tests

Three existing tests changed on purpose, each pinning behaviour this PR redefines:

- `planMembershipWindow`'s undated case — now the club day's start rather than `now`.
- The `checkInWarnings` list — new code added.
- The "has not started yet" coverage case — now also asserts the warning it emits.

New cases cover signing at the door after a class has begun, and signing the day after a class. Both would have failed before this change.

`bun run lint`, `bun run typecheck`, `bun run test` (1452 passing) and `bun run build` all pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_016otMcoAryLDo9Q6oxdr6yT)_