### PR TITLE
Notifications: one page, one badge, and email you can turn off

### DIFF
--- a/.github/workflows/notification-digest.yml
+++ b/.github/workflows/notification-digest.yml
@@ -1,0 +1,85 @@
+name: Notification digest
+
+# The once-a-day summary of everything that was not worth an instant email:
+# thread activity, new posts, and the comments managers moderate.
+#
+# This project has no other scheduler. The Supabase project is Lovable-managed
+# and pg_cron is not in this repo's migrations, and there is no wrangler.toml
+# here because Lovable owns the deploy, so neither a database cron nor a
+# Cloudflare cron trigger is available. A GitHub Actions schedule calling the
+# site's own endpoint is the mechanism.
+#
+# ⚠️ This workflow deliberately does NOT run on `pull_request`.
+#
+# It holds a credential that makes the live site email its members, and this
+# repo takes same-repo feature branches from Lovable and from coding agents. A
+# `pull_request` run on a same-repo branch DOES receive secrets, so pairing the
+# secret with a workflow the PR itself can rewrite would let any PR exfiltrate
+# it, or mail every member, in one line. Running only on trusted refs keeps the
+# credential away from unreviewed code. Same reasoning as migration-drift.yml.
+on:
+  schedule:
+    # 20:00 UTC is 7am in Sydney during daylight saving and 6am outside it.
+    # Cron has no notion of DST and an hour's drift on a club digest is not
+    # worth a scheduler of our own, so the wobble is accepted deliberately.
+    - cron: "0 20 * * *"
+  workflow_dispatch:
+
+concurrency:
+  # Never two digests at once. The endpoint is idempotent per person per day
+  # (see the digest-<user>-<date> idempotency key), but a second run racing the
+  # first would still do the work twice for no benefit. `cancel-in-progress` is
+  # false on purpose: cancelling a run mid-send would leave some people mailed
+  # and their rows unstamped.
+  group: notification-digest
+  cancel-in-progress: false
+
+permissions:
+  contents: none
+
+jobs:
+  digest:
+    name: Send the daily notification digest
+    runs-on: ubuntu-latest
+    steps:
+      # A single POST. Nothing is checked out: the workflow needs no repo
+      # contents, and not checking out is one less way for branch code to reach
+      # the secret.
+      - name: Ask the site to send today's digests
+        env:
+          DIGEST_URL: ${{ secrets.NOTIFICATION_DIGEST_URL }}
+          DIGEST_KEY: ${{ secrets.NOTIFICATION_DIGEST_KEY }}
+        run: |
+          set -euo pipefail
+
+          # A missing secret warns and passes rather than failing, so setting
+          # this workflow up does not wedge the default branch. That means a
+          # green tick here does NOT prove a digest went out — read the summary,
+          # which says which of the two happened.
+          if [ -z "${DIGEST_KEY:-}" ] || [ -z "${DIGEST_URL:-}" ]; then
+            echo "::warning::NOTIFICATION_DIGEST_URL or NOTIFICATION_DIGEST_KEY is not set — no digest was sent."
+            {
+              echo "### ⚠️ Digest not armed"
+              echo
+              echo "\`NOTIFICATION_DIGEST_URL\` and \`NOTIFICATION_DIGEST_KEY\` must both be set."
+              echo "A green tick here does **not** mean anybody was emailed."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # --fail-with-body so a non-2xx fails the job AND shows the reason,
+          # rather than the silent success plain curl would give.
+          response=$(curl --silent --show-error --fail-with-body \
+            --max-time 300 \
+            --request POST "$DIGEST_URL" \
+            --header "Authorization: Bearer $DIGEST_KEY" \
+            --header "Content-Length: 0")
+
+          echo "$response"
+          {
+            echo "### Digest sent"
+            echo
+            echo '```json'
+            echo "$response"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,17 @@ Core tables:
   path; it is owner-scoped and **no manager screen reads it**. Managers edit all
   of this at `/manager/kb` or through the manager agent API, which do the same
   things to the same data. Product flows: `docs/knowledge-base.md`.
+- `notifications` / `notification_preferences` / `notification_tokens` — the
+  `/notifications` page, the sidebar badge and the emails behind them. One
+  `notifications` row per person per event drives **both** the in-app list
+  (`read_at`) and the email (`emailed_at`), so there is no separate outbox, and
+  a unique index on `(user_id, kind, subject_id)` makes every writer safe to
+  call twice. The manager "needs attention" items are **not** stored: they stay
+  derived from `membership_plans` and clear by being fixed, which is why they
+  have no read state. Preferences are **nullable booleans** on purpose (NULL =
+  "never chose", resolved against `NOTIFICATION_DEFAULTS`) and govern **email
+  only** — every row is written regardless. A **private** `kb_annotation`
+  notifies nobody, managers included. Product flows: `docs/notifications.md`.
 - `user_roles` — role assignments; managed by managers / service role.
 - `manager_api_tokens` — manager-issued bearer tokens for the manager agent API
   (`/api/manager/agent`); stores only a SHA-256 hash + display prefix, manager-only RLS.
@@ -484,6 +495,12 @@ meaningfully). The app reads:
   manager agent API (`/api/manager/agent`). Normally managers mint revocable
   tokens at `/manager/api-tokens` (stored hashed in `manager_api_tokens`); this
   env var is just an optional fallback (see AGENTS.md).
+- Server, optional: `NOTIFICATION_DIGEST_KEY` — bearer token for the daily
+  notification digest (`POST /api/notifications/digest`, driven by
+  `.github/workflows/notification-digest.yml`). **Unset means the endpoint
+  refuses everything**, so no digest goes out until it is configured. The
+  workflow also needs `NOTIFICATION_DIGEST_URL` and the matching key as
+  repository secrets.
 
 Missing Supabase vars throw a clear "Connect Supabase in Lovable Cloud" error.
 

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -65,7 +65,13 @@ severities of moderation, not the same action.
 9. **A comment's body is plain text**, not Markdown — no formatting, no
    embedded photos or videos in comments. This is a deliberate scope line for
    now (see Future features).
-10. **A commenter's display name is their own choice, not their legal name.**
+10. **Comments and new posts produce notifications.** A reply emails its
+    recipient straight away; thread activity, announcements and the manager
+    moderation alert batch into a daily summary. Nobody is notified about their
+    own comment, and a reply to a **hidden** comment notifies nobody, since its
+    author is being moderated and telling them would undo that quietly.
+    Announcements are opt-in. Full spec: `docs/notifications.md`.
+11. **A commenter's display name is their own choice, not their legal name.**
     `profiles.display_name` is an optional override a person sets in their
     account settings; when unset, the name shown is derived — first (or
     preferred) name plus last initial (`commentDisplayName` in

--- a/docs/database.md
+++ b/docs/database.md
@@ -958,6 +958,91 @@ service role only.
 
 ---
 
+## Notifications
+
+The `/notifications` page, the sidebar badge and the emails behind them. The
+product spec is **`docs/notifications.md`**. Added by
+`20260806030000_notifications.sql`.
+
+One table drives both the in-app list and the email, which is why there is no
+separate outbox: `read_at` is the in-app state and `emailed_at` is the delivery
+state. The manager "needs attention" items are **not** stored here at all: they
+are derived live from `membership_plans` by `sellableWindowNotifications`, and
+clear by being fixed.
+
+### `notifications`
+
+| Column         | Type          | Null | Notes                                                                              |
+| -------------- | ------------- | ---- | ---------------------------------------------------------------------------------- |
+| `id`           | `uuid` PK     | no   | Default `gen_random_uuid()`.                                                       |
+| `user_id`      | `uuid`        | no   | `REFERENCES profiles(user_id) ON DELETE CASCADE`. The recipient.                   |
+| `kind`         | `text`        | no   | `reply\|thread_activity\|new_blog_post\|blog_comment\|kb_comment`.                 |
+| `subject_type` | `text`        | no   | `blog_comment\|kb_annotation\|blog_post`.                                          |
+| `subject_id`   | `uuid`        | no   | What happened. **No FK**: it points at three tables, and must outlive its subject. |
+| `actor_id`     | `uuid`        | yes  | `REFERENCES auth.users(id) ON DELETE SET NULL`. Who did it.                        |
+| `title`        | `text`        | no   | 1–200 chars. Frozen at write time.                                                 |
+| `body`         | `text`        | yes  | ≤ 500 chars. A preview of the comment (`commentPreview`).                          |
+| `href`         | `text`        | no   | Site-relative (`CHECK href LIKE '/%'`); the sender prefixes the origin.            |
+| `read_at`      | `timestamptz` | yes  | NULL = unread. Drives the badge.                                                   |
+| `emailed_at`   | `timestamptz` | yes  | NULL = not yet considered for email.                                               |
+| `created_at`   | `timestamptz` | no   | Default `now()`.                                                                   |
+
+`UNIQUE (user_id, kind, subject_id)`, plus indexes on `(user_id, created_at
+DESC)`, a partial `(user_id) WHERE read_at IS NULL` for the badge, and a partial
+`(created_at) WHERE emailed_at IS NULL` for the digest sweep.
+
+**The unique index is the idempotency guard**, and it is why `blog_posts` needs
+no `announced_at` column: a post unpublished and republished cannot produce a
+second announcement, because the second insert collides. `published_at` could
+not have carried that, since it is deliberately never cleared.
+
+**Titles are frozen, not joined.** A notification is a record of a moment, the
+same call `waivers` makes about its person fields. Rendering from a live join
+would also mean every list read re-checks article visibility, and one missed
+check leaks a members-only passage.
+
+**RLS:** owner-scoped SELECT and UPDATE, with deliberately no manager policy —
+the same call `kb_article_reads` makes. Reading other people's notifications
+would be reading who replied to whom. No client grants, so every read and write
+runs through a server function on the service role and
+`client-grants-expected.txt` needs no entry.
+
+### `notification_preferences`
+
+`user_id → profiles(user_id) ON DELETE CASCADE` PK, four **nullable** booleans
+(`reply_to_me`, `thread_activity`, `new_blog_post`, `manager_comment_alerts`),
+`created_at`, `updated_at`.
+
+**Nullable is the design, not an oversight.** NULL means "never chose" and hands
+that switch to `NOTIFICATION_DEFAULTS` in `src/lib/notifications.ts`. A
+`NOT NULL DEFAULT` could not express it: changing a club default later would
+then move either nobody or everybody, including people who deliberately switched
+it off. `manager_comment_alerts` is only consulted for somebody holding the
+`manager` role, re-checked at send time rather than trusted from whenever the
+row was written.
+
+These govern **email only**. Every notification row is written regardless.
+
+**RLS:** owner-scoped SELECT, defence in depth; no client grants.
+
+### `notification_tokens`
+
+`user_id → profiles(user_id) ON DELETE CASCADE` PK, `token` (raw, unique, **NOT
+NULL**), `token_hash` (unique), `token_prefix`, `created_at`. Powers the
+settings link at `/email-settings/<token>` in every email footer.
+
+The raw token is stored for the same reason `calendar_feed_tokens` stores one:
+the server has to put this link into an email it composes later, which a one-way
+hash cannot do. Unlike that table, `token` is NOT NULL here, because a row whose
+raw token had gone missing would be a footer link that cannot be built.
+
+**RLS:** enabled with **no policy at all**, deliberately. This is a credential
+granting signed-out access to somebody's email settings; `authenticated` has no
+grant and no reason to read even its own row, since the page it powers is
+reached from a link rather than by looking the token up.
+
+---
+
 ## Knowledge base
 
 Versioned markdown pages members read and annotate, served at `/kb/<slug>`,

--- a/docs/knowledge-base.md
+++ b/docs/knowledge-base.md
@@ -243,6 +243,24 @@ cannot trust that way is one they stop using honestly.
 Deleting a thread's root deletes its replies with it (`ON DELETE CASCADE`), and
 the UI warns before doing so.
 
+### Who gets told
+
+A **shared** comment notifies people: a reply emails its recipient straight
+away, everybody else on the thread gets it in the next daily summary, and
+managers get a summary of new comments so feedback stops depending on somebody
+remembering to open `/manager/kb`.
+
+A **private note notifies nobody**, managers included. That follows from what a
+private note is, and it is enforced twice: `createAnnotation` refuses a private
+reply, and `notifyKbAnnotation` returns immediately for anything that is not
+`shared`, so a private note's text can never reach an inbox.
+
+One rule is specific to this feature: recipients are re-checked against the
+article **as it stands now**, not as it stood when they commented. An article a
+manager has narrowed from `members` to `managers` only notifies managers, even
+about a thread a member took part in while it was wider. Full spec:
+`docs/notifications.md`.
+
 ## Versioning, and what happens to comments when an article changes
 
 Every save that carries text writes a **new version** and publishes it. Nothing

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,179 @@
+# Notifications
+
+One page for everything waiting on somebody, one badge in the sidebar, and email
+they can turn off. Schema reference: `docs/database.md`'s "Notifications"
+section, which must stay in sync with this document and the migrations, in the
+same change.
+
+## What problem this solves
+
+The club had two places where people wrote to each other and nobody found out.
+Reply to somebody on the blog and they learned about it by coming back to the
+page. Leave feedback on a knowledge base passage and it sat there until a
+manager opened `/manager/kb` and picked that exact article. Publish a post and
+nobody was told at all.
+
+Managers did have a "Needs attention" card on `/manager`, but it showed one kind
+of thing, was recomputed on every load, and had no notion of having been seen.
+Adding comment alerts somewhere else would have left managers checking two
+screens.
+
+## The model in one paragraph
+
+There are two kinds of thing on `/notifications`, and the difference is the
+whole design. An **attention item** is a standing problem, worked out live from
+club data every time the page loads, and it goes away by being fixed. It has no
+read state, and nothing can dismiss it. An **activity item** is something that
+happened, stored as a row in `notifications`, unread until somebody looks at it.
+They share one badge, and nothing else. The **email switches**
+(`notification_preferences`) govern the inbox only: every activity item is
+written whether or not the person wants it emailed.
+
+## Rules
+
+1. **The page is for everybody signed in, not just managers.** A member's
+   replies land there, so it sits in the sidebar's "Your account" group next to
+   Knowledge base and Account. A manager sees the same page with more on it.
+2. **The badge is one number**: open attention items plus unread activity. A
+   count of zero renders no badge at all rather than a "0" pill.
+3. **Attention items count toward the badge even though they can never be marked
+   read.** That is deliberate. A badge that went quiet while the club had no
+   sellable training dates would be worse than no badge.
+4. **The switches control email, never the page.** Somebody who turns off
+   new-post announcements still sees them under Activity. Turning email off must
+   never cost somebody the record of what happened.
+5. **A private knowledge base note notifies nobody**, managers included. It is
+   readable by its author alone (see `docs/knowledge-base.md`), and a
+   notification carrying its text would be the leak. `notifyKbAnnotation`
+   returns immediately for anything that is not `shared`.
+6. **Recipients are re-checked against the article as it stands now.** An
+   article that has narrowed from `members` to `managers` since somebody
+   commented must not be quoted at them, so a `managers` article only ever
+   notifies managers, regardless of who took part when it was wider.
+7. **Nobody is notified about their own writing, or about a hidden comment.** A
+   reply to a comment a manager has hidden notifies nobody: its author is being
+   moderated, and telling them their hidden comment got a reply would undo that
+   quietly.
+8. **A reply is instant; everything else is a daily summary.** You said
+   something and somebody answered, which is worth an interruption. Thread
+   activity, announcements and moderation alerts batch, so a busy thread cannot
+   produce ten emails in an afternoon.
+9. **Announcements are off until somebody opts in.** They are the only kind that
+   would reach a person who did nothing to ask for it. Everything else is on by
+   default. A NULL column means "never chose", which is why the preference
+   columns are nullable: it keeps "unset" distinguishable from "deliberately
+   off", so changing a club default later moves the right people.
+10. **The link in an email footer opens the switches, not an unsubscribe.**
+    Somebody who only wanted fewer announcements should not lose replies too.
+
+## Flows
+
+### Somebody replies to you
+
+`postComment` (`src/lib/blog-comments.functions.ts`) and `createAnnotation`
+(`src/lib/kb.functions.ts`) call into
+`src/lib/notification-events.server.ts` after the write succeeds, fire and
+forget. Three audiences come out of one comment: the person replied to, everyone
+else on the thread, and the managers. Only the first is emailed immediately.
+
+Every part of this is best-effort and swallows its own failures. A comment is
+saved, and must never fail because telling somebody about it did.
+
+### The daily summary
+
+`.github/workflows/notification-digest.yml` POSTs to
+`/api/notifications/digest` once a day with a bearer token
+(`NOTIFICATION_DIGEST_KEY`). The endpoint groups every row with no `emailed_at`
+by person, drops the kinds they have switched off, and sends one email to
+whoever has anything left.
+
+Two things about the stamping are worth knowing, because they are what keep it
+honest:
+
+- **Every row considered is stamped, including the suppressed ones.** A
+  preference is forward-looking. Without this, switching a kind back on would
+  release weeks of backlog into somebody's inbox.
+- **A row is stamped only after a successful send**, so a failed run retries
+  tomorrow rather than silently dropping a day. The one exception is a missing
+  `LOVABLE_API_KEY`, where nothing is stamped at all: those notifications are
+  still owed.
+
+The workflow runs on `schedule` and `workflow_dispatch` only, never on
+`pull_request`. It holds a credential that makes the live site email its
+members, and this repo takes same-repo branches from Lovable and from coding
+agents, so pairing that secret with a workflow a PR can rewrite would be a way
+to exfiltrate it, or to mail every member, in one line. Same reasoning as
+`migration-drift.yml`.
+
+There is no other scheduler available: the Supabase project is Lovable-managed
+and `pg_cron` is not in this repo's migrations, and there is no `wrangler.toml`
+here because Lovable owns the deploy. `cron: "0 20 * * *"` is 7am in Sydney
+during daylight saving and 6am outside it; cron has no notion of DST and an
+hour's drift on a club digest is not worth a scheduler of our own.
+
+### A post goes live
+
+`createBlogPost` and `updateBlogPost` announce on the transition **into**
+`published`, fanned out to everybody with a `profiles` row. Editing a published
+post announces nothing: a typo fix is not news.
+
+An unpublish and republish round trip announces the post exactly once, because
+the unique index on `(user_id, kind, subject_id)` absorbs the repeat. That is
+also why `blog_posts` needs no `announced_at` column: `published_at` is
+deliberately never cleared (`resolvePublishedAt` in `src/lib/blog.functions.ts`)
+so it could not have carried "has this been announced".
+
+### Turning email off
+
+The switches are on `/notifications` for somebody signed in, and at
+`/email-settings/<token>` for somebody who clicked the link at the bottom of an
+email. Both render `NotificationSwitches`, so the two can never offer different
+choices.
+
+The token rides in the URL path because an email client cannot send an
+`Authorization` header, the same as `/api/calendar/<token>` and
+`/api/verify-email/<token>`. The response is **uniform**: a token that never
+existed, one that has been rotated, and a malformed one all render the same
+page. Anything else would make the endpoint a way to probe which links the club
+has issued.
+
+The signed-out page deliberately omits the manager switch. With no session it
+cannot tell whether the person holds the role, and offering a manager-only
+choice to a member would be a lie about what they can turn on.
+
+## What is deliberately not built
+
+- **Upvotes notify nobody.** Not a conversation.
+- **No per-thread mute.** The switches are per kind. If one thread turns noisy,
+  the answer today is to turn thread activity off.
+- **No in-app bell or toast.** The sidebar badge is the only in-app signal.
+- **The attention list keeps the one check it had.** Pending waiver approvals,
+  unmatched bank transactions and unpaid invoices are all obvious next entries
+  and the shape supports them, but widening the manager queue is separate work.
+- **No digest for somebody with nothing.** An empty digest is not sent, and the
+  rows are stamped anyway so tomorrow's run is not re-reading them forever.
+
+## Known gap this did not fix
+
+`contact_messages` is **write-only**. The contact form saves a row and nothing
+in the app ever reads it: no manager screen, no server function, no email
+(unlike the interest form, which does notify managers). Anybody who has used the
+contact form has been talking into a void. It is a real bug, it is out of scope
+here, and it deserves its own fix.
+
+## Where the code lives
+
+| Concern                      | File                                                                   |
+| ---------------------------- | ---------------------------------------------------------------------- |
+| The rules (pure, tested)     | `src/lib/notifications.ts`                                             |
+| Who hears about what         | `src/lib/notification-events.server.ts`                                |
+| Sending, and the digest run  | `src/lib/notification-email.server.ts`                                 |
+| Page and settings server fns | `src/lib/notifications.functions.ts`                                   |
+| The shared query             | `src/hooks/useNotifications.ts`                                        |
+| The page                     | `src/routes/_authenticated/notifications.tsx`                          |
+| The signed-out settings      | `src/routes/email-settings/$token.tsx`                                 |
+| The switches                 | `src/components/site/NotificationSwitches.tsx`                         |
+| The sidebar badge            | `src/components/site/MemberLayout.tsx`                                 |
+| The digest endpoint          | `src/routes/api/notifications/digest.ts`                               |
+| The schedule                 | `.github/workflows/notification-digest.yml`                            |
+| Email templates              | `src/lib/email-templates/comment-reply.tsx`, `notification-digest.tsx` |

--- a/src/components/site/MemberLayout.test.tsx
+++ b/src/components/site/MemberLayout.test.tsx
@@ -1,12 +1,20 @@
 import { render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockUseAuth = vi.fn();
 const mockUseRoles = vi.fn();
+const mockUseNotifications = vi.fn();
 
 vi.mock("@/hooks/useAuth", () => ({
   useAuth: () => mockUseAuth(),
   useRoles: () => mockUseRoles(),
+}));
+
+// Mocked rather than wrapped in a QueryClientProvider: this suite is about the
+// navigation, and the real hook would drag a server function and the query
+// cache into every case here.
+vi.mock("@/hooks/useNotifications", () => ({
+  useNotifications: () => mockUseNotifications(),
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -43,9 +51,15 @@ const managerOnlyLinks = [
 ];
 
 describe("MemberLayout", () => {
+  beforeEach(() => {
+    // Nothing waiting, unless a case says otherwise.
+    mockUseNotifications.mockReturnValue({ badge: 0 });
+  });
+
   afterEach(() => {
     mockUseAuth.mockReset();
     mockUseRoles.mockReset();
+    mockUseNotifications.mockReset();
   });
 
   it("shows member links and the sign-out / back-to-site controls for any signed-in user", () => {
@@ -131,5 +145,53 @@ describe("MemberLayout", () => {
     );
     // Member links remain available to managers too.
     expect(screen.getByRole("link", { name: /account/i })).toBeInTheDocument();
+  });
+
+  // Notifications sit in the MEMBER group, not the manager one: a member's
+  // replies land there too, so it is the one place anybody looks to catch up.
+  it("shows notifications to a plain member", () => {
+    mockUseAuth.mockReturnValue({ user: { id: "u1", email: "m@example.com" } });
+    mockUseRoles.mockReturnValue({ roles: ["member"], isManager: false });
+
+    render(
+      <MemberLayout>
+        <div />
+      </MemberLayout>,
+    );
+
+    expect(screen.getByRole("link", { name: /^notifications$/i })).toHaveAttribute(
+      "href",
+      "/notifications",
+    );
+  });
+
+  it("shows the unread count next to notifications", () => {
+    mockUseAuth.mockReturnValue({ user: { id: "u1", email: "m@example.com" } });
+    mockUseRoles.mockReturnValue({ roles: ["member"], isManager: false });
+    mockUseNotifications.mockReturnValue({ badge: 3 });
+
+    render(
+      <MemberLayout>
+        <div />
+      </MemberLayout>,
+    );
+
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  // A "0" pill reads as something waiting when nothing is, so zero renders
+  // nothing at all.
+  it("renders no badge when nothing is waiting", () => {
+    mockUseAuth.mockReturnValue({ user: { id: "u1", email: "m@example.com" } });
+    mockUseRoles.mockReturnValue({ roles: ["member"], isManager: false });
+    mockUseNotifications.mockReturnValue({ badge: 0 });
+
+    render(
+      <MemberLayout>
+        <div />
+      </MemberLayout>,
+    );
+
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
   });
 });

--- a/src/components/site/MemberLayout.tsx
+++ b/src/components/site/MemberLayout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import {
+  Bell,
   BookOpen,
   CalendarDays,
   ChevronLeft,
@@ -20,6 +21,7 @@ import {
 } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth, useRoles } from "@/hooks/useAuth";
+import { useNotifications } from "@/hooks/useNotifications";
 import logoAsset from "@/assets/UTS_JITSU_CMYK.png.asset.json";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -31,6 +33,7 @@ import {
   SidebarHeader,
   SidebarInset,
   SidebarMenu,
+  SidebarMenuBadge,
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarProvider,
@@ -39,12 +42,23 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 
-type NavItem = { to: string; label: string; icon: typeof User };
+type NavItem = {
+  to: string;
+  label: string;
+  icon: typeof User;
+  /** When set, this entry carries a count badge. Only `/notifications` has one,
+   * and it is the single number for the whole member space: open attention
+   * items plus unread activity. */
+  badge?: number;
+};
 
 const memberNav: NavItem[] = [
   // First: what a new member is meant to read before anything else. The rest of
   // this group is admin they only visit when something needs doing.
   { to: "/kb", label: "Knowledge base", icon: BookOpen },
+  // Everyone signed in, not just managers: a member's replies land here too, so
+  // this is the one place anybody looks to catch up.
+  { to: "/notifications", label: "Notifications", icon: Bell },
   { to: "/account", label: "Account", icon: User },
   { to: "/membership", label: "Membership", icon: CreditCard },
 ];
@@ -92,6 +106,9 @@ function NavList({ items, pathname }: { items: NavItem[]; pathname: string }) {
               <span>{item.label}</span>
             </Link>
           </SidebarMenuButton>
+          {/* Zero renders nothing rather than a "0" pill: an empty badge reads
+              as something waiting when nothing is. */}
+          {item.badge ? <SidebarMenuBadge>{item.badge}</SidebarMenuBadge> : null}
         </SidebarMenuItem>
       ))}
     </SidebarMenu>
@@ -103,6 +120,11 @@ export function MemberLayout({ children }: { children: ReactNode }) {
   const { pathname } = useLocation();
   const { user } = useAuth();
   const { isManager } = useRoles(user?.id);
+  // The same cached query the /notifications page reads, so the badge and the
+  // list can never disagree about how many things are waiting.
+  const { badge } = useNotifications();
+
+  const nav = memberNav.map((item) => (item.to === "/notifications" ? { ...item, badge } : item));
 
   async function signOut() {
     await supabase.auth.signOut();
@@ -141,7 +163,7 @@ export function MemberLayout({ children }: { children: ReactNode }) {
         <SidebarContent>
           <SidebarGroup>
             <SidebarGroupLabel>Your account</SidebarGroupLabel>
-            <NavList items={memberNav} pathname={pathname} />
+            <NavList items={nav} pathname={pathname} />
           </SidebarGroup>
 
           {isManager && (

--- a/src/components/site/NotificationSwitches.tsx
+++ b/src/components/site/NotificationSwitches.tsx
@@ -1,0 +1,79 @@
+// The email switches, rendered by both places they appear: /notifications for
+// somebody signed in, and /email-settings/<token> for somebody who clicked the
+// link at the bottom of an email. One component so the two can never drift into
+// offering different choices.
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import type { EmailPreferenceKey } from "@/lib/notifications";
+
+type SwitchSpec = {
+  key: EmailPreferenceKey;
+  label: string;
+  hint: string;
+  /** Only shown to managers. A member has no use for it and would read it as
+   * an offer of something they cannot have. */
+  managerOnly?: boolean;
+};
+
+/** Written as what arrives in the inbox, not as what the system does. */
+const SWITCHES: SwitchSpec[] = [
+  {
+    key: "reply_to_me",
+    label: "Someone replies to me",
+    hint: "Sent straight away, so you can answer while the conversation is live.",
+  },
+  {
+    key: "thread_activity",
+    label: "More activity on a thread I am in",
+    hint: "Once a day, covering threads you have commented on.",
+  },
+  {
+    key: "new_blog_post",
+    label: "A new blog post goes up",
+    hint: "Once a day. Off unless you turn it on.",
+  },
+  {
+    key: "manager_comment_alerts",
+    label: "New comments to review",
+    hint: "Once a day, covering blog and knowledge base comments.",
+    managerOnly: true,
+  },
+];
+
+export function NotificationSwitches({
+  values,
+  onChange,
+  disabled,
+  isManager,
+}: {
+  values: Record<EmailPreferenceKey, boolean>;
+  onChange: (key: EmailPreferenceKey, next: boolean) => void;
+  disabled?: boolean;
+  isManager?: boolean;
+}) {
+  const shown = SWITCHES.filter((s) => !s.managerOnly || isManager);
+  return (
+    <div className="space-y-4">
+      {shown.map((spec) => (
+        <div key={spec.key} className="flex items-start justify-between gap-4">
+          <div className="space-y-0.5">
+            <Label htmlFor={`notify-${spec.key}`} className="text-sm font-medium">
+              {spec.label}
+            </Label>
+            <p className="text-sm text-muted-foreground">{spec.hint}</p>
+          </div>
+          <Switch
+            id={`notify-${spec.key}`}
+            checked={values[spec.key]}
+            disabled={disabled}
+            onCheckedChange={(next) => onChange(spec.key, next)}
+          />
+        </div>
+      ))}
+      <p className="text-sm text-muted-foreground">
+        These control email only. Everything still shows up on your notifications page, so turning
+        one off never loses you the record of what happened.
+      </p>
+    </div>
+  );
+}

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,0 +1,58 @@
+// Everything on /notifications, fetched once and shared with the sidebar badge.
+//
+// Its own module rather than an export from the page or from `MemberLayout.tsx`
+// because both need the same answer, and a file that exports a component and a
+// hook loses React Fast Refresh. One query key means the badge and the list are
+// reading the same object, so they cannot disagree about how many things are
+// waiting.
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useServerFn } from "@tanstack/react-start";
+
+import { useAuth } from "@/hooks/useAuth";
+import { badgeCount } from "@/lib/notifications";
+import { listMyNotifications, type NotificationsPayload } from "@/lib/notifications.functions";
+
+/** The shared query key, exported so a mutation can invalidate it by hand. */
+export function notificationsQueryKey(userId: string | null | undefined) {
+  return ["notifications", userId ?? null] as const;
+}
+
+export function useNotifications(): {
+  data: NotificationsPayload | undefined;
+  loading: boolean;
+  failed: boolean;
+  badge: number;
+  refresh: () => void;
+} {
+  const { user, loading: authLoading } = useAuth();
+  const fetchAll = useServerFn(listMyNotifications);
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    // Keyed by WHO it was fetched for, the same reasoning as `useKbNav`:
+    // `__root.tsx` does not invalidate the cache on SIGNED_OUT, and a bare
+    // ["notifications"] would leave one person's replies on screen in a tab
+    // whose session ended. Here that would be somebody else's comment traffic.
+    queryKey: notificationsQueryKey(user?.id),
+    queryFn: () => fetchAll(),
+    // Nothing to ask for until we know who is asking.
+    enabled: !authLoading && Boolean(user?.id),
+    // The badge sits in the shell of every member-space page, so a stale count
+    // is the normal state. A minute keeps it honest without a request per
+    // navigation.
+    staleTime: 60_000,
+  });
+
+  return {
+    data: query.data,
+    loading: authLoading || query.isLoading,
+    // A failed fetch is NOT "you have nothing waiting". The page says the
+    // honest thing and offers a retry instead, the same call `/account` makes
+    // about a failed profile load.
+    failed: query.isError,
+    badge: query.data ? badgeCount(query.data.attention, query.data.items) : 0,
+    refresh: () => {
+      void queryClient.invalidateQueries({ queryKey: notificationsQueryKey(user?.id) });
+    },
+  };
+}

--- a/src/integrations/supabase/schema-contract.test.ts
+++ b/src/integrations/supabase/schema-contract.test.ts
@@ -368,6 +368,83 @@ export type _KbArticlePositionIsNumber = Expect<
   Equals<Tables["kb_articles"]["Row"]["position"], number>
 >;
 
+// ---- notifications: the /notifications page, the badge, and the emails ----
+
+/**
+ * Committed alongside `20260806030000_notifications.sql`, which hand-added this
+ * table's block to `types.ts` (the migration is not applied yet, so the
+ * generator has never seen it) — the same situation as `kb_article_reads`
+ * above, and see that migration's own header. This pins the shape the hand-add
+ * asserted, so a real regeneration landing with a different one is caught here
+ * rather than at runtime.
+ *
+ * `read_at` and `emailed_at` are the two load-bearing columns: the first is the
+ * in-app unread state behind the sidebar badge, the second is what stops a
+ * notification being emailed twice. Losing either would not fail a query, it
+ * would just quietly mail people again.
+ */
+export type _NotificationColumns = RequireColumns<
+  Tables["notifications"]["Row"],
+  | "id"
+  | "user_id"
+  | "kind"
+  | "subject_type"
+  | "subject_id"
+  | "actor_id"
+  | "title"
+  | "body"
+  | "href"
+  | "read_at"
+  | "emailed_at"
+  | "created_at"
+>;
+
+/**
+ * Both timestamps are nullable, and that IS the state machine: NULL `read_at`
+ * means unread, NULL `emailed_at` means "not yet considered for email". A
+ * NOT NULL widening on either would mean the column had gained a default, at
+ * which point every notification arrives pre-read and pre-sent and the whole
+ * feature silently does nothing.
+ */
+export type _NotificationReadAtIsNullable = Expect<
+  Equals<Tables["notifications"]["Row"]["read_at"], string | null>
+>;
+export type _NotificationEmailedAtIsNullable = Expect<
+  Equals<Tables["notifications"]["Row"]["emailed_at"], string | null>
+>;
+
+/**
+ * The four switches, and the reason they are nullable: NULL means "never chose"
+ * and hands that switch to `NOTIFICATION_DEFAULTS` in `src/lib/notifications.ts`.
+ * A NOT NULL widening would collapse "unset" into "off", which silently opts
+ * everybody out of replies and makes changing a club default impossible to
+ * apply to the people who never expressed a view.
+ */
+export type _NotificationPreferenceColumns = RequireColumns<
+  Tables["notification_preferences"]["Row"],
+  "user_id" | "reply_to_me" | "thread_activity" | "new_blog_post" | "manager_comment_alerts"
+>;
+export type _NotificationPreferenceReplyIsNullable = Expect<
+  Equals<Tables["notification_preferences"]["Row"]["reply_to_me"], boolean | null>
+>;
+export type _NotificationPreferenceNewPostIsNullable = Expect<
+  Equals<Tables["notification_preferences"]["Row"]["new_blog_post"], boolean | null>
+>;
+
+/**
+ * The credential behind the settings link in an email footer. `token` holds the
+ * RAW value and is NOT NULL, unlike `calendar_feed_tokens.token`: the server has
+ * to be able to put this link into an email it composes later, so a row whose
+ * raw token had gone missing would be a footer link that cannot be built.
+ */
+export type _NotificationTokenColumns = RequireColumns<
+  Tables["notification_tokens"]["Row"],
+  "user_id" | "token" | "token_hash" | "token_prefix"
+>;
+export type _NotificationTokenRawIsNotNull = Expect<
+  Equals<Tables["notification_tokens"]["Row"]["token"], string>
+>;
+
 describe("live schema contract", () => {
   it("is enforced by the typechecker, not by this test", () => {
     // Nothing to assert at runtime: the contract is the type declarations above,

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -985,6 +985,129 @@ export type Database = {
           },
         ]
       }
+      notification_preferences: {
+        Row: {
+          created_at: string
+          manager_comment_alerts: boolean | null
+          new_blog_post: boolean | null
+          reply_to_me: boolean | null
+          thread_activity: boolean | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          manager_comment_alerts?: boolean | null
+          new_blog_post?: boolean | null
+          reply_to_me?: boolean | null
+          thread_activity?: boolean | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          manager_comment_alerts?: boolean | null
+          new_blog_post?: boolean | null
+          reply_to_me?: boolean | null
+          thread_activity?: boolean | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "notification_preferences_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
+      notification_tokens: {
+        Row: {
+          created_at: string
+          token: string
+          token_hash: string
+          token_prefix: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          token: string
+          token_hash: string
+          token_prefix: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          token?: string
+          token_hash?: string
+          token_prefix?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "notification_tokens_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
+      notifications: {
+        Row: {
+          actor_id: string | null
+          body: string | null
+          created_at: string
+          emailed_at: string | null
+          href: string
+          id: string
+          kind: string
+          read_at: string | null
+          subject_id: string
+          subject_type: string
+          title: string
+          user_id: string
+        }
+        Insert: {
+          actor_id?: string | null
+          body?: string | null
+          created_at?: string
+          emailed_at?: string | null
+          href: string
+          id?: string
+          kind: string
+          read_at?: string | null
+          subject_id: string
+          subject_type: string
+          title: string
+          user_id: string
+        }
+        Update: {
+          actor_id?: string | null
+          body?: string | null
+          created_at?: string
+          emailed_at?: string | null
+          href?: string
+          id?: string
+          kind?: string
+          read_at?: string | null
+          subject_id?: string
+          subject_type?: string
+          title?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "notifications_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
       profiles: {
         Row: {
           address: string | null

--- a/src/lib/blog-comments.functions.ts
+++ b/src/lib/blog-comments.functions.ts
@@ -232,12 +232,31 @@ export const postComment = createServerFn({ method: "POST" })
   .handler(async ({ data, context }) => {
     if (data.hp) return { id: "" };
     const { supabaseAdmin } = await import("@/integrations/supabase/client.server");
-    return insertBlogComment(supabaseAdmin, {
+    const comment = await insertBlogComment(supabaseAdmin, {
       postId: data.post_id,
       userId: context.userId,
       parentCommentId: data.parent_comment_id,
       body: data.body,
     });
+
+    // Best-effort notifications: the reply email, the thread fan-out and the
+    // manager alert. Deliberately outside `insertBlogComment`, which stays a
+    // pure DB helper with its own tests, and deliberately swallowed: a comment
+    // is saved and must never fail because telling somebody about it did.
+    try {
+      const { notifyBlogComment } = await import("@/lib/notification-events.server");
+      await notifyBlogComment(supabaseAdmin, {
+        commentId: comment.id,
+        postId: data.post_id,
+        actorId: context.userId,
+        parentCommentId: data.parent_comment_id ?? null,
+        body: data.body,
+      });
+    } catch (e) {
+      console.error("[postComment] failed to send notifications:", e);
+    }
+
+    return comment;
   });
 
 export const toggleCommentUpvote = createServerFn({ method: "POST" })

--- a/src/lib/blog.functions.ts
+++ b/src/lib/blog.functions.ts
@@ -227,8 +227,35 @@ export const createBlogPost = createServerFn({ method: "POST" })
       .select("id, slug")
       .single();
     if (error) throw new Error(error.message);
+    if (data.status === "published") {
+      await announcePost(row.id, row.slug, data.title, context.userId);
+    }
     return row;
   });
+
+/**
+ * Tell everybody a post went live. Best-effort and swallowed: a post is
+ * published and must never fail because the announcement did.
+ *
+ * Safe to call more than once for the same post. The unique index behind
+ * `notifications` absorbs the repeat, which is what makes an
+ * unpublish/republish round trip announce a post exactly once, and is why
+ * `blog_posts` carries no `announced_at` column.
+ */
+async function announcePost(
+  postId: string,
+  slug: string,
+  title: string,
+  actorId: string,
+): Promise<void> {
+  try {
+    const { supabaseAdmin } = await import("@/integrations/supabase/client.server");
+    const { notifyNewBlogPost } = await import("@/lib/notification-events.server");
+    await notifyNewBlogPost(supabaseAdmin, { postId, slug, title, actorId });
+  } catch (e) {
+    console.error("[blog] failed to announce a published post:", e);
+  }
+}
 
 export const updateBlogPost = createServerFn({ method: "POST" })
   .middleware([requireSupabaseAuth])
@@ -265,6 +292,13 @@ export const updateBlogPost = createServerFn({ method: "POST" })
       })
       .eq("id", data.id);
     if (error) throw new Error(error.message);
+    // Announce on the transition INTO published, not on every save of a
+    // published post: editing a typo is not news. The unique index makes a
+    // repeat harmless anyway, so this is about not doing the work rather than
+    // about correctness.
+    if (data.status === "published" && existing.status !== "published") {
+      await announcePost(data.id, slug, data.title, context.userId);
+    }
     // `slug` and `excerpt` both come back because the server may have resolved
     // either one (a slug collision, or an excerpt derived from the body): the
     // edit page uses them as the new baseline so the form isn't left reading

--- a/src/lib/email-templates/comment-reply.tsx
+++ b/src/lib/email-templates/comment-reply.tsx
@@ -1,0 +1,99 @@
+import * as React from "react";
+
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Link,
+  Preview,
+  Text,
+} from "@react-email/components";
+
+interface CommentReplyEmailProps {
+  siteName: string;
+  /** The replier's public display name, never their legal name (see docs/blog.md). */
+  authorName: string;
+  /** What they wrote, already trimmed to a preview by `commentPreview`. */
+  preview: string;
+  /** Absolute link to the comment, anchored so it opens on the reply. */
+  replyUrl: string;
+  /** Where this person can change what gets emailed. Works signed out. */
+  settingsUrl: string;
+  /** "your comment on Belt gradings" reads better than a bare "your comment". */
+  context: string;
+}
+
+/** Sent the moment somebody replies to your blog or knowledge base comment. */
+export const CommentReplyEmail = ({
+  siteName,
+  authorName,
+  preview,
+  replyUrl,
+  settingsUrl,
+  context,
+}: CommentReplyEmailProps) => (
+  <Html lang="en" dir="ltr">
+    <Head />
+    <Preview>
+      {authorName} replied to {context}
+    </Preview>
+    <Body style={main}>
+      <Container style={container}>
+        <Heading style={h1}>{authorName} replied to you</Heading>
+        <Text style={text}>
+          On {context} at {siteName}, {authorName} wrote:
+        </Text>
+        <Text style={quote}>{preview}</Text>
+        <Button style={button} href={replyUrl}>
+          Read the reply
+        </Button>
+        <Text style={footer}>
+          You are getting this because somebody replied to you.{" "}
+          <Link href={settingsUrl} style={link}>
+            Choose what we email you
+          </Link>
+          .
+        </Text>
+      </Container>
+    </Body>
+  </Html>
+);
+
+export default CommentReplyEmail;
+
+const main = { backgroundColor: "#ffffff", fontFamily: "Arial, sans-serif" };
+const container = { padding: "20px 25px" };
+const h1 = {
+  fontSize: "22px",
+  fontWeight: "bold" as const,
+  color: "#008eaa",
+  margin: "0 0 20px",
+};
+const text = {
+  fontSize: "14px",
+  color: "#55575d",
+  lineHeight: "1.5",
+  margin: "0 0 15px",
+};
+const quote = {
+  fontSize: "14px",
+  color: "#55575d",
+  lineHeight: "1.5",
+  margin: "0 0 25px",
+  padding: "10px 15px",
+  borderLeft: "3px solid #008eaa",
+  backgroundColor: "#f6f8f9",
+};
+const link = { color: "inherit", textDecoration: "underline" };
+const button = {
+  backgroundColor: "#008eaa",
+  color: "#ffffff",
+  fontSize: "14px",
+  borderRadius: "8px",
+  padding: "12px 20px",
+  textDecoration: "none",
+};
+const footer = { fontSize: "12px", color: "#999999", margin: "30px 0 0" };

--- a/src/lib/email-templates/notification-digest.tsx
+++ b/src/lib/email-templates/notification-digest.tsx
@@ -1,0 +1,108 @@
+import * as React from "react";
+
+import { Body, Container, Head, Heading, Html, Link, Preview, Text } from "@react-email/components";
+
+export interface DigestLine {
+  title: string;
+  body: string | null;
+  /** Absolute link to the thing that happened. */
+  url: string;
+}
+
+export interface DigestBlock {
+  heading: string;
+  lines: DigestLine[];
+}
+
+interface NotificationDigestEmailProps {
+  siteName: string;
+  greeting: string;
+  /** Only non-empty blocks are passed in, so the email never shows a bare heading. */
+  blocks: DigestBlock[];
+  notificationsUrl: string;
+  settingsUrl: string;
+}
+
+/** The once-a-day summary of everything that was not worth an instant email. */
+export const NotificationDigestEmail = ({
+  siteName,
+  greeting,
+  blocks,
+  notificationsUrl,
+  settingsUrl,
+}: NotificationDigestEmailProps) => (
+  <Html lang="en" dir="ltr">
+    <Head />
+    <Preview>What happened at {siteName} since yesterday</Preview>
+    <Body style={main}>
+      <Container style={container}>
+        <Heading style={h1}>Since yesterday</Heading>
+        <Text style={text}>
+          {greeting}, here is what happened at {siteName}.
+        </Text>
+
+        {blocks.map((block) => (
+          <div key={block.heading}>
+            <Heading as="h2" style={h2}>
+              {block.heading}
+            </Heading>
+            {block.lines.map((line) => (
+              <Text key={line.url + line.title} style={item}>
+                <Link href={line.url} style={itemLink}>
+                  {line.title}
+                </Link>
+                {line.body ? <span style={itemBody}>{line.body}</span> : null}
+              </Text>
+            ))}
+          </div>
+        ))}
+
+        <Text style={text}>
+          <Link href={notificationsUrl} style={link}>
+            Open your notifications
+          </Link>
+        </Text>
+        <Text style={footer}>
+          You are getting this because you take part at {siteName}.{" "}
+          <Link href={settingsUrl} style={link}>
+            Choose what we email you
+          </Link>
+          .
+        </Text>
+      </Container>
+    </Body>
+  </Html>
+);
+
+export default NotificationDigestEmail;
+
+const main = { backgroundColor: "#ffffff", fontFamily: "Arial, sans-serif" };
+const container = { padding: "20px 25px" };
+const h1 = {
+  fontSize: "22px",
+  fontWeight: "bold" as const,
+  color: "#008eaa",
+  margin: "0 0 20px",
+};
+const h2 = {
+  fontSize: "15px",
+  fontWeight: "bold" as const,
+  color: "#2b2d31",
+  margin: "25px 0 10px",
+};
+const text = {
+  fontSize: "14px",
+  color: "#55575d",
+  lineHeight: "1.5",
+  margin: "0 0 20px",
+};
+const item = {
+  fontSize: "14px",
+  color: "#55575d",
+  lineHeight: "1.5",
+  margin: "0 0 10px",
+};
+const itemLink = { color: "#008eaa", textDecoration: "none", fontWeight: "bold" as const };
+const itemBody = { display: "block", color: "#77797d" };
+const link = { color: "inherit", textDecoration: "underline" };
+const footer = { fontSize: "12px", color: "#999999", margin: "30px 0 0" };

--- a/src/lib/kb.functions.ts
+++ b/src/lib/kb.functions.ts
@@ -748,6 +748,25 @@ export const createAnnotation = createServerFn({ method: "POST" })
       .select("id, created_at")
       .single();
     if (error || !inserted) throw new Error(error?.message ?? "Could not save your comment.");
+
+    // Best-effort notifications. `notifyKbAnnotation` refuses anything that is
+    // not `shared`, so a private note never reaches it in a state where it
+    // could be quoted; passing the visibility explicitly keeps that check on
+    // the value that was actually stored rather than on the request.
+    try {
+      const { notifyKbAnnotation } = await import("@/lib/notification-events.server");
+      await notifyKbAnnotation(db, {
+        annotationId: inserted.id,
+        articleId: loaded.article.id,
+        actorId: viewer.userId,
+        parentId: data.parent_id ?? null,
+        body: data.body,
+        visibility,
+      });
+    } catch (e) {
+      console.error("[createAnnotation] failed to send notifications:", e);
+    }
+
     return { ok: true as const, id: inserted.id, created_at: inserted.created_at };
   });
 

--- a/src/lib/membership.functions.ts
+++ b/src/lib/membership.functions.ts
@@ -11,6 +11,7 @@ import {
   matchesMembershipReference,
   matchTransactionSchema,
   sellableWindowNotifications,
+  type ManagerNotification,
   normalizeRef,
   greetingName,
   nameWithPreferred,
@@ -735,25 +736,33 @@ export async function listMembershipPlanRows(
   return data ?? [];
 }
 
-// ---- Manager: dashboard notifications ----
+// ---- Manager: the "needs attention" list ----
 //
-// The dashboard's "needs attention" list. The rules live in pure functions
-// (validation.ts, unit-tested); this handler is only auth + data fetch.
-export const managerNotifications = createServerFn({ method: "GET" })
-  .middleware([requireSupabaseAuth])
-  .handler(async ({ context }) => {
-    await requireManager(context as { supabase: MembershipClient; userId: string });
-    const admin = await adminClient();
-    const plans = await listMembershipPlanRows(admin);
-    // Only dated plans (starts_on/ends_on both set) need a successor —
-    // an undated one (trial, casual, insurance) never runs out of training
-    // dates to sell.
-    const dated = plans.filter(
-      (p): p is MembershipPlanRow & { starts_on: string; ends_on: string } =>
-        p.starts_on != null && p.ends_on != null,
-    );
-    return sellableWindowNotifications(dated, new Date().toISOString());
-  });
+// Standing problems only a manager can fix. Derived on every call and never
+// stored, which is what makes them clear by being FIXED rather than by being
+// dismissed — see docs/notifications.md.
+//
+// A plain exported function rather than a `createServerFn`, the same shape as
+// `listMembershipPlanRows` above: its one caller is `listMyNotifications` in
+// `notifications.functions.ts`, which already has the caller's identity and
+// has checked the manager role. Two server functions deriving this list would
+// be two places for the rule to drift.
+//
+// The rules themselves live in pure functions (validation.ts, unit-tested);
+// this is only the data fetch.
+export async function managerAttentionItems(
+  admin: MembershipClient,
+): Promise<ManagerNotification[]> {
+  const plans = await listMembershipPlanRows(admin);
+  // Only dated plans (starts_on/ends_on both set) need a successor —
+  // an undated one (trial, casual, insurance) never runs out of training
+  // dates to sell.
+  const dated = plans.filter(
+    (p): p is MembershipPlanRow & { starts_on: string; ends_on: string } =>
+      p.starts_on != null && p.ends_on != null,
+  );
+  return sellableWindowNotifications(dated, new Date().toISOString());
+}
 
 // ---- Manager: club settings (invoice payment instructions) ----
 export const getClubSettings = createServerFn({ method: "GET" })

--- a/src/lib/notification-email.server.ts
+++ b/src/lib/notification-email.server.ts
@@ -19,6 +19,7 @@ import {
   NotificationDigestEmail,
   type DigestBlock,
 } from "@/lib/email-templates/notification-digest";
+import { CLUB_TIME_ZONE, clubLocalDate } from "@/lib/calendar";
 import { generateRawToken, hashToken, tokenPreview } from "@/lib/manager-api-tokens";
 import {
   digestSections,
@@ -305,9 +306,13 @@ export async function sendDailyDigests(db: AdminClient, now = new Date()): Promi
     return { considered: pending.length, recipients: byUser.size, sent: 0 };
   }
 
-  // Date in the club's own terms, so the idempotency key matches what a person
-  // would call "today" and a re-run after midnight UTC is still the same digest.
-  const day = now.toISOString().slice(0, 10);
+  // The club's date, not the UTC one. The schedule fires at 20:00 UTC, which is
+  // already tomorrow morning in Sydney, so a UTC key would label every digest
+  // with the previous day and a re-run either side of midnight UTC would mint
+  // two different keys for one morning's mail. `emailed_at` is the real guard;
+  // this key is the second belt, and a second belt that changes halfway through
+  // the window is not one.
+  const day = clubLocalDate(now, CLUB_TIME_ZONE);
   let sent = 0;
 
   for (const [userId, items] of byUser) {

--- a/src/lib/notification-email.server.ts
+++ b/src/lib/notification-email.server.ts
@@ -1,0 +1,384 @@
+// Server-only: writes notification rows and sends the emails that go with them.
+//
+// Like `waiver-email.server.ts` and `interest-email.server.ts`, this pulls in
+// server-only dependencies (the Lovable send API, the React-email renderer) so
+// it must never reach the client bundle. It is named `*.server.ts` and is only
+// ever lazy-imported from inside a server-function handler or an API route.
+//
+// Writing the row and sending the email live together on purpose: an instant
+// reply email is "insert, then send, then stamp `emailed_at`", and splitting
+// that across modules is how a row ends up mailed twice or never.
+import * as React from "react";
+import { render } from "@react-email/render";
+import { sendLovableEmail } from "@lovable.dev/email-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "@/integrations/supabase/types";
+import { CommentReplyEmail } from "@/lib/email-templates/comment-reply";
+import {
+  NotificationDigestEmail,
+  type DigestBlock,
+} from "@/lib/email-templates/notification-digest";
+import { generateRawToken, hashToken, tokenPreview } from "@/lib/manager-api-tokens";
+import {
+  digestSections,
+  digestSubject,
+  hasDigestContent,
+  shouldEmail,
+  type NotificationItem,
+  type NotificationKind,
+  type NotificationSubjectType,
+} from "@/lib/notifications";
+import { greetingName } from "@/lib/validation";
+import { userEmails } from "@/lib/supabase-rpc";
+
+// Sender configuration mirrors the auth-email webhook and every other email
+// this app sends.
+const SITE_NAME = "UTS Jitsu";
+// Must match SENDER_DOMAIN so DKIM/SPF align under DMARC.
+const FROM_DOMAIN = "notify.jitsu.au";
+const SENDER_DOMAIN = "notify.jitsu.au";
+const SITE_URL = "https://jitsu.au";
+const FROM = `${SITE_NAME} <noreply@${FROM_DOMAIN}>`;
+
+type AdminClient = SupabaseClient<Database>;
+
+async function sendOne(opts: {
+  apiKey: string;
+  sendUrl?: string;
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+  idempotencyKey: string;
+}) {
+  await sendLovableEmail(
+    {
+      to: opts.to,
+      from: FROM,
+      sender_domain: SENDER_DOMAIN,
+      subject: opts.subject,
+      html: opts.html,
+      text: opts.text,
+      purpose: "transactional",
+      idempotency_key: opts.idempotencyKey,
+    },
+    { apiKey: opts.apiKey, sendUrl: opts.sendUrl },
+  );
+}
+
+/** Turn a stored site-relative `href` into something an email client can open. */
+export function absoluteUrl(href: string): string {
+  return `${SITE_URL}${href}`;
+}
+
+/**
+ * The person's settings link, minted on first need.
+ *
+ * Get-or-create with a race fallback, the same shape `calendar.functions.ts`
+ * uses for a feed token: two emails composed at once for the same person would
+ * otherwise both try to insert, and the loser must end up with the winner's
+ * token rather than an error. Returns null if a token cannot be established, in
+ * which case the caller falls back to the signed-in page.
+ */
+export async function settingsUrlFor(db: AdminClient, userId: string): Promise<string> {
+  const url = (token: string) => `${SITE_URL}/email-settings/${token}`;
+
+  const { data: existing } = await db
+    .from("notification_tokens")
+    .select("token")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (existing?.token) return url(existing.token);
+
+  const raw = generateRawToken();
+  const { error } = await db.from("notification_tokens").insert({
+    user_id: userId,
+    token: raw,
+    token_hash: await hashToken(raw),
+    token_prefix: tokenPreview(raw),
+  });
+  if (!error) return url(raw);
+
+  const { data: raced } = await db
+    .from("notification_tokens")
+    .select("token")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (raced?.token) return url(raced.token);
+
+  // No token, so no signed-out link. The signed-in page still works, and an
+  // email with a settings link that needs a login beats no email at all.
+  console.error(`[notifications] could not mint a settings token for ${userId}`);
+  return `${SITE_URL}/notifications`;
+}
+
+export type NotificationDraft = {
+  userId: string;
+  kind: NotificationKind;
+  subjectType: NotificationSubjectType;
+  subjectId: string;
+  actorId?: string | null;
+  title: string;
+  body?: string | null;
+  href: string;
+};
+
+/**
+ * Insert notification rows, ignoring any that already exist.
+ *
+ * `ON CONFLICT DO NOTHING` against `notifications_user_kind_subject_key` is what
+ * makes every writer safe to call twice: a post unpublished and republished, or
+ * a retried request, cannot produce a second notification. Returns the rows
+ * that were actually new, so the caller only emails about those.
+ */
+export async function writeNotifications(
+  db: AdminClient,
+  drafts: NotificationDraft[],
+): Promise<{ id: string; user_id: string; kind: NotificationKind }[]> {
+  if (drafts.length === 0) return [];
+  const { data, error } = await db
+    .from("notifications")
+    .upsert(
+      drafts.map((d) => ({
+        user_id: d.userId,
+        kind: d.kind,
+        subject_type: d.subjectType,
+        subject_id: d.subjectId,
+        actor_id: d.actorId ?? null,
+        title: d.title,
+        body: d.body ?? null,
+        href: d.href,
+      })),
+      { onConflict: "user_id,kind,subject_id", ignoreDuplicates: true },
+    )
+    .select("id, user_id, kind");
+  if (error) {
+    // Never allowed to fail the comment somebody just posted.
+    console.error("[notifications] could not write notifications:", error.message);
+    return [];
+  }
+  return (data ?? []).map((r) => ({
+    id: r.id,
+    user_id: r.user_id,
+    kind: r.kind as NotificationKind,
+  }));
+}
+
+/** One person's email address, or null. */
+async function emailFor(db: AdminClient, userId: string): Promise<string | null> {
+  const { data, error } = await userEmails(db, [userId]);
+  if (error || !data?.length) return null;
+  return data[0].email ?? null;
+}
+
+/**
+ * Email somebody straight away that they were replied to, then stamp the row so
+ * the digest never mentions it again.
+ *
+ * Best-effort throughout: a missing API key, an unknown address or a failed send
+ * is logged and swallowed. The notification is already on their page either way,
+ * which is the point of storing it rather than only mailing it.
+ */
+export async function sendReplyNotification(
+  db: AdminClient,
+  opts: {
+    notificationId: string;
+    recipientId: string;
+    authorName: string;
+    preview: string;
+    href: string;
+    context: string;
+  },
+): Promise<boolean> {
+  const apiKey = process.env.LOVABLE_API_KEY;
+  if (!apiKey) {
+    console.warn("[notifications] LOVABLE_API_KEY not set — skipping reply email");
+    return false;
+  }
+
+  const { data: prefs } = await db
+    .from("notification_preferences")
+    .select("reply_to_me, thread_activity, new_blog_post, manager_comment_alerts")
+    .eq("user_id", opts.recipientId)
+    .maybeSingle();
+  if (!shouldEmail(prefs, "reply")) {
+    // Switched off. Stamp it anyway so the digest does not pick it up later as
+    // an unemailed row: a preference is forward-looking, not a queue.
+    await stampEmailed(db, [opts.notificationId]);
+    return false;
+  }
+
+  const to = await emailFor(db, opts.recipientId);
+  if (!to) return false;
+
+  const el = React.createElement(CommentReplyEmail, {
+    siteName: SITE_NAME,
+    authorName: opts.authorName,
+    preview: opts.preview,
+    replyUrl: absoluteUrl(opts.href),
+    settingsUrl: await settingsUrlFor(db, opts.recipientId),
+    context: opts.context,
+  });
+  const [html, text] = await Promise.all([render(el), render(el, { plainText: true })]);
+
+  try {
+    await sendOne({
+      apiKey,
+      sendUrl: process.env.LOVABLE_SEND_URL,
+      to,
+      subject: `${opts.authorName} replied to you at ${SITE_NAME}`,
+      html,
+      text,
+      // Keyed by the notification row, which is itself unique per person per
+      // subject, so a retry cannot mail the same reply twice.
+      idempotencyKey: `reply-${opts.notificationId}`,
+    });
+    await stampEmailed(db, [opts.notificationId]);
+    return true;
+  } catch (e) {
+    console.error(`[notifications] failed to email a reply to ${opts.recipientId}:`, e);
+    return false;
+  }
+}
+
+/** Mark rows as dealt with, so the digest does not consider them again. */
+async function stampEmailed(db: AdminClient, ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  const { error } = await db
+    .from("notifications")
+    .update({ emailed_at: new Date().toISOString() })
+    .in("id", ids);
+  if (error) console.error("[notifications] could not stamp emailed_at:", error.message);
+}
+
+const SECTION_HEADINGS = {
+  replies: "Replies to you",
+  threads: "Threads you are in",
+  posts: "New on the blog",
+  moderation: "Comments to review",
+} as const;
+
+export type DigestResult = { considered: number; recipients: number; sent: number };
+
+/**
+ * The daily run: everything not yet considered for email, grouped by person.
+ *
+ * Every row it looks at is stamped, including the ones a preference suppressed.
+ * That is what keeps switching a kind back on forward-looking instead of
+ * releasing weeks of backlog into somebody's inbox.
+ */
+export async function sendDailyDigests(db: AdminClient, now = new Date()): Promise<DigestResult> {
+  const { data: rows, error } = await db
+    .from("notifications")
+    .select("id, user_id, kind, title, body, href, read_at, created_at")
+    .is("emailed_at", null)
+    .order("created_at", { ascending: true })
+    .limit(5000);
+  if (error) throw new Error(error.message);
+
+  const pending = rows ?? [];
+  if (pending.length === 0) return { considered: 0, recipients: 0, sent: 0 };
+
+  const byUser = new Map<string, NotificationItem[]>();
+  for (const r of pending) {
+    const list = byUser.get(r.user_id) ?? [];
+    list.push({
+      id: r.id,
+      kind: r.kind as NotificationKind,
+      title: r.title,
+      body: r.body,
+      href: r.href,
+      read_at: r.read_at,
+      created_at: r.created_at,
+    });
+    byUser.set(r.user_id, list);
+  }
+
+  const apiKey = process.env.LOVABLE_API_KEY;
+  const sendUrl = process.env.LOVABLE_SEND_URL;
+  if (!apiKey) {
+    // Deliberately NOT stamped. With no way to send, these are still owed, and
+    // stamping them would silently swallow a day of notifications the first
+    // time the key went missing.
+    console.warn("[notifications] LOVABLE_API_KEY not set — skipping the digest");
+    return { considered: pending.length, recipients: byUser.size, sent: 0 };
+  }
+
+  // Date in the club's own terms, so the idempotency key matches what a person
+  // would call "today" and a re-run after midnight UTC is still the same digest.
+  const day = now.toISOString().slice(0, 10);
+  let sent = 0;
+
+  for (const [userId, items] of byUser) {
+    try {
+      const [{ data: prefs }, { data: manager }, profile] = await Promise.all([
+        db
+          .from("notification_preferences")
+          .select("reply_to_me, thread_activity, new_blog_post, manager_comment_alerts")
+          .eq("user_id", userId)
+          .maybeSingle(),
+        db.rpc("has_role", { _user_id: userId, _role: "manager" }),
+        db
+          .from("profiles")
+          .select("first_name, last_name, preferred_name")
+          .eq("user_id", userId)
+          .maybeSingle(),
+      ]);
+
+      const sections = digestSections(items, prefs, { isManager: Boolean(manager) });
+      const ids = items.map((i) => i.id);
+
+      if (!hasDigestContent(sections)) {
+        // Nothing they want to hear about. Stamp and move on, so tomorrow's run
+        // is not re-reading the same rows forever.
+        await stampEmailed(db, ids);
+        continue;
+      }
+
+      const to = await emailFor(db, userId);
+      if (!to) {
+        await stampEmailed(db, ids);
+        continue;
+      }
+
+      const blocks: DigestBlock[] = (["replies", "threads", "posts", "moderation"] as const)
+        .filter((key) => sections[key].length > 0)
+        .map((key) => ({
+          heading: SECTION_HEADINGS[key],
+          lines: sections[key].map((i) => ({
+            title: i.title,
+            body: i.body,
+            url: absoluteUrl(i.href),
+          })),
+        }));
+
+      const el = React.createElement(NotificationDigestEmail, {
+        siteName: SITE_NAME,
+        greeting: profile.data ? greetingName(profile.data) : "Hi",
+        blocks,
+        notificationsUrl: `${SITE_URL}/notifications`,
+        settingsUrl: await settingsUrlFor(db, userId),
+      });
+      const [html, text] = await Promise.all([render(el), render(el, { plainText: true })]);
+
+      await sendOne({
+        apiKey,
+        sendUrl,
+        to,
+        subject: digestSubject(SITE_NAME, sections),
+        html,
+        text,
+        idempotencyKey: `digest-${userId}-${day}`,
+      });
+      // Stamp only after a successful send, so a failure retries tomorrow
+      // rather than silently dropping the day.
+      await stampEmailed(db, ids);
+      sent += 1;
+    } catch (e) {
+      console.error(`[notifications] digest failed for ${userId}:`, e);
+    }
+  }
+
+  return { considered: pending.length, recipients: byUser.size, sent };
+}

--- a/src/lib/notification-events.server.ts
+++ b/src/lib/notification-events.server.ts
@@ -1,0 +1,347 @@
+// Server-only: works out WHO hears about a comment or a post, and writes the
+// notifications. Delivery lives in `notification-email.server.ts`; this module
+// is the recipient rules.
+//
+// Split out from the sender so the two questions stay separable: "who should be
+// told" is where the privacy guards live, and "how does it reach them" is where
+// the transport does. Both are lazy-imported from server-function handlers, and
+// neither may ever reach the client bundle.
+//
+// Everything here is best-effort and swallows its own failures. A notification
+// must never be able to fail the comment somebody just posted.
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "@/integrations/supabase/types";
+import {
+  blogCommentHref,
+  blogPostHref,
+  commentPreview,
+  kbAnnotationHref,
+  threadActivityRecipients,
+} from "@/lib/notifications";
+import { commentDisplayName } from "@/lib/validation";
+
+type AdminClient = SupabaseClient<Database>;
+
+/** Everyone holding the manager role, for the moderation alerts. */
+async function managerIds(db: AdminClient): Promise<string[]> {
+  const { data, error } = await db.from("user_roles").select("user_id").eq("role", "manager");
+  if (error || !data) return [];
+  return [...new Set(data.map((r) => r.user_id))];
+}
+
+/** The commenter's public display name. Never the legal name: this is quoted
+ * into an email that goes to other members (see docs/blog.md rule 10). */
+async function displayNameFor(db: AdminClient, userId: string): Promise<string> {
+  const { data } = await db
+    .from("profiles")
+    .select("first_name, last_name, preferred_name, display_name")
+    .eq("user_id", userId)
+    .maybeSingle();
+  return data ? commentDisplayName(data) : "Someone at the club";
+}
+
+/** Drop anybody with no `profiles` row. `notifications.user_id` is a foreign key
+ * to it, so an insert for a role-holder whose profile was deleted would fail the
+ * whole batch and lose everybody else's notification with it. */
+async function withProfiles(db: AdminClient, userIds: string[]): Promise<string[]> {
+  if (userIds.length === 0) return [];
+  const { data, error } = await db.from("profiles").select("user_id").in("user_id", userIds);
+  if (error || !data) return [];
+  const known = new Set(data.map((p) => p.user_id));
+  return userIds.filter((id) => known.has(id));
+}
+
+/**
+ * Somebody commented on a blog post.
+ *
+ * Three audiences, in order of how personal they are: the person replied to
+ * (instant email), everybody else in the thread, and the managers.
+ */
+export async function notifyBlogComment(
+  db: AdminClient,
+  input: {
+    commentId: string;
+    postId: string;
+    actorId: string;
+    parentCommentId?: string | null;
+    body: string;
+  },
+): Promise<void> {
+  const { writeNotifications, sendReplyNotification } =
+    await import("@/lib/notification-email.server");
+
+  const { data: post } = await db
+    .from("blog_posts")
+    .select("slug, title, status")
+    .eq("id", input.postId)
+    .maybeSingle();
+  // A comment on an unpublished post notifies nobody. `postComment` already
+  // refuses one, so this is belt and braces.
+  if (!post || post.status !== "published") return;
+
+  const authorName = await displayNameFor(db, input.actorId);
+  const preview = commentPreview(input.body);
+  const href = blogCommentHref(post.slug, input.commentId);
+  const context = `your comment on ${post.title}`;
+
+  // ---- The person replied to ----
+  let repliedToId: string | null = null;
+  if (input.parentCommentId) {
+    const { data: parent } = await db
+      .from("blog_comments")
+      .select("user_id, status")
+      .eq("id", input.parentCommentId)
+      .maybeSingle();
+    // A hidden parent notifies nobody: its author is being moderated, and
+    // telling them their hidden comment got a reply undoes that quietly.
+    if (parent && parent.status === "visible" && parent.user_id !== input.actorId) {
+      repliedToId = parent.user_id;
+    }
+  }
+
+  // ---- Everybody else in the thread ----
+  const { data: participants } = await db
+    .from("blog_comments")
+    .select("user_id")
+    .eq("post_id", input.postId)
+    .eq("status", "visible");
+  const others = threadActivityRecipients(
+    (participants ?? []).map((p) => p.user_id),
+    { actorId: input.actorId, directReplyToId: repliedToId },
+  );
+
+  // ---- Managers ----
+  const managers = (await managerIds(db)).filter((id) => id !== input.actorId);
+
+  const [replyTo, threadIds, managerIdsWithProfiles] = await Promise.all([
+    repliedToId ? withProfiles(db, [repliedToId]) : Promise.resolve([]),
+    withProfiles(db, others),
+    withProfiles(db, managers),
+  ]);
+
+  const written = await writeNotifications(db, [
+    ...replyTo.map((userId) => ({
+      userId,
+      kind: "reply" as const,
+      subjectType: "blog_comment" as const,
+      subjectId: input.commentId,
+      actorId: input.actorId,
+      title: `${authorName} replied to you`,
+      body: preview,
+      href,
+    })),
+    ...threadIds.map((userId) => ({
+      userId,
+      kind: "thread_activity" as const,
+      subjectType: "blog_comment" as const,
+      subjectId: input.commentId,
+      actorId: input.actorId,
+      title: `${authorName} commented on ${post.title}`,
+      body: preview,
+      href,
+    })),
+    ...managerIdsWithProfiles.map((userId) => ({
+      userId,
+      kind: "blog_comment" as const,
+      subjectType: "blog_comment" as const,
+      subjectId: input.commentId,
+      actorId: input.actorId,
+      title: `New blog comment from ${authorName}`,
+      body: preview,
+      href,
+    })),
+  ]);
+
+  // Only the reply is instant. Everything else waits for the daily digest.
+  const replyRow = written.find((r) => r.kind === "reply");
+  if (replyRow) {
+    await sendReplyNotification(db, {
+      notificationId: replyRow.id,
+      recipientId: replyRow.user_id,
+      authorName,
+      preview,
+      href,
+      context,
+    });
+  }
+}
+
+/**
+ * Somebody commented on a knowledge base article.
+ *
+ * The privacy rules here are the strict ones. A PRIVATE note notifies nobody,
+ * managers included: it is readable by its author alone, and a notification
+ * carrying its text would be the leak. And because an article's visibility can
+ * narrow after somebody commented, every recipient is re-checked against the
+ * article as it stands NOW, not as it stood when they took part.
+ */
+export async function notifyKbAnnotation(
+  db: AdminClient,
+  input: {
+    annotationId: string;
+    articleId: string;
+    actorId: string;
+    parentId?: string | null;
+    body: string;
+    visibility: string;
+  },
+): Promise<void> {
+  // The guard the whole feature rests on. `createAnnotation` already refuses a
+  // private reply, so this is belt and braces, but a private note's text must
+  // never leave the database and this is the last place to stop it.
+  if (input.visibility !== "shared") return;
+
+  const { writeNotifications, sendReplyNotification } =
+    await import("@/lib/notification-email.server");
+
+  const { data: article } = await db
+    .from("kb_articles")
+    .select("slug, visibility")
+    .eq("id", input.articleId)
+    .maybeSingle();
+  if (!article) return;
+
+  const { data: version } = await db
+    .from("kb_article_versions")
+    .select("title")
+    .eq("article_id", input.articleId)
+    .eq("is_current", true)
+    .maybeSingle();
+  const articleTitle = version?.title ?? article.slug;
+
+  const authorName = await displayNameFor(db, input.actorId);
+  const preview = commentPreview(input.body);
+  const href = kbAnnotationHref(article.slug, input.annotationId);
+  const context = `your comment on ${articleTitle}`;
+
+  // ---- The person replied to ----
+  let repliedToId: string | null = null;
+  let threadRootId = input.annotationId;
+  if (input.parentId) {
+    const { data: parent } = await db
+      .from("kb_annotations")
+      .select("user_id, visibility")
+      .eq("id", input.parentId)
+      .maybeSingle();
+    // Replying to a private note is already refused upstream. Re-checked here
+    // because "which rows may be quoted" is this module's job.
+    if (parent && parent.visibility === "shared" && parent.user_id !== input.actorId) {
+      repliedToId = parent.user_id;
+    }
+    threadRootId = input.parentId;
+  }
+
+  // ---- Everybody else on the thread ----
+  const { data: thread } = await db
+    .from("kb_annotations")
+    .select("user_id, id, parent_id, visibility")
+    .eq("article_id", input.articleId)
+    .eq("visibility", "shared");
+  const participants = (thread ?? [])
+    .filter((a) => a.id === threadRootId || a.parent_id === threadRootId)
+    .map((a) => a.user_id);
+  const others = threadActivityRecipients(participants, {
+    actorId: input.actorId,
+    directReplyToId: repliedToId,
+  });
+
+  const managers = (await managerIds(db)).filter((id) => id !== input.actorId);
+
+  // The visibility re-check. A `managers` article must only ever reach managers,
+  // even if a member commented on it back when it was `members`.
+  const managerSet = new Set(managers);
+  const admitted = (ids: string[]) =>
+    article.visibility === "managers" ? ids.filter((id) => managerSet.has(id)) : ids;
+
+  const [replyTo, threadIds, managerIdsWithProfiles] = await Promise.all([
+    withProfiles(db, admitted(repliedToId ? [repliedToId] : [])),
+    withProfiles(db, admitted(others)),
+    withProfiles(db, managers),
+  ]);
+
+  const written = await writeNotifications(db, [
+    ...replyTo.map((userId) => ({
+      userId,
+      kind: "reply" as const,
+      subjectType: "kb_annotation" as const,
+      subjectId: input.annotationId,
+      actorId: input.actorId,
+      title: `${authorName} replied to you`,
+      body: preview,
+      href,
+    })),
+    ...threadIds.map((userId) => ({
+      userId,
+      kind: "thread_activity" as const,
+      subjectType: "kb_annotation" as const,
+      subjectId: input.annotationId,
+      actorId: input.actorId,
+      title: `${authorName} commented on ${articleTitle}`,
+      body: preview,
+      href,
+    })),
+    ...managerIdsWithProfiles.map((userId) => ({
+      userId,
+      kind: "kb_comment" as const,
+      subjectType: "kb_annotation" as const,
+      subjectId: input.annotationId,
+      actorId: input.actorId,
+      title: `New knowledge base comment from ${authorName}`,
+      body: preview,
+      href,
+    })),
+  ]);
+
+  const replyRow = written.find((r) => r.kind === "reply");
+  if (replyRow) {
+    await sendReplyNotification(db, {
+      notificationId: replyRow.id,
+      recipientId: replyRow.user_id,
+      authorName,
+      preview,
+      href,
+      context,
+    });
+  }
+}
+
+/**
+ * A post went live.
+ *
+ * Fanned out to everybody with a club record, and safe to call again: the
+ * unique index on `(user_id, kind, subject_id)` absorbs the repeat, which is
+ * what makes an unpublish/republish round trip announce the post exactly once.
+ * That is also why `blog_posts` needs no `announced_at` column.
+ *
+ * Note this writes a row for everybody regardless of their email switch. The
+ * switches govern the inbox, not the page: somebody who does not want the
+ * announcement emailed still sees it in their notifications, and the digest is
+ * where the preference is applied.
+ */
+export async function notifyNewBlogPost(
+  db: AdminClient,
+  input: { postId: string; slug: string; title: string; actorId?: string | null },
+): Promise<void> {
+  const { writeNotifications } = await import("@/lib/notification-email.server");
+
+  const { data: people, error } = await db.from("profiles").select("user_id");
+  if (error || !people) return;
+
+  await writeNotifications(
+    db,
+    people
+      .map((p) => p.user_id)
+      .filter((userId) => userId !== input.actorId)
+      .map((userId) => ({
+        userId,
+        kind: "new_blog_post" as const,
+        subjectType: "blog_post" as const,
+        subjectId: input.postId,
+        actorId: input.actorId ?? null,
+        title: `New post: ${input.title}`,
+        body: null,
+        href: blogPostHref(input.slug),
+      })),
+  );
+}

--- a/src/lib/notifications.functions.ts
+++ b/src/lib/notifications.functions.ts
@@ -1,0 +1,236 @@
+// Server functions behind /notifications and the signed-out email settings
+// page.
+//
+// ⚠️ This file is bundled to the CLIENT (every `*.functions.ts` is), so the
+// service-role client is lazy-imported inside each handler and never at the top
+// level. The rules themselves live in `src/lib/notifications.ts`, which is pure
+// and imported freely.
+import { createServerFn } from "@tanstack/react-start";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "@/integrations/supabase/types";
+import { requireSupabaseAuth } from "@/integrations/supabase/auth-middleware";
+import {
+  emailPreferenceKeys,
+  resolveNotificationPreferences,
+  type EmailPreferenceKey,
+  type NotificationItem,
+  type NotificationKind,
+  type NotificationPreferenceRow,
+} from "@/lib/notifications";
+import { managerAttentionItems } from "@/lib/membership.functions";
+import {
+  markNotificationsReadSchema,
+  notificationPreferencesByTokenSchema,
+  notificationPreferencesSchema,
+  notificationTokenSchema,
+  type ManagerNotification,
+} from "@/lib/validation";
+
+type AdminClient = SupabaseClient<Database>;
+
+/** How many activity rows the page shows. Older ones stay in the database and
+ * still count as read/unread; nobody scrolls a year of comment traffic. */
+const PAGE_LIMIT = 100;
+
+async function adminClient(): Promise<AdminClient> {
+  const { supabaseAdmin } = await import("@/integrations/supabase/client.server");
+  return supabaseAdmin;
+}
+
+async function isManager(db: AdminClient, userId: string): Promise<boolean> {
+  // `has_role` is `SELECT EXISTS(...)` so it never returns NULL and needs no
+  // wrapper in `supabase-rpc.ts` (see the CLAUDE.md note on RPC nullability).
+  const { data, error } = await db.rpc("has_role", { _user_id: userId, _role: "manager" });
+  if (error) {
+    // A failed role lookup is NOT "not a manager". Saying so here would empty
+    // the attention list on a real manager's page and read as "all quiet" while
+    // the club had no sellable training dates.
+    throw new Error("Could not confirm your access just now. Reload the page and try again.");
+  }
+  return Boolean(data);
+}
+
+/** Read somebody's preferences row. A missing row is not an error: it means
+ * they have never touched a switch, and every switch resolves to its default. */
+export async function readPreferences(
+  db: AdminClient,
+  userId: string,
+): Promise<NotificationPreferenceRow | null> {
+  const { data, error } = await db
+    .from("notification_preferences")
+    .select("reply_to_me, thread_activity, new_blog_post, manager_comment_alerts")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return data ?? null;
+}
+
+/** Apply a patch to somebody's switches.
+ *
+ * Only keys actually present in the patch are written, so a page that renders
+ * one switch cannot blank the other three. `null` is a real value here and is
+ * written as such, handing that switch back to the club default. */
+async function writePreferences(
+  db: AdminClient,
+  userId: string,
+  patch: Partial<Record<EmailPreferenceKey, boolean | null>>,
+): Promise<NotificationPreferenceRow> {
+  const update: Record<string, boolean | null | string> = {};
+  for (const key of emailPreferenceKeys) {
+    if (key in patch) update[key] = patch[key] ?? null;
+  }
+  const { data, error } = await db
+    .from("notification_preferences")
+    .upsert(
+      { user_id: userId, ...update, updated_at: new Date().toISOString() },
+      { onConflict: "user_id" },
+    )
+    .select("reply_to_me, thread_activity, new_blog_post, manager_comment_alerts")
+    .single();
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+export type NotificationsPayload = {
+  attention: ManagerNotification[];
+  items: NotificationItem[];
+  preferences: Record<EmailPreferenceKey, boolean>;
+  isManager: boolean;
+};
+
+/** Everything the /notifications page and the sidebar badge need, in one call.
+ * They read the same cached query, so the badge and the list cannot disagree. */
+export const listMyNotifications = createServerFn({ method: "GET" })
+  .middleware([requireSupabaseAuth])
+  .handler(async ({ context }): Promise<NotificationsPayload> => {
+    const db = await adminClient();
+    const userId = context.userId;
+    const manager = await isManager(db, userId);
+
+    const [{ data: rows, error }, prefs, attention] = await Promise.all([
+      db
+        .from("notifications")
+        .select("id, kind, title, body, href, read_at, created_at")
+        .eq("user_id", userId)
+        .order("created_at", { ascending: false })
+        .limit(PAGE_LIMIT),
+      readPreferences(db, userId),
+      // Attention items are manager-only. A member asking gets an empty list
+      // rather than an error, so the page renders one way for everybody.
+      manager ? managerAttentionItems(db) : Promise.resolve([] as ManagerNotification[]),
+    ]);
+    if (error) throw new Error(error.message);
+
+    return {
+      attention,
+      items: (rows ?? []).map((r) => ({
+        id: r.id,
+        kind: r.kind as NotificationKind,
+        title: r.title,
+        body: r.body,
+        href: r.href,
+        read_at: r.read_at,
+        created_at: r.created_at,
+      })),
+      preferences: resolveNotificationPreferences(prefs),
+      isManager: manager,
+    };
+  });
+
+/** Mark notifications read. Scoped to the caller's own rows in the query
+ * itself, so naming somebody else's id marks nothing rather than erroring. */
+export const markNotificationsRead = createServerFn({ method: "POST" })
+  .middleware([requireSupabaseAuth])
+  .inputValidator((d: unknown) => markNotificationsReadSchema.parse(d))
+  .handler(async ({ data, context }) => {
+    const db = await adminClient();
+    let query = db
+      .from("notifications")
+      .update({ read_at: new Date().toISOString() })
+      .eq("user_id", context.userId)
+      .is("read_at", null);
+    // An absent list is "all of mine" ("Mark all as read"). An empty array is
+    // not the same thing and must be a no-op, or opening a page with nothing on
+    // it would silently clear the whole history.
+    if (data.ids) {
+      if (data.ids.length === 0) return { ok: true as const, marked: 0 };
+      query = query.in("id", data.ids);
+    }
+    const { data: updated, error } = await query.select("id");
+    if (error) throw new Error(error.message);
+    return { ok: true as const, marked: (updated ?? []).length };
+  });
+
+/** Read the caller's own switches. */
+export const getMyNotificationPreferences = createServerFn({ method: "GET" })
+  .middleware([requireSupabaseAuth])
+  .handler(async ({ context }) => {
+    const db = await adminClient();
+    return resolveNotificationPreferences(await readPreferences(db, context.userId));
+  });
+
+/** Save the caller's own switches. */
+export const saveMyNotificationPreferences = createServerFn({ method: "POST" })
+  .middleware([requireSupabaseAuth])
+  .inputValidator((d: unknown) => notificationPreferencesSchema.parse(d))
+  .handler(async ({ data, context }) => {
+    const db = await adminClient();
+    const row = await writePreferences(db, context.userId, data);
+    return resolveNotificationPreferences(row);
+  });
+
+/**
+ * Resolve the person behind a settings-link token.
+ *
+ * Returns null for anything that does not match, and the CALLER must render the
+ * same page for null as for a rotated token: a response that distinguished
+ * "no such token" from "expired" would turn this into a way to probe which
+ * links the club has issued. Same uniform-response reasoning as
+ * `src/routes/api/verify-email/$token.ts`.
+ */
+async function userIdForToken(db: AdminClient, raw: string): Promise<string | null> {
+  const { hashToken } = await import("@/lib/manager-api-tokens");
+  let token_hash: string;
+  try {
+    token_hash = await hashToken(raw);
+  } catch {
+    return null;
+  }
+  const { data, error } = await db
+    .from("notification_tokens")
+    .select("user_id")
+    .eq("token_hash", token_hash)
+    .maybeSingle();
+  if (error || !data) return null;
+  return data.user_id;
+}
+
+export type TokenSettings =
+  | { ok: true; preferences: Record<EmailPreferenceKey, boolean> }
+  | { ok: false };
+
+/** Read the switches behind a footer link, with no session. */
+export const getNotificationPreferencesByToken = createServerFn({ method: "POST" })
+  .inputValidator((d: unknown) => notificationTokenSchema.parse(d))
+  .handler(async ({ data }): Promise<TokenSettings> => {
+    const db = await adminClient();
+    const userId = await userIdForToken(db, data.token);
+    if (!userId) return { ok: false };
+    return {
+      ok: true,
+      preferences: resolveNotificationPreferences(await readPreferences(db, userId)),
+    };
+  });
+
+/** Save the switches behind a footer link, with no session. */
+export const saveNotificationPreferencesByToken = createServerFn({ method: "POST" })
+  .inputValidator((d: unknown) => notificationPreferencesByTokenSchema.parse(d))
+  .handler(async ({ data }): Promise<TokenSettings> => {
+    const db = await adminClient();
+    const userId = await userIdForToken(db, data.token);
+    if (!userId) return { ok: false };
+    const { token: _token, ...patch } = data;
+    const row = await writePreferences(db, userId, patch);
+    return { ok: true, preferences: resolveNotificationPreferences(row) };
+  });

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NOTIFICATION_DEFAULTS,
+  badgeCount,
+  blogCommentHref,
+  blogPostHref,
+  commentPreview,
+  digestItemCount,
+  digestSections,
+  digestSubject,
+  emailPreferenceKeys,
+  hasDigestContent,
+  kbAnnotationHref,
+  notificationKinds,
+  preferenceForKind,
+  resolveNotificationPreference,
+  resolveNotificationPreferences,
+  shouldEmail,
+  threadActivityRecipients,
+  type NotificationItem,
+  type NotificationKind,
+} from "./notifications";
+import type { ManagerNotification } from "./validation";
+
+const ATTENTION: ManagerNotification = {
+  type: "define_membership_window",
+  title: "Set up the club's training dates",
+  body: "Members cannot join as members until the club's training dates are set.",
+  href: "/manager/membership-plans",
+};
+
+function item(over: Partial<NotificationItem> = {}): NotificationItem {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    kind: "reply",
+    title: "Jane L. replied to you",
+    body: "Nice one",
+    href: "/blog/a-post#comment-1",
+    read_at: null,
+    created_at: "2026-08-06T00:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("preferenceForKind", () => {
+  it("maps every kind to a switch", () => {
+    for (const kind of notificationKinds) {
+      expect(emailPreferenceKeys).toContain(preferenceForKind[kind]);
+    }
+  });
+
+  // Two kinds, one switch: "tell me about new comments" is one decision a
+  // manager makes, not two. If this ever splits, the settings UI has to grow a
+  // fourth row, so it is pinned rather than left to drift.
+  it("puts both moderation kinds behind the same switch", () => {
+    expect(preferenceForKind.blog_comment).toBe("manager_comment_alerts");
+    expect(preferenceForKind.kb_comment).toBe("manager_comment_alerts");
+  });
+});
+
+describe("NOTIFICATION_DEFAULTS", () => {
+  // The product rule, not a tidiness check: announcements are the only kind
+  // that would reach somebody who did nothing to ask for it, so they are the
+  // only kind that defaults off.
+  it("defaults announcements off and everything else on", () => {
+    expect(NOTIFICATION_DEFAULTS.new_blog_post).toBe(false);
+    expect(NOTIFICATION_DEFAULTS.reply_to_me).toBe(true);
+    expect(NOTIFICATION_DEFAULTS.thread_activity).toBe(true);
+    expect(NOTIFICATION_DEFAULTS.manager_comment_alerts).toBe(true);
+  });
+});
+
+describe("resolveNotificationPreference", () => {
+  it("falls back to the default when the switch was never chosen", () => {
+    expect(resolveNotificationPreference({ reply_to_me: null }, "reply_to_me")).toBe(true);
+    expect(resolveNotificationPreference({ new_blog_post: null }, "new_blog_post")).toBe(false);
+  });
+
+  it("falls back to the default when there is no row at all", () => {
+    expect(resolveNotificationPreference(null, "reply_to_me")).toBe(true);
+    expect(resolveNotificationPreference(undefined, "new_blog_post")).toBe(false);
+  });
+
+  // The reason the columns are nullable. `false` is a decision and must not be
+  // overwritten by the default; if this ever collapsed to `stored || default`,
+  // switching replies off would silently do nothing.
+  it("keeps an explicit false distinct from an unset switch", () => {
+    expect(resolveNotificationPreference({ reply_to_me: false }, "reply_to_me")).toBe(false);
+    expect(resolveNotificationPreference({ reply_to_me: null }, "reply_to_me")).toBe(true);
+  });
+
+  it("keeps an explicit true on a switch that defaults off", () => {
+    expect(resolveNotificationPreference({ new_blog_post: true }, "new_blog_post")).toBe(true);
+  });
+});
+
+describe("resolveNotificationPreferences", () => {
+  it("resolves every switch, mixing stored values and defaults", () => {
+    expect(resolveNotificationPreferences({ new_blog_post: true, reply_to_me: false })).toEqual({
+      reply_to_me: false,
+      thread_activity: true,
+      new_blog_post: true,
+      manager_comment_alerts: true,
+    });
+  });
+
+  it("returns the defaults for somebody with no row", () => {
+    expect(resolveNotificationPreferences(null)).toEqual(NOTIFICATION_DEFAULTS);
+  });
+});
+
+describe("shouldEmail", () => {
+  it("follows the switch for a member kind", () => {
+    expect(shouldEmail({ reply_to_me: false }, "reply")).toBe(false);
+    expect(shouldEmail({ reply_to_me: true }, "reply")).toBe(true);
+  });
+
+  // A moderation alert reaching somebody who has lost the manager role would
+  // leak comment traffic to a member, so the role is re-checked at send time
+  // rather than trusted from whenever the preference row was written.
+  it("never emails a moderation alert to a non-manager, whatever the switch says", () => {
+    expect(shouldEmail({ manager_comment_alerts: true }, "blog_comment")).toBe(false);
+    expect(shouldEmail({ manager_comment_alerts: true }, "kb_comment")).toBe(false);
+    expect(shouldEmail({ manager_comment_alerts: true }, "blog_comment", { isManager: true })).toBe(
+      true,
+    );
+  });
+
+  it("lets a manager switch moderation alerts off", () => {
+    expect(shouldEmail({ manager_comment_alerts: false }, "kb_comment", { isManager: true })).toBe(
+      false,
+    );
+  });
+
+  it("keeps announcements off for somebody who never opted in", () => {
+    expect(shouldEmail(null, "new_blog_post")).toBe(false);
+    expect(shouldEmail({ new_blog_post: true }, "new_blog_post")).toBe(true);
+  });
+});
+
+describe("badgeCount", () => {
+  it("counts unread activity", () => {
+    expect(badgeCount([], [item(), item({ read_at: "2026-08-06T01:00:00.000Z" })])).toBe(1);
+  });
+
+  // Attention items have no read state, so they can only leave the badge by
+  // being fixed. A badge that went quiet while the club had no sellable
+  // training dates would be worse than no badge.
+  it("counts attention items even though they can never be read", () => {
+    expect(badgeCount([ATTENTION], [item({ read_at: "2026-08-06T01:00:00.000Z" })])).toBe(1);
+    expect(badgeCount([ATTENTION], [item()])).toBe(2);
+  });
+
+  it("is zero when everything is read and nothing needs attention", () => {
+    expect(badgeCount([], [item({ read_at: "2026-08-06T01:00:00.000Z" })])).toBe(0);
+    expect(badgeCount([], [])).toBe(0);
+  });
+});
+
+describe("digestSections", () => {
+  const rows = [
+    item({ kind: "reply" }),
+    item({ kind: "thread_activity" }),
+    item({ kind: "new_blog_post" }),
+    item({ kind: "blog_comment" }),
+    item({ kind: "kb_comment" }),
+  ];
+
+  it("groups the kinds a person wants into their sections", () => {
+    const sections = digestSections(rows, { new_blog_post: true }, { isManager: true });
+    expect(sections.replies).toHaveLength(1);
+    expect(sections.threads).toHaveLength(1);
+    expect(sections.posts).toHaveLength(1);
+    // Both moderation kinds land in one section, matching the single switch.
+    expect(sections.moderation).toHaveLength(2);
+  });
+
+  it("drops the kinds a person has switched off", () => {
+    const sections = digestSections(rows, { thread_activity: false, new_blog_post: false });
+    expect(sections.threads).toHaveLength(0);
+    expect(sections.posts).toHaveLength(0);
+    expect(sections.replies).toHaveLength(1);
+  });
+
+  it("gives a member no moderation section", () => {
+    expect(digestSections(rows, null).moderation).toHaveLength(0);
+  });
+
+  it("leaves a person with everything off nothing to send", () => {
+    const sections = digestSections(rows, {
+      reply_to_me: false,
+      thread_activity: false,
+      new_blog_post: false,
+      manager_comment_alerts: false,
+    });
+    expect(hasDigestContent(sections)).toBe(false);
+  });
+});
+
+describe("hasDigestContent", () => {
+  it("is false for an empty digest, so no email goes out", () => {
+    expect(hasDigestContent({ replies: [], threads: [], posts: [], moderation: [] })).toBe(false);
+  });
+
+  it("is true when any one section has something", () => {
+    expect(hasDigestContent({ replies: [], threads: [], posts: [item()], moderation: [] })).toBe(
+      true,
+    );
+  });
+});
+
+describe("digestItemCount and digestSubject", () => {
+  it("counts across every section", () => {
+    expect(
+      digestItemCount({ replies: [item()], threads: [item()], posts: [], moderation: [item()] }),
+    ).toBe(3);
+  });
+
+  it("says one thing in the singular", () => {
+    const subject = digestSubject("UTS Jitsu", {
+      replies: [item()],
+      threads: [],
+      posts: [],
+      moderation: [],
+    });
+    expect(subject).toBe("1 new thing at UTS Jitsu");
+  });
+
+  it("counts in the plural", () => {
+    const subject = digestSubject("UTS Jitsu", {
+      replies: [item(), item()],
+      threads: [],
+      posts: [],
+      moderation: [],
+    });
+    expect(subject).toBe("2 new things at UTS Jitsu");
+  });
+
+  // Copy rule from AGENTS.md: no em dashes in anything a person reads, and a
+  // subject line is the most-read copy the club writes.
+  it("uses no em dash", () => {
+    const subject = digestSubject("UTS Jitsu", {
+      replies: [item()],
+      threads: [],
+      posts: [],
+      moderation: [],
+    });
+    expect(subject).not.toContain("—");
+  });
+});
+
+describe("threadActivityRecipients", () => {
+  it("never tells you about your own comment", () => {
+    expect(threadActivityRecipients(["a", "b", "c"], { actorId: "b" })).toEqual(["a", "c"]);
+  });
+
+  // Without this the parent's author gets an instant reply email AND a line in
+  // their digest about the same words.
+  it("skips the person already getting a direct reply notification", () => {
+    expect(
+      threadActivityRecipients(["a", "b", "c"], { actorId: "b", directReplyToId: "a" }),
+    ).toEqual(["c"]);
+  });
+
+  it("de-duplicates somebody who commented several times", () => {
+    expect(threadActivityRecipients(["a", "a", "b"], { actorId: "b" })).toEqual(["a"]);
+  });
+
+  it("returns nobody when the writer is the only participant", () => {
+    expect(threadActivityRecipients(["a"], { actorId: "a" })).toEqual([]);
+  });
+});
+
+describe("hrefs", () => {
+  it("anchors a blog comment on its post", () => {
+    expect(blogCommentHref("2026-08-06-a-post", "c1")).toBe("/blog/2026-08-06-a-post#comment-c1");
+  });
+
+  it("anchors a knowledge base comment on its article", () => {
+    expect(kbAnnotationHref("grading", "a1")).toBe("/kb/grading#comment-a1");
+  });
+
+  it("points a post announcement at the post", () => {
+    expect(blogPostHref("a-post")).toBe("/blog/a-post");
+  });
+
+  // The DB CHECK requires `href LIKE '/%'`: these are site-relative because the
+  // email sender prefixes the origin, and a stored absolute URL would bake the
+  // host into rows that outlive it.
+  it("builds site-relative paths", () => {
+    expect(blogCommentHref("s", "c").startsWith("/")).toBe(true);
+    expect(kbAnnotationHref("s", "a").startsWith("/")).toBe(true);
+    expect(blogPostHref("s").startsWith("/")).toBe(true);
+  });
+});
+
+describe("commentPreview", () => {
+  it("leaves a short comment alone", () => {
+    expect(commentPreview("Great class tonight")).toBe("Great class tonight");
+  });
+
+  it("collapses newlines and runs of whitespace", () => {
+    expect(commentPreview("Great\n\n  class   tonight")).toBe("Great class tonight");
+  });
+
+  it("cuts at a word boundary and marks the cut", () => {
+    const preview = commentPreview("alpha bravo charlie delta", 13);
+    expect(preview).toBe("alpha bravo...");
+  });
+
+  it("stays within the limit plus the ellipsis", () => {
+    const preview = commentPreview("x".repeat(400));
+    expect(preview.length).toBeLessThanOrEqual(163);
+  });
+
+  it("handles a single word longer than the limit", () => {
+    expect(commentPreview("y".repeat(20), 5)).toBe("yyyyy...");
+  });
+});

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,250 @@
+// The rules behind the /notifications page, the sidebar badge and the
+// notification emails.
+//
+// Side-effect free and server-import free, like `src/lib/validation.ts`: the
+// server functions and the email sender import from here and do the I/O
+// themselves, so every rule below is unit-testable without a request context.
+//
+// The distinction the whole feature rests on: an ATTENTION item is a standing
+// problem (the club's training dates running out), worked out live and cleared
+// by fixing it, with no read state. An ACTIVITY item is something that
+// happened, stored as a row, unread until somebody looks. They share one badge
+// and nothing else.
+import type { ManagerNotification } from "@/lib/validation";
+
+/** Every kind of activity notification. Matches the `kind` CHECK in the DB. */
+export const notificationKinds = [
+  "reply",
+  "thread_activity",
+  "new_blog_post",
+  "blog_comment",
+  "kb_comment",
+] as const;
+export type NotificationKind = (typeof notificationKinds)[number];
+
+/** The things a notification can be about. Matches the `subject_type` CHECK. */
+export const notificationSubjectTypes = ["blog_comment", "kb_annotation", "blog_post"] as const;
+export type NotificationSubjectType = (typeof notificationSubjectTypes)[number];
+
+/**
+ * The four switches a person sees. Not the same list as `notificationKinds`:
+ * `blog_comment` and `kb_comment` are both manager moderation alerts and share
+ * one switch, because "tell me about new comments" is one decision a manager
+ * makes, not two.
+ */
+export const emailPreferenceKeys = [
+  "reply_to_me",
+  "thread_activity",
+  "new_blog_post",
+  "manager_comment_alerts",
+] as const;
+export type EmailPreferenceKey = (typeof emailPreferenceKeys)[number];
+
+/** The switch that governs whether a given kind is emailed. */
+export const preferenceForKind: Record<NotificationKind, EmailPreferenceKey> = {
+  reply: "reply_to_me",
+  thread_activity: "thread_activity",
+  new_blog_post: "new_blog_post",
+  blog_comment: "manager_comment_alerts",
+  kb_comment: "manager_comment_alerts",
+};
+
+/**
+ * What somebody gets before they have touched anything.
+ *
+ * Replies are on because you started the conversation and answering you is the
+ * one email people expect. Thread activity is on for the same reason, one step
+ * removed, and it only ever reaches people who chose to take part. New-post
+ * announcements are OFF: they are the only kind that would reach somebody who
+ * did nothing to ask for it, and a club that mails a newsletter to everyone who
+ * ever signed a waiver is a club that ends up in spam folders.
+ */
+export const NOTIFICATION_DEFAULTS: Record<EmailPreferenceKey, boolean> = {
+  reply_to_me: true,
+  thread_activity: true,
+  new_blog_post: false,
+  manager_comment_alerts: true,
+};
+
+/** A preferences row as stored: NULL on a switch means "never chose". */
+export type NotificationPreferenceRow = Partial<Record<EmailPreferenceKey, boolean | null>>;
+
+/**
+ * Resolve one switch. A NULL falls back to the club default, which is the whole
+ * point of the column being nullable: "never chose" has to stay distinguishable
+ * from "deliberately off", or changing a default later moves the wrong people.
+ * A missing row behaves as all-NULL, so somebody who has never opened the page
+ * needs no row written before they can be emailed.
+ */
+export function resolveNotificationPreference(
+  row: NotificationPreferenceRow | null | undefined,
+  key: EmailPreferenceKey,
+): boolean {
+  const stored = row?.[key];
+  return stored ?? NOTIFICATION_DEFAULTS[key];
+}
+
+/** All four switches resolved at once, for the settings UI and the digest. */
+export function resolveNotificationPreferences(
+  row: NotificationPreferenceRow | null | undefined,
+): Record<EmailPreferenceKey, boolean> {
+  return {
+    reply_to_me: resolveNotificationPreference(row, "reply_to_me"),
+    thread_activity: resolveNotificationPreference(row, "thread_activity"),
+    new_blog_post: resolveNotificationPreference(row, "new_blog_post"),
+    manager_comment_alerts: resolveNotificationPreference(row, "manager_comment_alerts"),
+  };
+}
+
+/**
+ * Whether a notification of this kind should be EMAILED to this person.
+ *
+ * Note what this does not do: it never suppresses the in-app row. The switches
+ * are about the inbox, so turning email off never costs somebody the record of
+ * what happened.
+ */
+export function shouldEmail(
+  row: NotificationPreferenceRow | null | undefined,
+  kind: NotificationKind,
+  opts: { isManager?: boolean } = {},
+): boolean {
+  const key = preferenceForKind[kind];
+  // A manager alert reaching somebody who is no longer a manager is a leak of
+  // moderation traffic, so the role is re-checked at send time rather than
+  // trusted from whenever the row was written.
+  if (key === "manager_comment_alerts" && !opts.isManager) return false;
+  return resolveNotificationPreference(row, key);
+}
+
+/** An activity row, as the page and the digest read it. */
+export type NotificationItem = {
+  id: string;
+  kind: NotificationKind;
+  title: string;
+  body: string | null;
+  href: string;
+  read_at: string | null;
+  created_at: string;
+};
+
+/**
+ * The one number in the sidebar: open attention items plus unread activity.
+ *
+ * Attention items count even though they can never be marked read. That is
+ * deliberate. They are the things most worth acting on, and a badge that went
+ * quiet while the club had no sellable training dates would be worse than no
+ * badge at all.
+ */
+export function badgeCount(
+  attention: ManagerNotification[],
+  items: Pick<NotificationItem, "read_at">[],
+): number {
+  return attention.length + items.filter((i) => i.read_at === null).length;
+}
+
+/** A digest email, grouped so each section can have its own heading. */
+export type DigestSections = {
+  replies: NotificationItem[];
+  threads: NotificationItem[];
+  posts: NotificationItem[];
+  moderation: NotificationItem[];
+};
+
+/**
+ * Split a person's pending rows into the sections a digest email renders, and
+ * drop the kinds they have switched off.
+ *
+ * `reply` rows appear here only when they were never sent instantly (no API
+ * key configured, a failed send). A reply that already went out is stamped
+ * `emailed_at` at send time and never reaches the digest, so nobody is told
+ * twice about the same comment.
+ */
+export function digestSections(
+  rows: NotificationItem[],
+  prefs: NotificationPreferenceRow | null | undefined,
+  opts: { isManager?: boolean } = {},
+): DigestSections {
+  const allowed = rows.filter((r) => shouldEmail(prefs, r.kind, opts));
+  return {
+    replies: allowed.filter((r) => r.kind === "reply"),
+    threads: allowed.filter((r) => r.kind === "thread_activity"),
+    posts: allowed.filter((r) => r.kind === "new_blog_post"),
+    moderation: allowed.filter((r) => r.kind === "blog_comment" || r.kind === "kb_comment"),
+  };
+}
+
+/** Whether a digest has anything in it. An empty one is not sent. */
+export function hasDigestContent(sections: DigestSections): boolean {
+  return (
+    sections.replies.length > 0 ||
+    sections.threads.length > 0 ||
+    sections.posts.length > 0 ||
+    sections.moderation.length > 0
+  );
+}
+
+/** How many items a digest covers, for the subject line and the logs. */
+export function digestItemCount(sections: DigestSections): number {
+  return (
+    sections.replies.length +
+    sections.threads.length +
+    sections.posts.length +
+    sections.moderation.length
+  );
+}
+
+/**
+ * The subject line. Plain and countable rather than clever: this arrives every
+ * day, so the useful thing is being able to tell at a glance whether it is
+ * worth opening.
+ */
+export function digestSubject(siteName: string, sections: DigestSections): string {
+  const n = digestItemCount(sections);
+  return n === 1 ? `1 new thing at ${siteName}` : `${n} new things at ${siteName}`;
+}
+
+/**
+ * The recipients of a thread-activity notification: everyone who has taken part
+ * except the person who just wrote, and except anyone already being told about
+ * this same comment as a direct reply. Without that second exclusion the author
+ * of the parent comment gets both an instant reply email and a line in their
+ * digest about the same words.
+ */
+export function threadActivityRecipients(
+  participantIds: string[],
+  opts: { actorId: string; directReplyToId?: string | null },
+): string[] {
+  const excluded = new Set([opts.actorId]);
+  if (opts.directReplyToId) excluded.add(opts.directReplyToId);
+  return [...new Set(participantIds)].filter((id) => !excluded.has(id));
+}
+
+/** Where a blog comment lives, for a notification's `href`. */
+export function blogCommentHref(slug: string, commentId: string): string {
+  return `/blog/${slug}#comment-${commentId}`;
+}
+
+/** Where a knowledge base comment lives, for a notification's `href`. */
+export function kbAnnotationHref(slug: string, annotationId: string): string {
+  return `/kb/${slug}#comment-${annotationId}`;
+}
+
+/** Where a published post lives. */
+export function blogPostHref(slug: string): string {
+  return `/blog/${slug}`;
+}
+
+/**
+ * A comment reduced to a preview line for a notification's body.
+ *
+ * Collapses whitespace and cuts at a word boundary, the same shape
+ * `deriveExcerpt` gives a post. Comments are plain text (see docs/blog.md), so
+ * there is no markup to strip.
+ */
+export function commentPreview(body: string, max = 160): string {
+  const flat = body.replace(/\s+/g, " ").trim();
+  if (flat.length <= max) return flat;
+  const cut = flat.slice(0, max);
+  const lastSpace = cut.lastIndexOf(" ");
+  return `${(lastSpace > 0 ? cut.slice(0, lastSpace) : cut).trimEnd()}...`;
+}

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -32,6 +32,10 @@ import {
   isPaperWaiver,
   isUtsStudent,
   managerEmailChangeSchema,
+  markNotificationsReadSchema,
+  notificationPreferencesByTokenSchema,
+  notificationPreferencesSchema,
+  notificationTokenSchema,
   MAX_SCAN_BYTES,
   base64ByteLength,
   normalizeEmail,
@@ -209,6 +213,91 @@ describe("blogCommentSchema", () => {
 describe("blockCommenterSchema", () => {
   it("requires a valid user id to block someone", () => {
     expect(() => blockCommenterSchema.parse({ user_id: "not-a-uuid" })).toThrow();
+  });
+});
+
+describe("notificationPreferencesSchema", () => {
+  it("accepts a switch being turned on or off", () => {
+    expect(notificationPreferencesSchema.parse({ new_blog_post: true }).new_blog_post).toBe(true);
+    expect(notificationPreferencesSchema.parse({ reply_to_me: false }).reply_to_me).toBe(false);
+  });
+
+  // `null` is a real value here, not a missing one: it hands the switch back to
+  // the club default. If this ever became `.nullish()`, "use the default" and
+  // "leave it alone" would collapse into each other and clearing a switch would
+  // silently do nothing.
+  it("allows handing a switch back to the club default with null", () => {
+    expect(notificationPreferencesSchema.parse({ reply_to_me: null }).reply_to_me).toBeNull();
+  });
+
+  it("keeps an absent key distinct from an explicit null", () => {
+    const parsed = notificationPreferencesSchema.parse({ reply_to_me: null });
+    expect("reply_to_me" in parsed).toBe(true);
+    expect("thread_activity" in parsed).toBe(false);
+  });
+
+  it("accepts an empty patch, which changes nothing", () => {
+    expect(notificationPreferencesSchema.parse({})).toEqual({});
+  });
+
+  it("rejects a non-boolean switch", () => {
+    expect(() => notificationPreferencesSchema.parse({ reply_to_me: "yes" })).toThrow();
+    expect(() => notificationPreferencesSchema.parse({ new_blog_post: 1 })).toThrow();
+  });
+});
+
+describe("notificationPreferencesByTokenSchema", () => {
+  // The token IS the authentication on this path, so it can never be optional.
+  it("requires a token", () => {
+    expect(() => notificationPreferencesByTokenSchema.parse({ reply_to_me: false })).toThrow();
+  });
+
+  it("carries the same switches as the signed-in patch", () => {
+    const parsed = notificationPreferencesByTokenSchema.parse({
+      token: "utsj_abc123",
+      new_blog_post: true,
+    });
+    expect(parsed).toEqual({ token: "utsj_abc123", new_blog_post: true });
+  });
+
+  it("rejects a blank token", () => {
+    expect(() => notificationPreferencesByTokenSchema.parse({ token: "   " })).toThrow();
+  });
+});
+
+describe("notificationTokenSchema", () => {
+  it("trims the token, so a copied link with stray whitespace still works", () => {
+    expect(notificationTokenSchema.parse({ token: " utsj_abc " }).token).toBe("utsj_abc");
+  });
+
+  it("rejects an empty token", () => {
+    expect(() => notificationTokenSchema.parse({ token: "" })).toThrow();
+  });
+
+  // Bounded so a hostile caller cannot make the server hash a megabyte.
+  it("rejects an absurdly long token", () => {
+    expect(() => notificationTokenSchema.parse({ token: "x".repeat(201) })).toThrow();
+  });
+});
+
+describe("markNotificationsReadSchema", () => {
+  // An absent list means "all of mine", which is what "Mark all as read" sends.
+  it("allows an absent list", () => {
+    expect(markNotificationsReadSchema.parse({}).ids).toBeUndefined();
+  });
+
+  it("accepts a list of ids", () => {
+    const ids = ["11111111-1111-4111-8111-111111111111"];
+    expect(markNotificationsReadSchema.parse({ ids }).ids).toEqual(ids);
+  });
+
+  it("rejects an id that is not a uuid", () => {
+    expect(() => markNotificationsReadSchema.parse({ ids: ["nope"] })).toThrow();
+  });
+
+  it("rejects an unbounded list", () => {
+    const ids = Array.from({ length: 201 }, () => "11111111-1111-4111-8111-111111111111");
+    expect(() => markNotificationsReadSchema.parse({ ids })).toThrow();
   });
 });
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -2238,6 +2238,53 @@ export type BlockCommenterInput = z.infer<typeof blockCommenterSchema>;
 export const unblockCommenterSchema = z.object({ user_id: z.string().uuid() });
 export type UnblockCommenterInput = z.infer<typeof unblockCommenterSchema>;
 
+// ---- Notifications ----
+//
+// The /notifications page and the email switches behind it. The kinds and the
+// defaults live in `src/lib/notifications.ts` (pure, and imported by the email
+// sender too); this file only validates what crosses the wire.
+
+/** The four switches, as the settings UI sends them.
+ *
+ * Every key is optional and every value is `boolean | null`, which is the whole
+ * point: `null` is a real, meaningful value here meaning "no longer a choice of
+ * mine, use the club default", not an absent field. So this deliberately uses
+ * `.nullable().optional()` rather than `.nullish()` — an absent key means
+ * "leave that switch alone", the same convention `updateProfileSchema` uses,
+ * and collapsing the two would make clearing a switch impossible to express. */
+export const notificationPreferencesSchema = z.object({
+  reply_to_me: z.boolean().nullable().optional(),
+  thread_activity: z.boolean().nullable().optional(),
+  new_blog_post: z.boolean().nullable().optional(),
+  manager_comment_alerts: z.boolean().nullable().optional(),
+});
+export type NotificationPreferencesInput = z.infer<typeof notificationPreferencesSchema>;
+
+/** The same patch, arriving from the signed-out settings link in an email
+ * footer. The token IS the authentication, so it is required and the handler
+ * resolves the person from it rather than from a session. */
+export const notificationPreferencesByTokenSchema = notificationPreferencesSchema.extend({
+  token: z.string().trim().min(1).max(200),
+});
+export type NotificationPreferencesByTokenInput = z.infer<
+  typeof notificationPreferencesByTokenSchema
+>;
+
+/** Read the switches behind a footer link, before anything is changed. */
+export const notificationTokenSchema = z.object({
+  token: z.string().trim().min(1).max(200),
+});
+export type NotificationTokenInput = z.infer<typeof notificationTokenSchema>;
+
+/** Mark notifications read. An empty/absent list means "all of mine", which is
+ * what the "Mark all as read" button sends; naming ids is what opening the page
+ * sends, so a notification that arrived while the page was open is not marked
+ * read without ever having been on screen. */
+export const markNotificationsReadSchema = z.object({
+  ids: z.array(z.string().uuid()).max(200).optional(),
+});
+export type MarkNotificationsReadInput = z.infer<typeof markNotificationsReadSchema>;
+
 // ---- Account: the details a member maintains themselves ----
 
 /**

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -32,8 +32,10 @@ import { Route as UpdatePasswordRouteImport } from './routes/update-password'
 import { Route as WaiverRouteImport } from './routes/waiver'
 import { Route as AuthenticatedAccountRouteImport } from './routes/_authenticated/account'
 import { Route as AuthenticatedMembershipRouteImport } from './routes/_authenticated/membership'
+import { Route as AuthenticatedNotificationsRouteImport } from './routes/_authenticated/notifications'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
+import { Route as EmailSettingsTokenRouteImport } from './routes/email-settings/$token'
 import { Route as KbIndexRouteImport } from './routes/kb/index'
 import { Route as KbSlugRouteImport } from './routes/kb/$slug'
 import { Route as AuthenticatedManagerIndexRouteImport } from './routes/_authenticated/manager.index'
@@ -52,6 +54,7 @@ import { Route as AuthenticatedManagerWaiverTemplateRouteImport } from './routes
 import { Route as AuthenticatedManagerWaiversRouteImport } from './routes/_authenticated/manager.waivers'
 import { Route as ApiCalendarTokenRouteImport } from './routes/api/calendar/$token'
 import { Route as ApiManagerAgentRouteImport } from './routes/api/manager/agent'
+import { Route as ApiNotificationsDigestRouteImport } from './routes/api/notifications/digest'
 import { Route as ApiVerifyEmailTokenRouteImport } from './routes/api/verify-email/$token'
 import { Route as AuthenticatedManagerBlogIdRouteImport } from './routes/_authenticated/manager.blog_.$id'
 import { Route as AuthenticatedManagerBlogNewRouteImport } from './routes/_authenticated/manager.blog_.new'
@@ -174,6 +177,12 @@ const AuthenticatedMembershipRoute = AuthenticatedMembershipRouteImport.update({
   path: '/membership',
   getParentRoute: () => AuthenticatedRouteRoute,
 } as any)
+const AuthenticatedNotificationsRoute =
+  AuthenticatedNotificationsRouteImport.update({
+    id: '/notifications',
+    path: '/notifications',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const BlogIndexRoute = BlogIndexRouteImport.update({
   id: '/blog/',
   path: '/blog/',
@@ -182,6 +191,11 @@ const BlogIndexRoute = BlogIndexRouteImport.update({
 const BlogSlugRoute = BlogSlugRouteImport.update({
   id: '/blog/$slug',
   path: '/blog/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const EmailSettingsTokenRoute = EmailSettingsTokenRouteImport.update({
+  id: '/email-settings/$token',
+  path: '/email-settings/$token',
   getParentRoute: () => rootRouteImport,
 } as any)
 const KbIndexRoute = KbIndexRouteImport.update({
@@ -287,6 +301,11 @@ const ApiManagerAgentRoute = ApiManagerAgentRouteImport.update({
   path: '/api/manager/agent',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiNotificationsDigestRoute = ApiNotificationsDigestRouteImport.update({
+  id: '/api/notifications/digest',
+  path: '/api/notifications/digest',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiVerifyEmailTokenRoute = ApiVerifyEmailTokenRouteImport.update({
   id: '/api/verify-email/$token',
   path: '/api/verify-email/$token',
@@ -350,7 +369,9 @@ export interface FileRoutesByFullPath {
   '/waiver': typeof WaiverRoute
   '/account': typeof AuthenticatedAccountRoute
   '/membership': typeof AuthenticatedMembershipRoute
+  '/notifications': typeof AuthenticatedNotificationsRoute
   '/blog/$slug': typeof BlogSlugRoute
+  '/email-settings/$token': typeof EmailSettingsTokenRoute
   '/kb/$slug': typeof KbSlugRoute
   '/blog/': typeof BlogIndexRoute
   '/kb/': typeof KbIndexRoute
@@ -369,6 +390,7 @@ export interface FileRoutesByFullPath {
   '/manager/waivers': typeof AuthenticatedManagerWaiversRoute
   '/api/calendar/$token': typeof ApiCalendarTokenRoute
   '/api/manager/agent': typeof ApiManagerAgentRoute
+  '/api/notifications/digest': typeof ApiNotificationsDigestRoute
   '/api/verify-email/$token': typeof ApiVerifyEmailTokenRoute
   '/manager/': typeof AuthenticatedManagerIndexRoute
   '/manager/blog/$id': typeof AuthenticatedManagerBlogIdRoute
@@ -400,7 +422,9 @@ export interface FileRoutesByTo {
   '/waiver': typeof WaiverRoute
   '/account': typeof AuthenticatedAccountRoute
   '/membership': typeof AuthenticatedMembershipRoute
+  '/notifications': typeof AuthenticatedNotificationsRoute
   '/blog/$slug': typeof BlogSlugRoute
+  '/email-settings/$token': typeof EmailSettingsTokenRoute
   '/kb/$slug': typeof KbSlugRoute
   '/blog': typeof BlogIndexRoute
   '/kb': typeof KbIndexRoute
@@ -419,6 +443,7 @@ export interface FileRoutesByTo {
   '/manager/waivers': typeof AuthenticatedManagerWaiversRoute
   '/api/calendar/$token': typeof ApiCalendarTokenRoute
   '/api/manager/agent': typeof ApiManagerAgentRoute
+  '/api/notifications/digest': typeof ApiNotificationsDigestRoute
   '/api/verify-email/$token': typeof ApiVerifyEmailTokenRoute
   '/manager': typeof AuthenticatedManagerIndexRoute
   '/manager/blog/$id': typeof AuthenticatedManagerBlogIdRoute
@@ -453,7 +478,9 @@ export interface FileRoutesById {
   '/waiver': typeof WaiverRoute
   '/_authenticated/account': typeof AuthenticatedAccountRoute
   '/_authenticated/membership': typeof AuthenticatedMembershipRoute
+  '/_authenticated/notifications': typeof AuthenticatedNotificationsRoute
   '/blog/$slug': typeof BlogSlugRoute
+  '/email-settings/$token': typeof EmailSettingsTokenRoute
   '/kb/$slug': typeof KbSlugRoute
   '/blog/': typeof BlogIndexRoute
   '/kb/': typeof KbIndexRoute
@@ -472,6 +499,7 @@ export interface FileRoutesById {
   '/_authenticated/manager/waivers': typeof AuthenticatedManagerWaiversRoute
   '/api/calendar/$token': typeof ApiCalendarTokenRoute
   '/api/manager/agent': typeof ApiManagerAgentRoute
+  '/api/notifications/digest': typeof ApiNotificationsDigestRoute
   '/api/verify-email/$token': typeof ApiVerifyEmailTokenRoute
   '/_authenticated/manager/': typeof AuthenticatedManagerIndexRoute
   '/_authenticated/manager/blog_/$id': typeof AuthenticatedManagerBlogIdRoute
@@ -506,7 +534,9 @@ export interface FileRouteTypes {
     | '/waiver'
     | '/account'
     | '/membership'
+    | '/notifications'
     | '/blog/$slug'
+    | '/email-settings/$token'
     | '/kb/$slug'
     | '/blog/'
     | '/kb/'
@@ -525,6 +555,7 @@ export interface FileRouteTypes {
     | '/manager/waivers'
     | '/api/calendar/$token'
     | '/api/manager/agent'
+    | '/api/notifications/digest'
     | '/api/verify-email/$token'
     | '/manager/'
     | '/manager/blog/$id'
@@ -556,7 +587,9 @@ export interface FileRouteTypes {
     | '/waiver'
     | '/account'
     | '/membership'
+    | '/notifications'
     | '/blog/$slug'
+    | '/email-settings/$token'
     | '/kb/$slug'
     | '/blog'
     | '/kb'
@@ -575,6 +608,7 @@ export interface FileRouteTypes {
     | '/manager/waivers'
     | '/api/calendar/$token'
     | '/api/manager/agent'
+    | '/api/notifications/digest'
     | '/api/verify-email/$token'
     | '/manager'
     | '/manager/blog/$id'
@@ -608,7 +642,9 @@ export interface FileRouteTypes {
     | '/waiver'
     | '/_authenticated/account'
     | '/_authenticated/membership'
+    | '/_authenticated/notifications'
     | '/blog/$slug'
+    | '/email-settings/$token'
     | '/kb/$slug'
     | '/blog/'
     | '/kb/'
@@ -627,6 +663,7 @@ export interface FileRouteTypes {
     | '/_authenticated/manager/waivers'
     | '/api/calendar/$token'
     | '/api/manager/agent'
+    | '/api/notifications/digest'
     | '/api/verify-email/$token'
     | '/_authenticated/manager/'
     | '/_authenticated/manager/blog_/$id'
@@ -660,9 +697,11 @@ export interface RootRouteChildren {
   UpdatePasswordRoute: typeof UpdatePasswordRoute
   WaiverRoute: typeof WaiverRoute
   BlogSlugRoute: typeof BlogSlugRoute
+  EmailSettingsTokenRoute: typeof EmailSettingsTokenRoute
   BlogIndexRoute: typeof BlogIndexRoute
   ApiCalendarTokenRoute: typeof ApiCalendarTokenRoute
   ApiManagerAgentRoute: typeof ApiManagerAgentRoute
+  ApiNotificationsDigestRoute: typeof ApiNotificationsDigestRoute
   ApiVerifyEmailTokenRoute: typeof ApiVerifyEmailTokenRoute
   LovableEmailAuthPreviewRoute: typeof LovableEmailAuthPreviewRoute
   LovableEmailAuthWebhookRoute: typeof LovableEmailAuthWebhookRoute
@@ -831,6 +870,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedMembershipRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/notifications': {
+      id: '/_authenticated/notifications'
+      path: '/notifications'
+      fullPath: '/notifications'
+      preLoaderRoute: typeof AuthenticatedNotificationsRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/blog/': {
       id: '/blog/'
       path: '/blog'
@@ -843,6 +889,13 @@ declare module '@tanstack/react-router' {
       path: '/blog/$slug'
       fullPath: '/blog/$slug'
       preLoaderRoute: typeof BlogSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/email-settings/$token': {
+      id: '/email-settings/$token'
+      path: '/email-settings/$token'
+      fullPath: '/email-settings/$token'
+      preLoaderRoute: typeof EmailSettingsTokenRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/kb/': {
@@ -971,6 +1024,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiManagerAgentRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/notifications/digest': {
+      id: '/api/notifications/digest'
+      path: '/api/notifications/digest'
+      fullPath: '/api/notifications/digest'
+      preLoaderRoute: typeof ApiNotificationsDigestRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/verify-email/$token': {
       id: '/api/verify-email/$token'
       path: '/api/verify-email/$token'
@@ -1026,6 +1086,7 @@ declare module '@tanstack/react-router' {
 interface AuthenticatedRouteRouteChildren {
   AuthenticatedAccountRoute: typeof AuthenticatedAccountRoute
   AuthenticatedMembershipRoute: typeof AuthenticatedMembershipRoute
+  AuthenticatedNotificationsRoute: typeof AuthenticatedNotificationsRoute
   AuthenticatedManagerApiTokensRoute: typeof AuthenticatedManagerApiTokensRoute
   AuthenticatedManagerBlogRoute: typeof AuthenticatedManagerBlogRoute
   AuthenticatedManagerBlogCommentsRoute: typeof AuthenticatedManagerBlogCommentsRoute
@@ -1049,6 +1110,7 @@ interface AuthenticatedRouteRouteChildren {
 const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedAccountRoute: AuthenticatedAccountRoute,
   AuthenticatedMembershipRoute: AuthenticatedMembershipRoute,
+  AuthenticatedNotificationsRoute: AuthenticatedNotificationsRoute,
   AuthenticatedManagerApiTokensRoute: AuthenticatedManagerApiTokensRoute,
   AuthenticatedManagerBlogRoute: AuthenticatedManagerBlogRoute,
   AuthenticatedManagerBlogCommentsRoute: AuthenticatedManagerBlogCommentsRoute,
@@ -1112,9 +1174,11 @@ const rootRouteChildren: RootRouteChildren = {
   UpdatePasswordRoute: UpdatePasswordRoute,
   WaiverRoute: WaiverRoute,
   BlogSlugRoute: BlogSlugRoute,
+  EmailSettingsTokenRoute: EmailSettingsTokenRoute,
   BlogIndexRoute: BlogIndexRoute,
   ApiCalendarTokenRoute: ApiCalendarTokenRoute,
   ApiManagerAgentRoute: ApiManagerAgentRoute,
+  ApiNotificationsDigestRoute: ApiNotificationsDigestRoute,
   ApiVerifyEmailTokenRoute: ApiVerifyEmailTokenRoute,
   LovableEmailAuthPreviewRoute: LovableEmailAuthPreviewRoute,
   LovableEmailAuthWebhookRoute: LovableEmailAuthWebhookRoute,

--- a/src/routes/_authenticated/manager.index.tsx
+++ b/src/routes/_authenticated/manager.index.tsx
@@ -1,12 +1,8 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
-import { useServerFn } from "@tanstack/react-start";
-import { toast } from "sonner";
+import { useEffect } from "react";
 import { BellRing } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { managerNotifications } from "@/lib/membership.functions";
-import type { ManagerNotification } from "@/lib/validation";
 import { useAuth, useRoles } from "@/hooks/useAuth";
 
 export const Route = createFileRoute("/_authenticated/manager/")({
@@ -20,27 +16,10 @@ function ManagerDashboard() {
   const navigate = useNavigate();
   const { user } = useAuth();
   const { isManager, loading: rolesLoading } = useRoles(user?.id);
-  const fetchNotifications = useServerFn(managerNotifications);
-
-  const [notifications, setNotifications] = useState<ManagerNotification[]>([]);
-  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (!rolesLoading && user && !isManager) navigate({ to: "/account" });
   }, [rolesLoading, isManager, user, navigate]);
-
-  useEffect(() => {
-    if (!isManager) return;
-    fetchNotifications()
-      .then((data) => {
-        setNotifications(data);
-        setLoading(false);
-      })
-      .catch((e) => {
-        toast.error(e instanceof Error ? e.message : "Failed to load notifications");
-        setLoading(false);
-      });
-  }, [isManager, fetchNotifications]);
 
   return (
     <>
@@ -52,35 +31,24 @@ function ManagerDashboard() {
           </p>
         </div>
 
+        {/* The attention list itself now lives on /notifications, alongside
+            comment activity, so a manager has one queue rather than two. This
+            card is the signpost to it and deliberately keeps no copy of the
+            items: two places rendering the same list is how they drift. */}
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <BellRing className="h-5 w-5" />
               Needs attention
             </CardTitle>
-            <CardDescription>Things only a manager can fix.</CardDescription>
+            <CardDescription>
+              Things only a manager can fix, plus new comments, all on one page.
+            </CardDescription>
           </CardHeader>
           <CardContent>
-            {loading && <p className="text-sm text-muted-foreground">Loading...</p>}
-            {!loading && notifications.length === 0 && (
-              <p className="text-sm text-muted-foreground">All quiet. Nothing needs doing.</p>
-            )}
-            <div className="space-y-3">
-              {notifications.map((n, i) => (
-                <div
-                  key={`${n.type}-${i}`}
-                  className="flex flex-wrap items-start justify-between gap-3 rounded-lg border bg-card p-4"
-                >
-                  <div>
-                    <p className="font-medium">{n.title}</p>
-                    <p className="mt-1 text-sm text-muted-foreground">{n.body}</p>
-                  </div>
-                  <Button asChild size="sm" variant="outline">
-                    <Link to={n.href}>Fix it</Link>
-                  </Button>
-                </div>
-              ))}
-            </div>
+            <Button asChild>
+              <Link to="/notifications">Open notifications</Link>
+            </Button>
           </CardContent>
         </Card>
 

--- a/src/routes/_authenticated/notifications.test.tsx
+++ b/src/routes/_authenticated/notifications.test.tsx
@@ -1,0 +1,215 @@
+// `/notifications` merges two things that look alike and behave differently, and
+// that difference is what these cases pin.
+//
+// An ATTENTION item is a standing problem: it clears by being fixed, so it has
+// no read control at all. An ACTIVITY item is something that happened, and is
+// marked read by opening the page. Blur the two and a manager gains a button
+// that hides an unfixed problem, which is exactly the failure the split exists
+// to prevent.
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const markNotificationsRead = vi.fn().mockResolvedValue({ ok: true, marked: 0 });
+const saveMyNotificationPreferences = vi.fn();
+const useNotifications = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => opts,
+  Link: ({ to, children }: { to: string; children: ReactNode }) => <a href={to}>{children}</a>,
+}));
+
+vi.mock("@tanstack/react-start", () => ({
+  useServerFn: (fn: unknown) => fn,
+}));
+
+vi.mock("@/lib/notifications.functions", () => ({
+  markNotificationsRead: (...args: unknown[]) => markNotificationsRead(...args),
+  saveMyNotificationPreferences: (...args: unknown[]) => saveMyNotificationPreferences(...args),
+}));
+
+vi.mock("@/hooks/useNotifications", () => ({
+  useNotifications: () => useNotifications(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const { Route } = await import("./notifications");
+const NotificationsPage = (Route as unknown as { component: () => ReactNode }).component;
+
+const ATTENTION = {
+  type: "define_membership_window" as const,
+  title: "Set up the club's training dates",
+  body: "Members cannot join as members until the club's training dates are set.",
+  href: "/manager/membership-plans",
+};
+
+const PREFERENCES = {
+  reply_to_me: true,
+  thread_activity: true,
+  new_blog_post: false,
+  manager_comment_alerts: true,
+};
+
+function activity(over: Record<string, unknown> = {}) {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    kind: "reply" as const,
+    title: "Jane L. replied to you",
+    body: "See you Tuesday",
+    href: "/blog/a-post#comment-1",
+    read_at: null,
+    created_at: new Date().toISOString(),
+    ...over,
+  };
+}
+
+function mockPayload(over: Record<string, unknown> = {}) {
+  useNotifications.mockReturnValue({
+    data: {
+      attention: [],
+      items: [],
+      preferences: PREFERENCES,
+      isManager: false,
+      ...over,
+    },
+    loading: false,
+    failed: false,
+    badge: 0,
+    refresh: vi.fn(),
+  });
+}
+
+describe("/notifications", () => {
+  beforeEach(() => {
+    markNotificationsRead.mockClear();
+    saveMyNotificationPreferences.mockClear();
+    saveMyNotificationPreferences.mockResolvedValue(PREFERENCES);
+    useNotifications.mockReset();
+  });
+
+  it("lists activity with a link to what happened", async () => {
+    mockPayload({ items: [activity()] });
+    render(<NotificationsPage />);
+
+    expect(await screen.findByText("Jane L. replied to you")).toBeInTheDocument();
+    expect(screen.getByText("See you Tuesday")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Jane L\. replied to you/ })).toHaveAttribute(
+      "href",
+      "/blog/a-post#comment-1",
+    );
+  });
+
+  it("marks the notifications that were on screen read when the page opens", async () => {
+    mockPayload({ items: [activity()] });
+    render(<NotificationsPage />);
+
+    await waitFor(() => expect(markNotificationsRead).toHaveBeenCalled());
+    // By id, not "all of mine": a notification arriving while somebody is
+    // reading must not be marked read without ever having been seen.
+    expect(markNotificationsRead).toHaveBeenCalledWith({
+      data: { ids: ["11111111-1111-4111-8111-111111111111"] },
+    });
+  });
+
+  it("does not call the server when everything is already read", async () => {
+    mockPayload({ items: [activity({ read_at: "2026-08-06T01:00:00.000Z" })] });
+    render(<NotificationsPage />);
+
+    await screen.findByText("Jane L. replied to you");
+    expect(markNotificationsRead).not.toHaveBeenCalled();
+  });
+
+  // The core of the split. An attention item cannot be dismissed, so the only
+  // control it offers is the one that takes you to fix it.
+  it("gives an attention item somewhere to go and no way to mark it read", async () => {
+    mockPayload({ attention: [ATTENTION], isManager: true });
+    render(<NotificationsPage />);
+
+    expect(await screen.findByText("Set up the club's training dates")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /fix it/i })).toHaveAttribute(
+      "href",
+      "/manager/membership-plans",
+    );
+    // "Mark all as read" belongs to Activity, and there is no unread activity
+    // here, so an attention item on its own must not summon it.
+    expect(screen.queryByRole("button", { name: /mark all as read/i })).not.toBeInTheDocument();
+  });
+
+  it("offers to mark activity read only while something is unread", async () => {
+    mockPayload({ items: [activity({ read_at: "2026-08-06T01:00:00.000Z" })] });
+    const { unmount } = render(<NotificationsPage />);
+    await screen.findByText("Jane L. replied to you");
+    expect(screen.queryByRole("button", { name: /mark all as read/i })).not.toBeInTheDocument();
+    unmount();
+
+    mockPayload({ items: [activity()] });
+    render(<NotificationsPage />);
+    expect(await screen.findByRole("button", { name: /mark all as read/i })).toBeInTheDocument();
+  });
+
+  it("shows a member no moderation switch", async () => {
+    mockPayload();
+    render(<NotificationsPage />);
+
+    expect(await screen.findByLabelText("Someone replies to me")).toBeInTheDocument();
+    expect(screen.queryByLabelText("New comments to review")).not.toBeInTheDocument();
+  });
+
+  it("shows a manager the moderation switch", async () => {
+    mockPayload({ isManager: true });
+    render(<NotificationsPage />);
+
+    expect(await screen.findByLabelText("New comments to review")).toBeInTheDocument();
+  });
+
+  it("saves only the switch that was flipped", async () => {
+    mockPayload();
+    render(<NotificationsPage />);
+
+    await userEvent.click(await screen.findByLabelText("A new blog post goes up"));
+
+    await waitFor(() => expect(saveMyNotificationPreferences).toHaveBeenCalled());
+    // One key, not the whole set: a page that sent all four could blank a
+    // choice it never rendered.
+    expect(saveMyNotificationPreferences).toHaveBeenCalledWith({ data: { new_blog_post: true } });
+  });
+
+  it("puts a switch back when the save fails", async () => {
+    mockPayload();
+    saveMyNotificationPreferences.mockRejectedValue(new Error("nope"));
+    render(<NotificationsPage />);
+
+    const toggle = await screen.findByLabelText("Someone replies to me");
+    expect(toggle).toBeChecked();
+    await userEvent.click(toggle);
+
+    // The save really was attempted, so the assertion below is about the
+    // revert rather than about a click that never registered.
+    await waitFor(() =>
+      expect(saveMyNotificationPreferences).toHaveBeenCalledWith({ data: { reply_to_me: false } }),
+    );
+    // Optimistic while in flight, reverted once the failure lands. Leaving it
+    // flipped would tell somebody they had turned replies off when they had not.
+    await waitFor(() => expect(toggle).toBeChecked());
+  });
+
+  // A failed fetch is NOT "you have nothing waiting". Saying "all caught up"
+  // over a dropped connection is the one thing this page must not do.
+  it("says so honestly when it could not load", async () => {
+    useNotifications.mockReturnValue({
+      data: undefined,
+      loading: false,
+      failed: true,
+      badge: 0,
+      refresh: vi.fn(),
+    });
+    render(<NotificationsPage />);
+
+    expect(await screen.findByText(/couldn't load your notifications/i)).toBeInTheDocument();
+    expect(screen.queryByText(/all caught up/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/routes/_authenticated/notifications.tsx
+++ b/src/routes/_authenticated/notifications.tsx
@@ -1,0 +1,215 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useServerFn } from "@tanstack/react-start";
+import { toast } from "sonner";
+import { AlertTriangle, Bell } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { NotificationSwitches } from "@/components/site/NotificationSwitches";
+import { useNotifications } from "@/hooks/useNotifications";
+import type { EmailPreferenceKey } from "@/lib/notifications";
+import {
+  markNotificationsRead,
+  saveMyNotificationPreferences,
+} from "@/lib/notifications.functions";
+
+export const Route = createFileRoute("/_authenticated/notifications")({
+  head: () => ({
+    meta: [{ title: "Notifications | UTS Jitsu" }, { name: "robots", content: "noindex" }],
+  }),
+  component: NotificationsPage,
+});
+
+function timeAgo(iso: string, now = Date.now()): string {
+  const seconds = Math.max(0, Math.round((now - new Date(iso).getTime()) / 1000));
+  if (seconds < 60) return "just now";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+function NotificationsPage() {
+  const { data, loading, failed, badge, refresh } = useNotifications();
+  const markRead = useServerFn(markNotificationsRead);
+  const savePrefs = useServerFn(saveMyNotificationPreferences);
+
+  const [prefs, setPrefs] = useState<Record<EmailPreferenceKey, boolean> | null>(null);
+  const [savingPrefs, setSavingPrefs] = useState(false);
+  // Opening the page marks read exactly once, for the rows that were on screen
+  // when it loaded. A notification that arrives while somebody is reading must
+  // not be marked read without ever having been seen.
+  const markedOnOpen = useRef(false);
+
+  useEffect(() => {
+    if (data && prefs === null) setPrefs(data.preferences);
+  }, [data, prefs]);
+
+  useEffect(() => {
+    if (!data || markedOnOpen.current) return;
+    const unread = data.items.filter((i) => i.read_at === null).map((i) => i.id);
+    markedOnOpen.current = true;
+    if (unread.length === 0) return;
+    markRead({ data: { ids: unread } })
+      .then(() => refresh())
+      // Silent on failure: the notifications are all still on screen and the
+      // only cost is a badge that clears on the next load. An error toast for
+      // something the reader did not ask for would be noise.
+      .catch(() => {});
+  }, [data, markRead, refresh]);
+
+  const markAll = useCallback(() => {
+    markRead({ data: {} })
+      .then(() => refresh())
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Could not mark those read."));
+  }, [markRead, refresh]);
+
+  const onSwitch = useCallback(
+    (key: EmailPreferenceKey, next: boolean) => {
+      // Optimistic: a switch that waits for a round trip before moving feels
+      // broken. Reverted below if the save fails.
+      const previous = prefs;
+      setPrefs((p) => (p ? { ...p, [key]: next } : p));
+      setSavingPrefs(true);
+      savePrefs({ data: { [key]: next } })
+        .then((saved) => setPrefs(saved))
+        .catch((e) => {
+          setPrefs(previous);
+          toast.error(e instanceof Error ? e.message : "Could not save that.");
+        })
+        .finally(() => setSavingPrefs(false));
+    },
+    [prefs, savePrefs],
+  );
+
+  return (
+    <section className="mx-auto max-w-3xl space-y-6 px-4 py-10">
+      <div>
+        <h1 className="text-3xl font-black">Notifications</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          What has happened, and what needs doing.
+        </p>
+      </div>
+
+      {failed && (
+        <Card>
+          <CardHeader>
+            <CardTitle>We couldn't load your notifications</CardTitle>
+            <CardDescription>
+              Nothing is lost. This is usually a dropped connection, so try again.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button onClick={refresh}>Try again</Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Standing problems. No read control on purpose: these clear by being
+          fixed, and a "mark read" button would let a manager hide something
+          that is still broken. */}
+      {data && data.attention.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5" />
+              Needs attention
+            </CardTitle>
+            <CardDescription>
+              Things only a manager can fix. They clear themselves once they are sorted.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {data.attention.map((n, i) => (
+              <div
+                key={`${n.type}-${i}`}
+                className="flex flex-wrap items-start justify-between gap-3 rounded-lg border bg-card p-4"
+              >
+                <div>
+                  <p className="font-medium">{n.title}</p>
+                  <p className="mt-1 text-sm text-muted-foreground">{n.body}</p>
+                </div>
+                <Button asChild size="sm" variant="outline">
+                  <Link to={n.href}>Fix it</Link>
+                </Button>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+          <div className="space-y-1.5">
+            <CardTitle className="flex items-center gap-2">
+              <Bell className="h-5 w-5" />
+              Activity
+            </CardTitle>
+            <CardDescription>Replies, threads you are in, and new posts.</CardDescription>
+          </div>
+          {data && data.items.some((i) => i.read_at === null) && (
+            <Button size="sm" variant="ghost" onClick={markAll}>
+              Mark all as read
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          {loading && <p className="text-sm text-muted-foreground">Loading...</p>}
+          {data && data.items.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              Nothing yet. Replies to your comments will show up here.
+            </p>
+          )}
+          <div className="space-y-2">
+            {data?.items.map((item) => (
+              <Link
+                key={item.id}
+                to={item.href}
+                className={
+                  item.read_at === null
+                    ? "block rounded-lg border border-primary/40 bg-accent/40 p-4 transition-colors hover:bg-accent"
+                    : "block rounded-lg border p-4 transition-colors hover:bg-accent/50"
+                }
+              >
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <p className="font-medium">{item.title}</p>
+                  <span className="text-xs text-muted-foreground">{timeAgo(item.created_at)}</span>
+                </div>
+                {item.body && <p className="mt-1 text-sm text-muted-foreground">{item.body}</p>}
+              </Link>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Email</CardTitle>
+          <CardDescription>Choose what reaches your inbox. Change it any time.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {prefs ? (
+            <NotificationSwitches
+              values={prefs}
+              onChange={onSwitch}
+              disabled={savingPrefs}
+              isManager={data?.isManager}
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">Loading...</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Only rendered once loaded, so it never says "0 waiting" while the
+          count is still unknown. */}
+      {data && badge === 0 && (
+        <p className="text-center text-sm text-muted-foreground">All caught up.</p>
+      )}
+    </section>
+  );
+}

--- a/src/routes/_authenticated/notifications.tsx
+++ b/src/routes/_authenticated/notifications.tsx
@@ -164,11 +164,18 @@ function NotificationsPage() {
               Nothing yet. Replies to your comments will show up here.
             </p>
           )}
+          {/* A plain anchor, not a router `Link`, for two reasons. These hrefs
+              carry a fragment (`/blog/<slug>#comment-<id>`) that `Link` expects
+              as a separate `hash` prop rather than inside `to`. And they come
+              out of the DATABASE, not the route table: a row written by an
+              older version of the app can name a path that no longer exists,
+              which an anchor turns into the router's own not-found page instead
+              of throwing on the notifications page itself. */}
           <div className="space-y-2">
             {data?.items.map((item) => (
-              <Link
+              <a
                 key={item.id}
-                to={item.href}
+                href={item.href}
                 className={
                   item.read_at === null
                     ? "block rounded-lg border border-primary/40 bg-accent/40 p-4 transition-colors hover:bg-accent"
@@ -180,7 +187,7 @@ function NotificationsPage() {
                   <span className="text-xs text-muted-foreground">{timeAgo(item.created_at)}</span>
                 </div>
                 {item.body && <p className="mt-1 text-sm text-muted-foreground">{item.body}</p>}
-              </Link>
+              </a>
             ))}
           </div>
         </CardContent>

--- a/src/routes/api/notifications/digest.ts
+++ b/src/routes/api/notifications/digest.ts
@@ -1,0 +1,62 @@
+// The daily notification digest: POST /api/notifications/digest
+//
+// Called on a schedule by .github/workflows/notification-digest.yml, which is
+// the only scheduler this project has. There is no cron in the database (the
+// Supabase project is Lovable-managed and pg_cron is not in this repo's
+// migrations) and no Cloudflare cron (no wrangler.toml here, Lovable owns the
+// deploy), so a GitHub Actions schedule calling this endpoint is the mechanism.
+//
+// Auth is a shared bearer token in NOTIFICATION_DIGEST_KEY, compared in constant
+// time. An UNSET key refuses everything rather than running open: a digest
+// endpoint anybody can POST to is a way to make the club email its own members
+// on demand.
+//
+// All DB access uses the service-role client, lazy-imported (route files ship to
+// the client bundle, so it must never be a top-level import).
+import { createFileRoute } from "@tanstack/react-router";
+import { bearerToken, safeEqual } from "@/lib/manager-agent";
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export const Route = createFileRoute("/api/notifications/digest")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const expected = process.env.NOTIFICATION_DIGEST_KEY;
+        if (!expected) {
+          // Deliberately 503 and not 401: nothing the caller can send would
+          // work, and saying "unauthorized" would send somebody hunting for a
+          // token that has not been configured.
+          console.warn("[digest] NOTIFICATION_DIGEST_KEY is not set — refusing to run");
+          return json({ error: "The digest is not configured." }, 503);
+        }
+
+        const token = bearerToken(request.headers.get("authorization"));
+        if (!token || !safeEqual(token, expected)) {
+          return json({ error: "Unauthorized." }, 401);
+        }
+
+        try {
+          const { supabaseAdmin } = await import("@/integrations/supabase/client.server");
+          const { sendDailyDigests } = await import("@/lib/notification-email.server");
+          const result = await sendDailyDigests(supabaseAdmin);
+          // Echoed into the workflow log so a run that mailed nobody is
+          // distinguishable from a run that never happened.
+          console.log(
+            `[digest] considered ${result.considered} notifications for ${result.recipients} people, sent ${result.sent}`,
+          );
+          return json({ ok: true, ...result }, 200);
+        } catch (e) {
+          const message = e instanceof Error ? e.message : "The digest failed.";
+          console.error("[digest] run failed:", e);
+          return json({ error: message }, 500);
+        }
+      },
+    },
+  },
+});

--- a/src/routes/email-settings/$token.tsx
+++ b/src/routes/email-settings/$token.tsx
@@ -1,0 +1,145 @@
+// The settings panel at the bottom of every notification email:
+// /email-settings/<token>
+//
+// The token rides in the URL path because an email client cannot send an
+// Authorization header, exactly like the per-person calendar feed at
+// /api/calendar/<token> and the verification landing at /api/verify-email/
+// <token>.
+//
+// Deliberately NOT under /notifications/<token>: that path already belongs to
+// the signed-in page inside the `_authenticated` group, and two routes claiming
+// the same prefix is a collision waiting to be debugged at three in the morning.
+//
+// The response is deliberately UNIFORM. A token that never existed, one that has
+// been rotated, and a malformed one all render the same panel-less page. Doing
+// otherwise would make this endpoint a way to probe which links the club has
+// issued, and the visitor has nothing useful to do with the difference anyway.
+//
+// This is a settings PANEL, not a one-click unsubscribe. Somebody who only
+// wanted fewer announcements should not lose replies as well, which is what a
+// single "you are unsubscribed from everything" button would cost them.
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useCallback, useEffect, useState } from "react";
+import { useServerFn } from "@tanstack/react-start";
+import { toast } from "sonner";
+
+import { SiteLayout } from "@/components/site/SiteLayout";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { NotificationSwitches } from "@/components/site/NotificationSwitches";
+import type { EmailPreferenceKey } from "@/lib/notifications";
+import {
+  getNotificationPreferencesByToken,
+  saveNotificationPreferencesByToken,
+} from "@/lib/notifications.functions";
+
+export const Route = createFileRoute("/email-settings/$token")({
+  // Never indexable: the path contains a credential, and a crawler that reached
+  // one would put somebody's settings link in a search result.
+  head: () => ({
+    meta: [
+      { title: "Email settings | UTS Jitsu" },
+      { name: "robots", content: "noindex, nofollow" },
+    ],
+  }),
+  // No SSR: the token should not travel through a server render into the HTML
+  // payload of a page that might be cached anywhere along the way.
+  ssr: false,
+  component: EmailSettingsPage,
+});
+
+function EmailSettingsPage() {
+  const { token } = Route.useParams();
+  const load = useServerFn(getNotificationPreferencesByToken);
+  const save = useServerFn(saveNotificationPreferencesByToken);
+
+  const [prefs, setPrefs] = useState<Record<EmailPreferenceKey, boolean> | null>(null);
+  const [state, setState] = useState<"loading" | "ready" | "unavailable">("loading");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    load({ data: { token } })
+      .then((result) => {
+        if (result.ok) {
+          setPrefs(result.preferences);
+          setState("ready");
+        } else {
+          setState("unavailable");
+        }
+      })
+      // A failed request and an unknown token land in the same place on
+      // purpose. See the uniform-response note at the top of this file.
+      .catch(() => setState("unavailable"));
+  }, [load, token]);
+
+  const onSwitch = useCallback(
+    (key: EmailPreferenceKey, next: boolean) => {
+      const previous = prefs;
+      setPrefs((p) => (p ? { ...p, [key]: next } : p));
+      setSaving(true);
+      save({ data: { token, [key]: next } })
+        .then((result) => {
+          if (result.ok) setPrefs(result.preferences);
+          else {
+            setPrefs(previous);
+            setState("unavailable");
+          }
+        })
+        .catch(() => {
+          setPrefs(previous);
+          toast.error("Could not save that. Try again in a moment.");
+        })
+        .finally(() => setSaving(false));
+    },
+    [prefs, save, token],
+  );
+
+  return (
+    <SiteLayout>
+      <section className="mx-auto max-w-2xl space-y-6 px-4 py-16">
+        <div>
+          <h1 className="text-3xl font-black">Email settings</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Choose what UTS Jitsu emails you. No need to sign in.
+          </p>
+        </div>
+
+        {state === "loading" && <p className="text-sm text-muted-foreground">Loading...</p>}
+
+        {state === "unavailable" && (
+          <Card>
+            <CardHeader>
+              <CardTitle>This link is no longer live</CardTitle>
+              <CardDescription>
+                It may have been replaced by a newer one. You can still change everything from your
+                notifications page once you are signed in.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button asChild>
+                <Link to="/notifications">Sign in and open notifications</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        {state === "ready" && prefs && (
+          <Card>
+            <CardHeader>
+              <CardTitle>What we email you</CardTitle>
+              <CardDescription>Changes save as you make them.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {/* No manager switch here. This page cannot tell whether the
+                  person holds the role without a session, and offering a
+                  manager-only choice to a member would be a lie about what
+                  they can turn on. Managers have the full set on
+                  /notifications. */}
+              <NotificationSwitches values={prefs} onChange={onSwitch} disabled={saving} />
+            </CardContent>
+          </Card>
+        )}
+      </section>
+    </SiteLayout>
+  );
+}

--- a/supabase/migrations/20260806030000_notifications.sql
+++ b/supabase/migrations/20260806030000_notifications.sql
@@ -1,0 +1,170 @@
+-- Notifications: the /notifications page, the sidebar badge, and the email
+-- people can turn off.
+--
+-- Three tables:
+--   1. `notifications`             — one row per person per event. This single
+--                                    table drives BOTH the in-app list and the
+--                                    email, which is why there is no separate
+--                                    outbox: `read_at` is the in-app state and
+--                                    `emailed_at` is the delivery state.
+--   2. `notification_preferences`  — which kinds a person wants EMAILED. It
+--                                    never suppresses the in-app row.
+--   3. `notification_tokens`       — the credential behind the settings link in
+--                                    an email footer, which has to work signed
+--                                    out.
+--
+-- SEQUENCING. Entirely additive (three new tables, no column dropped, no policy
+-- narrowed, nothing renamed), so this is an expand-phase migration with no
+-- contract half: it goes live BEFORE the code that reads it, and the app runs
+-- unchanged until then. See docs/database-changes.md.
+--
+-- GRANTS. Supabase's bootstrap grants ALL on every new table to `anon` and
+-- `authenticated`, and GRANT cannot narrow that — only REVOKE can. So each
+-- table below revokes first and grants only `service_role`. Every read and
+-- write goes through a server function on the service role, exactly like the
+-- `kb_*` tables, so no client grant is kept and
+-- supabase/lint/client-grants-expected.txt needs no new line. The RLS policies
+-- are defence in depth and are unreachable from a browser today.
+--
+-- TYPES.TS. `src/integrations/supabase/types.ts` is generated from the live
+-- schema, so these tables appear there only once this migration is applied and
+-- Lovable regenerates. The column names are pinned in
+-- src/integrations/supabase/schema-contract.test.ts (`_NotificationColumns`,
+-- `_NotificationPreferenceColumns`, `_NotificationTokenColumns`) so a rename
+-- fails `bun run typecheck` rather than failing silently at runtime.
+
+-- ---------- 1. The notifications themselves ----------
+CREATE TABLE public.notifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- To `profiles`, not `auth.users`, matching `kb_annotations.user_id` and
+  -- `kb_article_reads.user_id`: a person in this app is a profile, and a
+  -- notification for somebody with no club record is not a thing that happens.
+  user_id UUID NOT NULL REFERENCES public.profiles(user_id) ON DELETE CASCADE,
+  kind TEXT NOT NULL CHECK (
+    kind IN ('reply', 'thread_activity', 'new_blog_post', 'blog_comment', 'kb_comment')
+  ),
+  subject_type TEXT NOT NULL CHECK (
+    subject_type IN ('blog_comment', 'kb_annotation', 'blog_post')
+  ),
+  -- What happened. Deliberately NOT a foreign key: it points at three different
+  -- tables depending on `subject_type`, and more importantly the notification
+  -- must outlive its subject. A manager deleting an abusive comment should not
+  -- silently erase the record that people were told about it.
+  subject_id UUID NOT NULL,
+  -- Who did it. NULL once that account is gone; the notification still reads
+  -- fine because the name is frozen into `title`/`body` below.
+  actor_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  -- Frozen at write time, the same call `waivers` makes about its person
+  -- fields: a notification is a record of a moment, not a live view of one.
+  -- Rendering from a join would also mean every list read has to re-check
+  -- article visibility, and one missed check leaks a members-only passage into
+  -- somebody's inbox.
+  title TEXT NOT NULL CHECK (char_length(title) BETWEEN 1 AND 200),
+  body TEXT CHECK (body IS NULL OR char_length(body) <= 500),
+  -- Where "open" goes. A site-relative path, never an absolute URL: the email
+  -- sender prefixes the origin, and storing one would bake the host into rows
+  -- that outlive it.
+  href TEXT NOT NULL CHECK (href LIKE '/%'),
+  -- NULL = unread. Drives the sidebar badge.
+  read_at TIMESTAMPTZ,
+  -- NULL = not yet considered for email. The digest stamps this on EVERY row it
+  -- considers, including ones a preference suppressed, so switching a kind back
+  -- on is forward-looking instead of releasing a backlog.
+  emailed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The idempotency guard, and the reason `blog_posts` needs no `announced_at`
+-- column: a post that is unpublished and republished cannot produce a second
+-- announcement, because the second insert collides here. `published_at` could
+-- not have carried that, since it is deliberately never cleared
+-- (`resolvePublishedAt` in src/lib/blog.functions.ts). Every writer uses
+-- ON CONFLICT DO NOTHING against this constraint.
+CREATE UNIQUE INDEX notifications_user_kind_subject_key
+  ON public.notifications (user_id, kind, subject_id);
+
+-- "This person's list, newest first" — the only query the page makes.
+CREATE INDEX notifications_user_created_idx
+  ON public.notifications (user_id, created_at DESC);
+
+-- The badge asks "how many unread" on every member-space page load, so it gets
+-- its own partial index rather than scanning a person's whole history.
+CREATE INDEX notifications_unread_idx
+  ON public.notifications (user_id) WHERE read_at IS NULL;
+
+-- The digest sweeps this across everybody, so it must not be a full scan.
+CREATE INDEX notifications_unemailed_idx
+  ON public.notifications (created_at) WHERE emailed_at IS NULL;
+
+REVOKE ALL ON public.notifications FROM anon, authenticated;
+GRANT ALL ON public.notifications TO service_role;
+ALTER TABLE public.notifications ENABLE ROW LEVEL SECURITY;
+
+-- Defence in depth, and unreachable today: there is no client grant, and every
+-- read and write goes through a server function on the service role. Written
+-- anyway, and owner-scoped in both directions with no manager policy — the same
+-- call `kb_article_reads` makes. A manager reading other people's notifications
+-- would be reading who replied to whom, which is nobody's business but theirs.
+CREATE POLICY "People can read their own notifications"
+  ON public.notifications
+  FOR SELECT TO authenticated USING (auth.uid() = user_id);
+
+CREATE POLICY "People can mark their own notifications read"
+  ON public.notifications
+  FOR UPDATE TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- ---------- 2. Email preferences ----------
+CREATE TABLE public.notification_preferences (
+  user_id UUID PRIMARY KEY REFERENCES public.profiles(user_id) ON DELETE CASCADE,
+  -- All four are NULLABLE ON PURPOSE. NULL means "never chose", which a
+  -- NOT NULL DEFAULT cannot express: with a default, changing the club's mind
+  -- about a default later either moves nobody (if the column was backfilled) or
+  -- moves everybody including people who deliberately switched it off. NULL
+  -- plus NOTIFICATION_DEFAULTS in src/lib/notifications.ts keeps "unset" and
+  -- "off" distinguishable, and puts the fallback somewhere unit-testable.
+  reply_to_me BOOLEAN,
+  thread_activity BOOLEAN,
+  new_blog_post BOOLEAN,
+  -- Only consulted for someone holding the `manager` role. Kept on the same row
+  -- rather than in a manager-only table because roles come and go and the
+  -- preference should survive losing and regaining one.
+  manager_comment_alerts BOOLEAN,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+REVOKE ALL ON public.notification_preferences FROM anon, authenticated;
+GRANT ALL ON public.notification_preferences TO service_role;
+ALTER TABLE public.notification_preferences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "People can read their own notification preferences"
+  ON public.notification_preferences
+  FOR SELECT TO authenticated USING (auth.uid() = user_id);
+
+-- ---------- 3. The settings link in an email footer ----------
+CREATE TABLE public.notification_tokens (
+  user_id UUID PRIMARY KEY REFERENCES public.profiles(user_id) ON DELETE CASCADE,
+  -- The RAW token is stored, not just its hash, for the same reason
+  -- `calendar_feed_tokens` stores one: the server has to be able to PUT this
+  -- link into an email it composes later, which a one-way hash cannot do. The
+  -- hash is kept alongside so lookups are constant-time-comparable and so a
+  -- future rotate-and-show-once flow needs no schema change.
+  token TEXT NOT NULL UNIQUE,
+  token_hash TEXT NOT NULL UNIQUE,
+  token_prefix TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+REVOKE ALL ON public.notification_tokens FROM anon, authenticated;
+GRANT ALL ON public.notification_tokens TO service_role;
+ALTER TABLE public.notification_tokens ENABLE ROW LEVEL SECURITY;
+
+-- No policy at all, deliberately. This table holds a credential that grants
+-- signed-out access to somebody's email settings; `authenticated` has no grant
+-- and no reason to read even its own row, since the page it powers is reached
+-- from a link rather than by looking the token up. RLS is enabled so the table
+-- is closed rather than merely ungranted.
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## ⚠️ SQL is waiting to be applied

`supabase/migrations/20260806030000_notifications.sql` is **not applied yet**. Per `docs/database-changes.md`, please approve this PR first, then the SQL gets applied to the live database, the `supabase_migrations.schema_migrations` ledger row written, PostgREST reloaded, and only then does this merge.

**What the SQL does** (entirely additive: three new tables, nothing dropped, no policy narrowed):

- **`notifications`** — one row per person per event. `user_id → profiles`, `kind`, `subject_type`, `subject_id` (no FK, it points at three tables and must outlive its subject), `actor_id`, frozen `title`/`body`/`href`, `read_at`, `emailed_at`, `created_at`. Unique index on `(user_id, kind, subject_id)`, plus indexes for the list, the badge and the digest sweep.
- **`notification_preferences`** — `user_id` PK plus four **nullable** booleans and timestamps.
- **`notification_tokens`** — `user_id` PK, raw `token`, `token_hash`, `token_prefix`, `created_at`.

Each one revokes from `anon`/`authenticated` before granting `service_role`, enables RLS, and adds owner-scoped policies as defence in depth. **No client grants are kept**, so `supabase/lint/client-grants-expected.txt` needs no new line (same as the `kb_*` tables).

Because the migration is not live, the three tables are **hand-added to `src/integrations/supabase/types.ts`** in the generator's style so the branch typechecks. That is the same thing `20260802160000` did for `kb_article_reads`, and the shapes are pinned in `schema-contract.test.ts` so a real regeneration landing differently is caught. Please ask Lovable to regenerate types once the SQL is live.

## What this changes for people

The blog and the knowledge base both took comments that nobody found out about. Reply to somebody and they learned by coming back to the page. Leave feedback on a policy passage and it sat there until a manager opened `/manager/kb` and picked that exact article. Publish a post and nobody was told at all.

**Everyone signed in gets a `/notifications` page**, in the member-space sidebar with an unread count. It has two halves that behave differently on purpose:

- **Needs attention** — standing problems (the club's training dates running out). Worked out live, cleared by being fixed, and with no "mark read" control, because hiding an unfixed problem is how it gets forgotten. Managers only.
- **Activity** — replies, threads you are in, new posts, and comments to moderate. Unread until you look.

The badge is one number covering both.

**For managers**, the dashboard keeps its tiles but its "Needs attention" card becomes a link across, so there is one queue rather than two.

**Email:**

| What | Default | Pacing |
| --- | --- | --- |
| Someone replies to you | On | Straight away |
| More activity on a thread you are in | On | Daily summary |
| A new blog post goes up | Off | Daily summary |
| New comments to review (managers) | On | Daily summary |

The switches govern the **inbox only**. Everything still appears on the page, so turning email off never costs somebody the record of what happened. Every notification email links to those switches at the bottom, and that link works **signed out** — it opens the panel rather than unsubscribing, so somebody who only wanted fewer announcements does not also lose replies.

## Design decisions worth a reviewer's eye

- **One table drives both surfaces.** `read_at` is the in-app state, `emailed_at` the delivery state, so there is no separate outbox.
- **The unique index is the idempotency guard.** It is why an unpublish/republish round trip announces a post exactly once, and why `blog_posts` needs no `announced_at` column: `published_at` is deliberately never cleared, so it could not have carried that.
- **Preference columns are nullable on purpose.** NULL means "never chose", which a `NOT NULL DEFAULT` cannot express. It keeps "unset" distinguishable from "deliberately off", so changing a club default later moves the right people.
- **The digest stamps every row it considers, including suppressed ones**, so switching a kind back on is forward-looking instead of releasing weeks of backlog. It stamps only after a successful send, so a failure retries tomorrow. A missing `LOVABLE_API_KEY` stamps nothing, since those notifications are still owed.
- **Titles are frozen, not joined.** A notification is a record of a moment, and a live join would mean every list read re-checks article visibility.

## Privacy guards

- **A private knowledge base note notifies nobody**, managers included. Enforced twice: `createAnnotation` already refuses a private reply, and `notifyKbAnnotation` returns immediately for anything that is not `shared`.
- **Recipients are re-checked against the article as it stands now.** One narrowed from `members` to `managers` stops reaching the members who commented while it was wider.
- **Nobody is notified about their own writing**, or about a reply to a comment a manager has hidden.
- The signed-out settings page renders the **same page** for an unknown, rotated or malformed token, so it is never an address oracle.
- Notification writes are fire-and-forget and swallow their own failures: a comment is saved and must never fail because telling somebody about it did.

## Before this can actually send anything

Two switches are deliberately off until set, so merging this cannot by itself mail anybody:

- `NOTIFICATION_DIGEST_KEY` (server env) — **unset means the endpoint refuses everything** rather than running open.
- `NOTIFICATION_DIGEST_URL` + `NOTIFICATION_DIGEST_KEY` (repository secrets) — the workflow warns and passes without them.

`.github/workflows/notification-digest.yml` runs on `schedule` + `workflow_dispatch` only, never on `pull_request`, for the reason `migration-drift.yml` spells out: it holds a credential that makes the live site email its members, and this repo takes same-repo branches from Lovable and from coding agents.

## Found on the way, not fixed here

`contact_messages` is **write-only**. The contact form saves a row and nothing in the app ever reads it: no manager screen, no server function, no email (unlike the interest form, which does notify managers). Anyone who has used the contact form has been talking into a void. Out of scope here, noted in `docs/notifications.md`, and it deserves its own change.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (1515 passing, 84 files) and `bun run build` all pass. New coverage: `src/lib/notifications.test.ts` (39 cases on defaults, the NULL-vs-false distinction, badge arithmetic, digest sectioning and dedupe), schema pins, the `/notifications` page suite, the sidebar badge, and the new Zod schemas.

Docs updated in the same change: new `docs/notifications.md`, plus `docs/database.md`, `docs/blog.md`, `docs/knowledge-base.md` and `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vc1AjQ6tv5gjjGr1AgXrfu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vc1AjQ6tv5gjjGr1AgXrfu)_