### PR TITLE
docs: dedupe AGENTS.md/CLAUDE.md, add engineering + UX guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,197 +11,32 @@
 
 <!-- LOVABLE:END -->
 
-## Database
+# Working in this repo
 
-The schema reference lives in **`docs/database.md`** (every table: columns,
-RLS, relationships, storage). The product spec for the waiver/profile/account
-flows lives in **`docs/waivers.md`**, and the club's house rules and how people
-agree to them in **`docs/code-of-conduct.md`**. The intended schema is defined by
-the migrations in `supabase/migrations/*.sql`.
+**`CLAUDE.md` is the main instruction file** — stack, layout, routing, Supabase
+clients, database rules, testing, CI, how to make a change, and the UX bar every
+change is held to. Read it whichever agent you are; it is not Claude-specific.
 
-**When you change a migration, a table, or the code that reads/writes it,
-update `docs/database.md` (and the matching product doc if the behavior
-changed) in the same change** so the docs and the code do not drift.
+This file holds the one thing it does not: how the site is allowed to talk.
+Everything else below is a pointer, so nothing is written down twice.
 
-⚠️ **Committing a migration does not apply it.** Nothing in this pipeline runs
-`supabase/migrations/*.sql` **against the live database** — Lovable applies only
-the SQL its own agent writes. (`supabase-lint.yml` does replay every migration,
-but onto a throwaway local Postgres: that proves a migration _can_ apply, not
-that it _has_.) A migration file pushed through GitHub is inert until somebody
-applies it to the live database (there is only one; no staging tier), which is
-how `column waivers.approval_status does not exist` reached production with the
-migration sitting merged in the repo.
+| Topic                            | Where it lives              |
+| -------------------------------- | --------------------------- |
+| Everything about the codebase    | `CLAUDE.md`                 |
+| Data model, every table          | `docs/database.md`          |
+| Changing the schema (read first) | `docs/database-changes.md`  |
+| Manager agent HTTP API           | `docs/manager-agent-api.md` |
+| Product flows, one file per flow | the rest of `docs/`         |
 
-**But do not apply it before the user has reviewed it.** Write the migration,
-open the PR, and stop — spell out in the PR body what SQL is waiting to run.
-Once the user approves, **apply the SQL, record it in
-`supabase_migrations.schema_migrations`, verify the object exists, and reload
-PostgREST — all before merging.** This holds for additive and destructive changes
-alike: there is one database and no staging tier, so applying a migration is a
-production change. Never merge a migration you have not applied, and never apply
-one the user has not approved. See `docs/database-changes.md` for the full
-procedure and the CI checks that catch both halves.
+Two rules from `CLAUDE.md` that get broken most often, repeated here only
+because breaking them is expensive:
 
-## Manager agent API
-
-A small, token-authenticated HTTP endpoint that lets a manager's AI agent perform
-a whitelisted set of manager actions against the live site. It is the "simplest
-way to plug in an agent": a bearer token + JSON, wrappable as an MCP server or
-driven directly by the bundled skill.
-
-- **Endpoint:** `src/routes/api/manager/agent.ts`
-  - `GET  /api/manager/agent` → the self-describing **manifest** (the runtime
-    source of truth for the current action set).
-  - `POST /api/manager/agent` with `{ "action", "params" }` → dispatch.
-- **Auth:** `Authorization: Bearer <token>`. Tokens are **manager-issued and
-  revocable** — a manager mints them at `/manager/api-tokens` (route
-  `_authenticated/manager.api-tokens.tsx`). Only a SHA-256 hash is stored
-  (`manager_api_tokens` table); the raw token is shown once at creation. On each
-  request the endpoint looks the token up by hash, confirms it isn't revoked, and
-  re-checks the owner still holds the `manager` role. A `MANAGER_AGENT_API_KEY`
-  env var is accepted as an **optional break-glass fallback** (e.g. bootstrap /
-  CI); it is not required. The endpoint runs actions with the service-role
-  client, so a token grants manager-level access to the exposed actions — treat
-  it as a secret.
-  - Token management server functions: `src/lib/manager-api-tokens.functions.ts`
-    (`listApiTokens` / `createApiToken` / `revokeApiToken`); token crypto +
-    the paste-able agent prompt: `src/lib/manager-api-tokens.ts`.
-  - The `/manager/api-tokens` screen also renders a copy-paste **agent prompt**
-    (`buildAgentPrompt`) for Claude Code / opencode / Cursor and points at the
-    `uts-manager-agent` skill.
-- **Actions** (an "invoice" is a `memberships` row — its price/reference/status
-  _are_ the invoice):
-  - `list_users` — members and their lifecycle status, roles, and invoices.
-  - `list_invoices` — invoices with member name/email (to find an id to edit).
-  - `edit_invoice` — correct an invoice's detail fields. Cannot set `status` to
-    `active` (activation grants the member role + emails the member, so it runs
-    through bank reconciliation, not a raw edit). Returns `changed` + `previous`
-    alongside the updated invoice, and writes an audit line to the server log
-    (`[agent.edit_invoice] audit`) naming the actor and each field's old → new.
-    **On a paid invoice** (`paid_at` set) the money fields — `price_cents`,
-    `payment_reference`, `payment_method` (`RECONCILED_GUARDED_FIELDS`) — are
-    refused with `409 reconciled_invoice` unless `confirm_paid_edit` is passed:
-    a reconciled invoice's amount is a record of money that moved, and the
-    status it belongs to is already protected. `notes` and `status` stay freely
-    editable (a note claims nothing about money; expiring a membership that ran
-    its course is ordinary). There is **no audit table** — if the log is not
-    enough for the club's bookkeeping, that is a schema change and a product
-    decision, not something to add quietly.
-  - `file_waiver` — file a scanned paper waiver (migration / bulk filing from
-    paper records). Same params as the manager's paper-upload form
-    (`paperWaiverUploadSchema`); dispatches to `filePaperWaiver` in
-    `src/lib/waiver.functions.ts`, the same function the web form calls, so an
-    agent-filed waiver and a manager's own upload are identical. Always lands
-    **pending**: it never approves, emails anyone, or marks the email verified
-    — approving is a separate, deliberate manager action because it promotes
-    the record, unlocks the login, emails them that their account is active and
-    assigns the free trial (docs/waivers.md rule 6). `uploaded_by` on the filed row is the
-    token's owner, or the `AGENT_ENV_KEY_UPLOADER` sentinel for the break-glass
-    env key, which has no owner to resolve. Filing a waiver the person already
-    has for the same `signed_on` is refused with `409 duplicate_waiver` (the
-    colliding rows come back in `error.existing`); `confirm_duplicate` files it
-    anyway, for the corrected re-scan that is a genuine second document. The
-    check lives in `filePaperWaiver`, so the manager's own upload form gets the
-    same speed bump.
-    - **The two surfaces present that one check differently on purpose, and
-      this is not an inconsistency to tidy up.** The HTTP API returns
-      `409 duplicate_waiver`, because a machine caller needs a distinct status
-      to branch on. `uploadPaperWaiver` instead returns a `filed: false` result
-      carrying the collision, so the screen can show the manager _what_ it hit
-      and offer "file it anyway". A thrown error would reach the form as a
-      toast with the detail lost, which is what makes the guard useless to a
-      human.
-    - The check is **check-then-insert, so it cannot stop two racing retries**
-      — neither sees a row the other has not committed. `client_submission_id`
-      is what makes a retry safe: same key, same waiver, enforced by the partial
-      unique index from `20260729020000`, exactly as the online signing path
-      uses it. That index covers the WHOLE table, so the key namespace is shared
-      with the public signing path — both lookups therefore ignore anything that
-      is not a paper filing, or a caller-chosen id could resolve to a waiver a
-      signer's browser minted. Scoping uniqueness per caller
-      (`(uploaded_by, client_submission_id)`) would need a migration and is a
-      deliberate follow-up, not an oversight.
-    - Comparing `signed_at` to the string this code WRITES never matches:
-      PostgREST renders TIMESTAMPTZ as `+00:00` with no fractional part. Compare
-      the date part. This killed the whole idempotency path once, and the test
-      fixture hid it by using the write format.
-    - Sending a key **transfers an obligation**: a failed filing keeps its row
-      for the retry instead of deleting it, so an abandoned attempt leaves a
-      documentless waiver. `setWaiverApproval` refuses a waiver with no
-      `pdf_path` so that row can never become somebody's ACTIVE record, and the
-      manifest says the obligation exists.
-    - A failed probe is `503 duplicate_check_failed` with a `Retry-After`
-      header, deliberately distinct from `file_waiver_failed` and deliberately
-      silent about `confirm_duplicate` — offering that flag as the fix for an
-      outage invites a retry policy to disable the guard wholesale. The 503 is
-      documented as "nothing was filed, safe to retry unchanged", which is true
-      only because the probe runs BEFORE `resolvePersonId`. Moving person
-      creation above it would strand an auth user per retry, and no status-code
-      test would notice.
-    - The probe matches a **UTC-day range**, not the midnight instant a paper
-      filing writes, so it catches an online signature on the same day too. The
-      club is UTC+10/+11, so a Sydney-morning signature falls on the previous
-      UTC day — known and accepted, since widening to the club's own day would
-      collide across two dates instead.
-    - `paperWaiverUploadSchema` is `.strict()`, matching `editInvoiceSchema`. A
-      misspelled `confirm_duplicate` would otherwise be stripped by Zod, default
-      to false, and return the same 409 forever while the message told the
-      caller to do what they thought they just did.
-- **Agent glue:** `.claude/skills/uts-manager-agent/` — a skill (with a `curl`
-  helper) that documents how to call the endpoint. An MCP wrapper is equally
-  simple: one tool per manifest action, forwarding to this endpoint.
-
-### Keep these in sync
-
-The action contract lives in **four** places — change all of them together, or
-the agent glue drifts from the deployed API:
-
-1. `src/lib/validation.ts` — `managerAgentActions` + the per-action Zod schemas.
-2. `src/lib/manager-agent.ts` — `AGENT_MANIFEST` (self-description) + projections.
-3. `src/routes/api/manager/agent.ts` — the request dispatch/handlers.
-4. `.claude/skills/uts-manager-agent/SKILL.md` — the agent-facing docs.
-
-`src/lib/manager-agent.test.ts` asserts the manifest matches `managerAgentActions`,
-so a forgotten manifest update fails CI. The `GET` manifest is authoritative at
-runtime: the skill instructs agents to read it before acting, so an MCP/skill
-wrapper never needs hand-syncing beyond the human-readable docs above.
-
-**Bump `AGENT_MANIFEST.version` whenever the behaviour a client can rely on
-changes**, not only when an action is added or removed. A guard that starts
-refusing a call that used to succeed, or a new field in a response, is exactly
-what a client needs the version to tell it about. The version is pinned by a
-test so the bump is a deliberate edit, and the current value is `"6"`.
-
-**Responses carry `version` too**, not just the manifest, so a client that
-cached the manifest at the start of a long run can notice a bump per call
-instead of meeting it as an unexplained refusal. Error payload beyond
-`code`/`message` is nested under `error.details` — never flat-merged, so the
-envelope can grow a reserved key without shadowing a caller's field.
-
-**There is no version pinning.** A caller cannot request the old behaviour; the
-contract is latest-only. That is defensible for a single-tenant API with
-manager-issued tokens where every caller is known, but it means `changes` is a
-record of what already happened, not a negotiation — say so rather than letting
-somebody build a client that expects to pin.
-
-**Add a `changes` entry in the same edit**, with `breaking: true` when the
-version turns a call that used to succeed into an error. A version number alone says only
-that something moved; the client that most needs to know what is the one that
-read the manifest at the start of a long import and cannot re-read it mid-run.
-A test asserts the head of `changes` matches `version`, so the two cannot drift.
-Call out anything that turns a previously-succeeding call into an error — that
-is the note a caching client is actually reading for.
-
-## Plans you show the user are product-level
-
-Plans presented to the user (plan mode, an approach proposal, a check-in before
-starting) describe **what changes for the people using the site**: who is
-affected, which page or flow, what is different afterwards, what decisions are
-theirs, and what is out of scope. Not file paths, table names, or migration
-ordering. Work the implementation out separately and keep it as working notes,
-the way `.lovable/plan.md` puts user-facing behavior first and the technical
-section after. Full detail on request. See "Plans you show the user are
-product-level" in `CLAUDE.md`.
+- **Committing a migration does not apply it, and you must not apply one before
+  the user has approved the PR.** There is one database and no staging tier.
+  Full procedure: `docs/database-changes.md`.
+- **Plans you show the user describe what changes for the people using the
+  site**, not file paths and table names. Full rule: "Plans you show the user
+  are product-level" in `CLAUDE.md`.
 
 ## Writing style for website copy
 
@@ -225,6 +60,11 @@ Also avoid other AI-prose tells in copy: hollow hype ("elevate", "unlock",
 constructions, and mechanical rule-of-three lists. Prefer concrete, specific
 wording.
 
+Write for the person in the state they are actually in. Someone reading an error
+message has just been stopped; tell them what to do next, not what went wrong
+internally. Someone on `/waiver` is standing in a gym on their phone. Length is
+a cost they pay, so cut every word that is not doing work.
+
 Exceptions (these are typography/UI, not prose, and are fine): an en dash (`–`)
 in a numeric range such as `5:30 – 7:00pm`, and an em dash used as a
 placeholder glyph for an empty value (e.g. `{value || "—"}`).
@@ -232,26 +72,5 @@ placeholder glyph for an empty value (e.g. `{value || "—"}`).
 When you add or change any user-facing copy (public, authenticated, or email),
 scan the diff for em dashes before committing.
 
-## Recurring build gotchas (for future agents)
-
-Two issues that have burned time recently. Fix these at the source, not by patching call sites over and over.
-
-### 1. Supabase generated types go stale after a migration
-
-Symptom (runtime, on the affected form): `Could not find the '<column>' column of '<table>' in the schema cache`. The migration ran, but `src/integrations/supabase/types.ts` (auto-generated) was not regenerated, so PostgREST rejects the insert against its cached schema view.
-
-First rule out the more serious cause: a `column <table>.<column> does not exist` error is a different problem — the migration never reached the live database at all. See `docs/database-changes.md` before touching the types.
-
-Fix: after any migration that adds/renames columns or tables, bring `src/integrations/supabase/types.ts` back in step in the same change, and run `NOTIFY pgrst, 'reload schema'` so PostgREST re-reads the schema. Only Lovable can truly regenerate the file; when it cannot (out of credits, say), hand-add **only** columns you have verified exist live, in the generator's own style. Also update `docs/database.md` per the project rule.
-
-Do **not** reach for a `never`/`unknown` cast to silence a stale type. Those casts are what let `waivers.approval_status` be missing from production for a week with a green build — the cast disables the only check that would have caught it. Fix the types instead.
-
-**Exception, and it is not a small one: never hand-fix the NULLABILITY of an RPC's return type.** "Hand-add only what you verified exists live" applies to a missing **column** on a table, where the generator does read nullability (`pg_attribute.attnotnull`) and is right. It does not apply to anything under `Database["public"]["Functions"]`: a function's declared return type says nothing about NULL and the generator has nowhere to look it up, so every RPC return prints non-null whether or not it is. A hand-fix there is erased by the next regeneration — `email_confirmed_at` was corrected by hand on 2026-07-29 and regenerated away hours later, taking `main` red with the contract test pinning it. Wrap such an RPC in `src/lib/supabase-rpc.ts` instead, and see "Supabase clients" in `CLAUDE.md`.
-
-### 2. `.maybeSingle()` returns `T | null`, but helpers often take `T | undefined`
-
-Symptom (typecheck, e.g. `src/routes/api/manager/agent.ts`): `Type 'null' is not assignable to type '{...} | undefined'` when passing a `.maybeSingle()` result into a helper whose optional parameter is typed `T | undefined` (default TS optional-parameter shape).
-
-Fix at the call site: `helper(row, (plan ?? undefined) as PlanRow | undefined)`. Do NOT widen the helper signature to accept `null` just to silence one caller — `null` and `undefined` are semantically the same "no row" here and the helper's other callers already pass `undefined`. The `?? undefined` normalization keeps the boundary tidy.
-
-Rule of thumb: Supabase `.maybeSingle()` / `.select().single()` speak `null`; TS optional params speak `undefined`. Normalize at the boundary.
+This rule is about **copy**. Code comments, commit messages, PR bodies and the
+files under `docs/` are internal writing and are not held to it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,12 +15,8 @@ Lovable's TanStack Start template.
 
 ## Lovable-managed project — read first
 
-This project is connected to [Lovable](https://lovable.dev) (see `AGENTS.md`).
+This project is connected to [Lovable](https://lovable.dev).
 
-- **Read `AGENTS.md` before you start.** It holds cross-tool directives that
-  apply to every agent working in this repo, including the writing-style rules
-  for public website copy (e.g. no em dashes in prose). Follow it alongside this
-  file.
 - **Never rewrite published history on `main`** (the branch connected to
   Lovable) — no force-push, and no rebasing/amending/squashing commits already
   pushed there. Doing so rewrites history on Lovable's side and the user can
@@ -33,6 +29,25 @@ This project is connected to [Lovable](https://lovable.dev) (see `AGENTS.md`).
 - `.lovable/` holds Lovable metadata (`project.json`) and the current work
   plan (`plan.md`). `src/routes/lovable/**` and `@lovable.dev/*` packages are
   Lovable platform integrations.
+
+## Where things are written down
+
+This file is the main instruction file and everything general lives here. The
+others own exactly one topic each, so nothing is stated twice — go to them when
+you are working in their area, not before.
+
+| Topic                                  | File                        |
+| -------------------------------------- | --------------------------- |
+| How the site is allowed to talk (copy) | `AGENTS.md`                 |
+| The data model, every table            | `docs/database.md`          |
+| Changing the schema — **read first**   | `docs/database-changes.md`  |
+| Manager agent HTTP API                 | `docs/manager-agent-api.md` |
+| Routing conventions                    | `src/routes/README.md`      |
+| Product flows, one file per flow       | the rest of `docs/`         |
+
+When you change behaviour, update the doc that owns it in the same change. When
+you find yourself repeating a rule that already exists somewhere, link it
+instead — every duplicate is a future contradiction.
 
 ## Tech stack
 
@@ -97,10 +112,12 @@ src/
     routeTree.gen.ts      AUTO-GENERATED route tree — never edit by hand
   components/
     ui/                   shadcn/ui primitives (generated; avoid hand-editing)
-    site/                 App chrome: SiteHeader, SiteFooter, SiteLayout, SignaturePad
+    site/                 App chrome + shared UX: SiteLayout/MemberLayout/KbLayout,
+                          SiteHeader, SiteFooter, SignaturePad, AuthPending,
+                          SubmitStatus, StatusPill
   integrations/supabase/  Supabase clients + auth middleware + generated types
   lib/                    Business logic, server functions, PDF, email templates, utils
-  hooks/                  useAuth / useRoles, use-mobile
+  hooks/                  useAuth / useRoles, use-resilient-submit, use-mobile
   router.tsx              createRouter() factory (QueryClient in context)
   server.ts               SSR entry — wraps errors into a rendered error page
   start.ts                createStart(): global function + request middleware
@@ -163,11 +180,22 @@ Read `src/routes/README.md` before touching routes. Key points:
 - `client.ts`, `client.server.ts`, `auth-middleware.ts`, and `types.ts` are
   **auto-generated** ("Do not edit it directly"). Prefer regenerating over hand-edits.
   `types.ts` is generated **from the live schema**, which makes it the repo's
-  closest mirror of what the database actually has — see Schema drift. If you
-  must hand-add a column to it (Lovable out of credits, say), add only what you
-  have verified exists live, in the generator's own style. It is listed in
-  `.prettierignore` so `bun run format` cannot reformat it: Prettier would
-  rewrite all ~1400 lines and the next regen would revert them.
+  closest mirror of what the database actually has (see "Schema drift" in
+  `docs/database-changes.md`). If you must hand-add a column to it (Lovable out
+  of credits, say), add only what you have verified exists live, in the
+  generator's own style. It is listed in `.prettierignore` so `bun run format`
+  cannot reformat it: Prettier would rewrite all ~1400 lines and the next regen
+  would revert them.
+- **Stale types after a migration** show up at runtime as
+  `Could not find the '<column>' column of '<table>' in the schema cache`: the
+  migration ran, but `types.ts` was not regenerated and PostgREST is answering
+  from its cached schema view. Fix both halves — bring `types.ts` back in step
+  and run `NOTIFY pgrst, 'reload schema'`. A `column <table>.<column> does not
+exist` error is the more serious cousin: the migration never reached the live
+  database at all (`docs/database-changes.md`).
+- **Never silence a stale type with a `never` / `unknown` cast.** Those casts are
+  what let `waivers.approval_status` be missing from production for a week with a
+  green build: the cast disables the only check that would have caught it.
 
 > [!WARNING]
 > **Never trust the nullability of an RPC's return type, and never hand-fix it
@@ -280,7 +308,9 @@ Core tables:
   notifies nobody, managers included. Product flows: `docs/notifications.md`.
 - `user_roles` — role assignments; managed by managers / service role.
 - `manager_api_tokens` — manager-issued bearer tokens for the manager agent API
-  (`/api/manager/agent`); stores only a SHA-256 hash + display prefix, manager-only RLS.
+  (`/api/manager/agent`); stores only a SHA-256 hash + display prefix,
+  manager-only RLS. The API's action contract and its four sync points:
+  `docs/manager-agent-api.md`.
 
 Signed waiver PDFs are stored in the Supabase Storage **`waivers`** bucket; access
 is via short-lived signed URLs, and `storage.objects` carries explicit
@@ -374,10 +404,10 @@ owner/manager policies (`20260727120000_waiver_storage_policies.sql`).
   data.
 - **Migration drift CI:** `.github/workflows/migration-drift.yml` checks every
   migration file against the **live** ledger. Not on PRs — it holds a
-  production credential (see Schema drift).
+  production credential (see "Schema drift" in `docs/database-changes.md`).
 - **Supabase lint CI:** `.github/workflows/supabase-lint.yml` (path-filtered to
   `supabase/**`) starts a local Postgres, applies every migration to it (which
-  is not the live database — see Schema drift), and runs the
+  is not the live database, see `docs/database-changes.md`), and runs the
   **Advisors** (Splinter — the dashboard's Security/Performance lints, e.g.
   `function_search_path_mutable`) plus `supabase db lint` (plpgsql_check on
   `public`). Security findings at WARN+ fail the build; performance findings are
@@ -447,11 +477,13 @@ hand-produce a public-npm lock.
   **and its own `rel="canonical"`**; manager and other private pages set
   `robots: noindex`. Match the existing pattern when adding pages, and see the
   SEO section below for the two things that are easy to get wrong.
-- **Copy voice:** user-facing website copy must read like a person wrote it, not
-  an AI. **No em dashes (`—`) in prose** — rewrite with a full stop, comma,
-  colon, or "and"/"but". See the "Writing style for website copy" section in
-  `AGENTS.md` for the full rules and allowed exceptions (numeric en-dash ranges,
-  empty-value placeholder glyphs).
+- **Copy voice:** **no em dashes (`—`) in user-facing copy** and no AI-prose
+  tells. `AGENTS.md` has the full rule; it is short, and it applies to emails and
+  signed-in screens too, not just marketing pages.
+- **`null` vs `undefined` at the Supabase boundary:** `.maybeSingle()` and
+  `.select().single()` speak `null`; TS optional parameters speak `undefined`.
+  Normalize at the call site (`helper(row, plan ?? undefined)`) rather than
+  widening a helper's signature to accept `null` for one caller.
 
 ## SEO
 
@@ -494,7 +526,7 @@ meaningfully). The app reads:
 - Server, optional: `MANAGER_AGENT_API_KEY` — break-glass bearer token for the
   manager agent API (`/api/manager/agent`). Normally managers mint revocable
   tokens at `/manager/api-tokens` (stored hashed in `manager_api_tokens`); this
-  env var is just an optional fallback (see AGENTS.md).
+  env var is just an optional fallback (see `docs/manager-agent-api.md`).
 - Server, optional: `NOTIFICATION_DIGEST_KEY` — bearer token for the daily
   notification digest (`POST /api/notifications/digest`, driven by
   `.github/workflows/notification-digest.yml`). **Unset means the endpoint
@@ -541,11 +573,118 @@ and get to it once the product shape is agreed. `.lovable/plan.md` is the shape
 to copy: user-facing behavior first, a technical section after it. If the user
 asks for the technical detail, give them all of it.
 
+## Make the change easy, then make the easy change
+
+**When a change feels hard, that is information about the code, not about the
+feature.** Threading a new flag through five call sites, copy-pasting an existing
+handler to vary one line, a third branch inside a branch: each is the code saying
+it is the wrong shape for what is being asked of it. Stop, reshape it so the
+feature becomes a small edit, then make that small edit.
+
+So a change has two kinds of commit, and they do not mix:
+
+1. **Preparatory refactor** — behaviour identical, tests green before and after,
+   no new feature smuggled in. Extract the pure function, widen the type, move
+   the shared bit into the module that should own it.
+2. **The change itself** — now small, and readable on its own.
+
+Say which one a commit is in its message. It makes review cheap and revert
+surgical: if the feature turns out wrong, the refactor usually still stands. If
+the preparatory refactor is large, push it and get CI green before layering the
+feature on top.
+
+Practical rules:
+
+- **Extend a seam, do not add a parallel one.** This repo already has the seam
+  for most things: form rules in `src/lib/validation.ts`, server work in
+  `src/lib/*.functions.ts` (`createServerFn` + Zod), writes from the browser
+  through `useResilientSubmit`, RPC shapes in `src/lib/supabase-rpc.ts`, page
+  chrome in `components/site/*Layout`, indexable pages in `src/lib/seo.ts`. If
+  your change seems to need a _second_ way to do one of these, that is a design
+  decision to raise with the user, not a shortcut to take quietly.
+- **Extracting logic into a pure module is usually the whole "make it easy"
+  step.** `validation.ts` and `submit-resilience.ts` exist because behaviour was
+  pulled out of handlers and components until it could be tested directly. Do
+  the same rather than testing through a server context or a rendered tree.
+- **Scope the refactor to what the change needs.** Preparatory means preparatory.
+  Unrelated tidying belongs in its own PR, where it can be judged on its merits.
+- **Do not abstract on the second occurrence.** Wait for the third, or for a rule
+  that genuinely has to be true in both places. Two similar-looking things that
+  can drift apart are cheaper duplicated.
+- **No speculative generality.** No option, hook point or parameter that has no
+  caller today. The next change will be easier to make than this one is to undo.
+- **Delete what your change makes dead** in the same PR: the branch nothing
+  reaches, the helper with no callers, the column nobody reads (that last one is
+  a migration, so `docs/database-changes.md` applies).
+- **Write the "why" where it will be read.** This codebase puts the non-obvious
+  reasoning at the top of the module it governs (`submit-resilience.ts` is the
+  model). A comment explaining what the code plainly does is noise; one
+  explaining what it is defending against is the most valuable line in the file.
+
+## The UX bar
+
+Every change ships an experience, not a diff. Before writing code, name the
+person it is for, and what they are doing when they hit it:
+
+- a **prospective member** on a phone, often in transit, often on bad reception;
+- a **member**, signed in, usually looking for one specific thing;
+- a **manager**, on a laptop, between classes, doing admin they'd rather not be
+  doing.
+
+Then hold the change to this:
+
+- **Build the whole state machine, not the happy path.** Loading, empty, error,
+  offline, slow, not-allowed, and already-done each need something on screen that
+  a person can act on. A blank panel while data loads, or a spinner with no exit,
+  is an unfinished feature.
+- **Reuse the components that already solve this.** `AuthPending` for "we are
+  working out who you are" (never a blank page while the session resolves).
+  `useResilientSubmit` + `SubmitStatus` for **every form that writes**: it gives
+  you the timeout, the retry that carries the same `client_submission_id`, the
+  "did it actually land?" confirm, and a failure panel that stays on screen with
+  a button in it. Do not write another `setLoading(true) / catch / toast.error`
+  form. Also `StatusPill`, `SiteLayout` / `MemberLayout` / `KbLayout`, and
+  `components/ui/*`.
+- **A toast is not a UI for anything that matters.** It auto-dismisses, it is
+  easy to miss on a phone, and it leaves nothing to press. Use it for "saved",
+  not for "your waiver did not go through".
+- **Never lose someone's input.** A failed submit keeps the form filled and
+  offers the retry. Ask for as little as possible in the first place, and prefill
+  what we already know (the waiver does this with `getMyLatestWaiver`). Every
+  field is friction somebody pays for.
+- **Errors say what to do next**, in the person's terms, not what failed
+  internally. "We could not reach the server. Your details are still here, try
+  again." beats any status code.
+- **Anything irreversible or outward-facing gets a confirm that says what will
+  happen** — in words, before the click. Approving a waiver emails the member and
+  unlocks their login; activating a membership grants a role. The person pressing
+  the button should already know that.
+- **Mobile first.** Most of this club's traffic is phones. Check at ~375px wide,
+  keep tap targets thumb-sized, and never hide something behind hover alone.
+- **Accessibility is part of "done", not a follow-up.** Real `<button>` and `<a>`
+  elements, labels tied to their inputs, `role="status"` / `aria-live` on async
+  updates, visible focus, contrast through the theme tokens. `AuthPending` and
+  `SubmitStatus` are small, correct examples to copy.
+- **Look at it.** For a UI change, run the app and open the screen (the `/run`
+  skill launches it), or read the PR-screenshots artifact. Note what that job
+  does _not_ catch: a route that handles its own loader error and renders a card
+  in place of its content still counts as a green screenshot.
+- **Say what the person will feel.** If a change adds a step, sends an email,
+  slows something down, or briefly breaks a flow mid-rollout, put that in the PR
+  body and in any plan you show the user. See "Plans you show the user are
+  product-level".
+
+Copy is part of the UX: `AGENTS.md` has the voice rules, and they apply to
+button labels, empty states and error text just as much as to marketing pages.
+
 ## When making changes
 
 1. Develop on the assigned feature branch; commit in a working state (Lovable
-   syncs the branch). **Never** force-push or rewrite pushed history.
-2. Don't hand-edit generated files: `routeTree.gen.ts`, the Supabase
+   syncs the branch). **Never** force-push or rewrite pushed history on `main`.
+2. **Shape first, then change** — if the feature does not fit the code as it is,
+   land the preparatory refactor before it (see "Make the change easy, then make
+   the easy change"). Reuse the existing seam rather than adding a second one.
+3. Don't hand-edit generated files: `routeTree.gen.ts`, the Supabase
    `integrations/supabase/*` clients/types, or `components/ui/*` primitives.
    That list is exhaustive — **every other file is normal, editable source**,
    including Lovable-scaffolded code (`src/integrations/lovable/*`,
@@ -553,21 +692,22 @@ asks for the technical detail, give them all of it.
    "Lovable-owned, do-not-touch" category; `bun run format` (Prettier) is the
    sanctioned way to fix formatting on any file, and CI failures in scaffolded
    files are usually a stale branch — merge `main` and re-format, don't avoid them.
-3. Keep the service-role client (`client.server.ts`) off the client bundle —
+4. Keep the service-role client (`client.server.ts`) off the client bundle —
    lazy-`import` it inside server handlers only.
-4. Validate all server-function input with Zod; enforce manager access with
+5. Validate all server-function input with Zod; enforce manager access with
    `has_role` / `requireSupabaseAuth`, never trust the client.
-5. **Keep the tests in step with the code** — update or add `*.test.ts(x)`
+6. **Touches a screen?** Hold it to "The UX bar": every state rendered, the
+   existing components reused, and somebody's input never lost.
+7. **Keep the tests in step with the code** — update or add `*.test.ts(x)`
    coverage for any behavior you change or add (see Testing & CI). A change that
    touches tested logic without touching its tests is incomplete.
-6. Verify with `bun run lint`, `bun run typecheck`, `bun run test`, and
+8. Update the doc that owns the behaviour you changed (see "Where things are
+   written down") in the same change.
+9. Verify with `bun run lint`, `bun run typecheck`, `bun run test`, and
    `bun run build`. The build alone does not type-check.
-7. **Touching the database?** Read `docs/database-changes.md` first — it covers
-   migrations, grants, RLS and the apply gate. Two things that catch everyone:
-   a new table needs `REVOKE ALL ... FROM anon, authenticated;` before any
-   grant, and you must **wait for the user to approve the PR before applying
-   any SQL to the live database**. Once approved, apply it and record it in the
-   ledger before merging; committing it applies nothing.
+10. **Touching the database?** `docs/database-changes.md`, first, every time.
+    The apply gate is summarised under "Database (Supabase)" above; the file has
+    the rest.
 
 ## After pushing — always do this
 

--- a/docs/manager-agent-api.md
+++ b/docs/manager-agent-api.md
@@ -1,0 +1,162 @@
+# Manager agent API
+
+A small, token-authenticated HTTP endpoint that lets a manager's AI agent perform
+a whitelisted set of manager actions against the live site. It is the "simplest
+way to plug in an agent": a bearer token + JSON, wrappable as an MCP server or
+driven directly by the bundled skill.
+
+> Read this before changing `src/routes/api/manager/agent.ts`,
+> `src/lib/manager-agent.ts`, or the agent schemas in `src/lib/validation.ts`.
+> You do not need it for anything else.
+
+- **Endpoint:** `src/routes/api/manager/agent.ts`
+  - `GET  /api/manager/agent` → the self-describing **manifest** (the runtime
+    source of truth for the current action set).
+  - `POST /api/manager/agent` with `{ "action", "params" }` → dispatch.
+- **Auth:** `Authorization: Bearer <token>`. Tokens are **manager-issued and
+  revocable** — a manager mints them at `/manager/api-tokens` (route
+  `_authenticated/manager.api-tokens.tsx`). Only a SHA-256 hash is stored
+  (`manager_api_tokens` table); the raw token is shown once at creation. On each
+  request the endpoint looks the token up by hash, confirms it isn't revoked, and
+  re-checks the owner still holds the `manager` role. A `MANAGER_AGENT_API_KEY`
+  env var is accepted as an **optional break-glass fallback** (e.g. bootstrap /
+  CI); it is not required. The endpoint runs actions with the service-role
+  client, so a token grants manager-level access to the exposed actions — treat
+  it as a secret.
+  - Token management server functions: `src/lib/manager-api-tokens.functions.ts`
+    (`listApiTokens` / `createApiToken` / `revokeApiToken`); token crypto +
+    the paste-able agent prompt: `src/lib/manager-api-tokens.ts`.
+  - The `/manager/api-tokens` screen also renders a copy-paste **agent prompt**
+    (`buildAgentPrompt`) for Claude Code / opencode / Cursor and points at the
+    `uts-manager-agent` skill.
+
+## Actions
+
+An "invoice" is a `memberships` row — its price/reference/status _are_ the invoice.
+
+- `list_users` — members and their lifecycle status, roles, and invoices.
+- `list_invoices` — invoices with member name/email (to find an id to edit).
+- `edit_invoice` — correct an invoice's detail fields. Cannot set `status` to
+  `active` (activation grants the member role + emails the member, so it runs
+  through bank reconciliation, not a raw edit). Returns `changed` + `previous`
+  alongside the updated invoice, and writes an audit line to the server log
+  (`[agent.edit_invoice] audit`) naming the actor and each field's old → new.
+  **On a paid invoice** (`paid_at` set) the money fields — `price_cents`,
+  `payment_reference`, `payment_method` (`RECONCILED_GUARDED_FIELDS`) — are
+  refused with `409 reconciled_invoice` unless `confirm_paid_edit` is passed:
+  a reconciled invoice's amount is a record of money that moved, and the
+  status it belongs to is already protected. `notes` and `status` stay freely
+  editable (a note claims nothing about money; expiring a membership that ran
+  its course is ordinary). There is **no audit table** — if the log is not
+  enough for the club's bookkeeping, that is a schema change and a product
+  decision, not something to add quietly.
+- `file_waiver` — file a scanned paper waiver (migration / bulk filing from
+  paper records). Same params as the manager's paper-upload form
+  (`paperWaiverUploadSchema`); dispatches to `filePaperWaiver` in
+  `src/lib/waiver.functions.ts`, the same function the web form calls, so an
+  agent-filed waiver and a manager's own upload are identical. Always lands
+  **pending**: it never approves, emails anyone, or marks the email verified
+  — approving is a separate, deliberate manager action because it promotes
+  the record, unlocks the login, emails them that their account is active and
+  assigns the free trial (docs/waivers.md rule 6). `uploaded_by` on the filed row is the
+  token's owner, or the `AGENT_ENV_KEY_UPLOADER` sentinel for the break-glass
+  env key, which has no owner to resolve. Filing a waiver the person already
+  has for the same `signed_on` is refused with `409 duplicate_waiver` (the
+  colliding rows come back in `error.existing`); `confirm_duplicate` files it
+  anyway, for the corrected re-scan that is a genuine second document. The
+  check lives in `filePaperWaiver`, so the manager's own upload form gets the
+  same speed bump.
+
+### `file_waiver`: the parts that have bitten us
+
+- **The two surfaces present that one check differently on purpose, and
+  this is not an inconsistency to tidy up.** The HTTP API returns
+  `409 duplicate_waiver`, because a machine caller needs a distinct status
+  to branch on. `uploadPaperWaiver` instead returns a `filed: false` result
+  carrying the collision, so the screen can show the manager _what_ it hit
+  and offer "file it anyway". A thrown error would reach the form as a
+  toast with the detail lost, which is what makes the guard useless to a
+  human.
+- The check is **check-then-insert, so it cannot stop two racing retries**
+  — neither sees a row the other has not committed. `client_submission_id`
+  is what makes a retry safe: same key, same waiver, enforced by the partial
+  unique index from `20260729020000`, exactly as the online signing path
+  uses it. That index covers the WHOLE table, so the key namespace is shared
+  with the public signing path — both lookups therefore ignore anything that
+  is not a paper filing, or a caller-chosen id could resolve to a waiver a
+  signer's browser minted. Scoping uniqueness per caller
+  (`(uploaded_by, client_submission_id)`) would need a migration and is a
+  deliberate follow-up, not an oversight.
+- Comparing `signed_at` to the string this code WRITES never matches:
+  PostgREST renders TIMESTAMPTZ as `+00:00` with no fractional part. Compare
+  the date part. This killed the whole idempotency path once, and the test
+  fixture hid it by using the write format.
+- Sending a key **transfers an obligation**: a failed filing keeps its row
+  for the retry instead of deleting it, so an abandoned attempt leaves a
+  documentless waiver. `setWaiverApproval` refuses a waiver with no
+  `pdf_path` so that row can never become somebody's ACTIVE record, and the
+  manifest says the obligation exists.
+- A failed probe is `503 duplicate_check_failed` with a `Retry-After`
+  header, deliberately distinct from `file_waiver_failed` and deliberately
+  silent about `confirm_duplicate` — offering that flag as the fix for an
+  outage invites a retry policy to disable the guard wholesale. The 503 is
+  documented as "nothing was filed, safe to retry unchanged", which is true
+  only because the probe runs BEFORE `resolvePersonId`. Moving person
+  creation above it would strand an auth user per retry, and no status-code
+  test would notice.
+- The probe matches a **UTC-day range**, not the midnight instant a paper
+  filing writes, so it catches an online signature on the same day too. The
+  club is UTC+10/+11, so a Sydney-morning signature falls on the previous
+  UTC day — known and accepted, since widening to the club's own day would
+  collide across two dates instead.
+- `paperWaiverUploadSchema` is `.strict()`, matching `editInvoiceSchema`. A
+  misspelled `confirm_duplicate` would otherwise be stripped by Zod, default
+  to false, and return the same 409 forever while the message told the
+  caller to do what they thought they just did.
+
+## Agent glue
+
+`.claude/skills/uts-manager-agent/` — a skill (with a `curl` helper) that
+documents how to call the endpoint. An MCP wrapper is equally simple: one tool
+per manifest action, forwarding to this endpoint.
+
+## Keep these in sync
+
+The action contract lives in **four** places — change all of them together, or
+the agent glue drifts from the deployed API:
+
+1. `src/lib/validation.ts` — `managerAgentActions` + the per-action Zod schemas.
+2. `src/lib/manager-agent.ts` — `AGENT_MANIFEST` (self-description) + projections.
+3. `src/routes/api/manager/agent.ts` — the request dispatch/handlers.
+4. `.claude/skills/uts-manager-agent/SKILL.md` — the agent-facing docs.
+
+`src/lib/manager-agent.test.ts` asserts the manifest matches `managerAgentActions`,
+so a forgotten manifest update fails CI. The `GET` manifest is authoritative at
+runtime: the skill instructs agents to read it before acting, so an MCP/skill
+wrapper never needs hand-syncing beyond the human-readable docs above.
+
+**Bump `AGENT_MANIFEST.version` whenever the behaviour a client can rely on
+changes**, not only when an action is added or removed. A guard that starts
+refusing a call that used to succeed, or a new field in a response, is exactly
+what a client needs the version to tell it about. The version is pinned by a
+test so the bump is a deliberate edit, and the current value is `"6"`.
+
+**Responses carry `version` too**, not just the manifest, so a client that
+cached the manifest at the start of a long run can notice a bump per call
+instead of meeting it as an unexplained refusal. Error payload beyond
+`code`/`message` is nested under `error.details` — never flat-merged, so the
+envelope can grow a reserved key without shadowing a caller's field.
+
+**There is no version pinning.** A caller cannot request the old behaviour; the
+contract is latest-only. That is defensible for a single-tenant API with
+manager-issued tokens where every caller is known, but it means `changes` is a
+record of what already happened, not a negotiation — say so rather than letting
+somebody build a client that expects to pin.
+
+**Add a `changes` entry in the same edit**, with `breaking: true` when the
+version turns a call that used to succeed into an error. A version number alone says only
+that something moved; the client that most needs to know what is the one that
+read the manifest at the start of a long import and cannot re-read it mid-run.
+A test asserts the head of `changes` matches `version`, so the two cannot drift.
+Call out anything that turns a previously-succeeding call into an error — that
+is the note a caching client is actually reading for.

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -127,6 +127,6 @@ own), and reconciliation, activation and cancellation follow the same
 | `/manager/membership-plans` | `list_membership_plans` / `save_membership_plan` | Add, price, date, retire, or duplicate a plan. |
 | `/manager/memberships`      | `list_invoices` / `edit_invoice`                 | See and correct invoices.                      |
 
-Per this repo's standing rule (`AGENTS.md`, "Manager agent API"), the agent
+Per this repo's standing rule (`docs/manager-agent-api.md`), the agent
 actions mirror what a manager can do in the UI — see the skill file for the
 full parameter list and worked examples.

--- a/docs/waivers.md
+++ b/docs/waivers.md
@@ -198,7 +198,7 @@ and a manager files the scan from `/manager/waivers` ("Upload a paper waiver").
 Managers only: nobody else can create a waiver on another person's behalf.
 
 The same filing runs through the manager agent API too (`file_waiver`,
-AGENTS.md), so a manager's own AI agent can file one from a script — the case
+docs/manager-agent-api.md), so a manager's own AI agent can file one from a script — the case
 this is for is migrating a backlog of paper records the club already holds, not
 a member filing their own. It is the identical function behind both entry
 points, so an agent-filed waiver and one uploaded through the form are the same

--- a/src/lib/manager-agent.ts
+++ b/src/lib/manager-agent.ts
@@ -6,7 +6,7 @@
 // invoice-edit patch builder, and the response projections.
 //
 // Keep AGENT_MANIFEST, managerAgentActions (validation.ts), the route dispatch,
-// and the skill (.claude/skills/uts-manager-agent/) in lockstep — see AGENTS.md.
+// and the skill (.claude/skills/uts-manager-agent/) in lockstep. See docs/manager-agent-api.md.
 import { formatCents } from "@/lib/validation";
 import type { EditInvoiceInput } from "@/lib/validation";
 import type { MembershipPlanRow, MembershipRow } from "@/lib/membership-types";

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1515,7 +1515,7 @@ export const matchTransactionSchema = z.object({
 });
 export type MatchTransactionInput = z.infer<typeof matchTransactionSchema>;
 
-// ---- Manager agent API (see src/lib/manager-agent.ts + AGENTS.md) ----
+// ---- Manager agent API (see src/lib/manager-agent.ts + docs/manager-agent-api.md) ----
 //
 // A small HTTP surface a manager's AI agent can drive (via MCP or a skill). The
 // action names below are the contract; keep them in sync with AGENT_MANIFEST in

--- a/src/lib/waiver.functions.ts
+++ b/src/lib/waiver.functions.ts
@@ -1341,7 +1341,7 @@ export async function filePaperWaiver(
     scan_files: data.scan.map((f) => f.name),
   };
   // Not every caller resolves to a real auth user: the manager agent API's
-  // break-glass env-key fallback (docs: AGENTS.md) has no owner to look up, so
+  // break-glass env-key fallback (docs/manager-agent-api.md) has no owner to look up, so
   // skip the lookup rather than log a spurious not-found error every call.
   if (UUID_RE.test(uploadedByUserId)) {
     try {


### PR DESCRIPTION
## Why

The two instruction files had grown to restate each other. The Lovable git-history rule, the migration apply gate, the product-level-plan rule, the copy voice, and the Supabase generated-types gotcha were each written twice, in slightly different words. That costs context on every session and, worse, means the two copies can drift into contradicting each other.

Alongside that, two things were missing from the guidance entirely: how to approach a change that does not fit the code as it stands, and what UX standard a change is held to.

## Deduplication

Every topic now has exactly one owner.

| Topic | Owner now |
| --- | --- |
| Everything about the codebase | `CLAUDE.md` |
| How the site is allowed to talk (copy) | `AGENTS.md` |
| Manager agent HTTP API | `docs/manager-agent-api.md` (new) |
| Data model / schema changes | `docs/database.md`, `docs/database-changes.md` |

- **`AGENTS.md`: 257 → 78 lines.** It keeps the Lovable block and the website copy rules, and points at `CLAUDE.md` for everything else. A short pointer table replaces the restated sections.
- **`CLAUDE.md`** gains a "Where things are written down" map at the top, and absorbs the two build gotchas that its own sections already covered 90% of: the `Could not find the '<column>' ... in the schema cache` symptom and the never-silence-a-stale-type-with-a-cast rule join the Supabase types warning; the `.maybeSingle()` `null` vs `undefined` rule joins Conventions.
- **`docs/manager-agent-api.md` (new)** takes the ~110-line manager agent API spec out of `AGENTS.md`. It is accumulated rationale about one endpoint (the `file_waiver` duplicate guard, the version/`changes` contract, the four sync points) that nobody needs loaded unless they are touching that endpoint. Moving it matches how the rest of `docs/` already works. Nothing was dropped in the move.
- The dangling "see Schema drift" cross-references now name the file that section lives in.

## New: "Make the change easy, then make the easy change"

When a change feels hard, that is information about the code, not about the feature. The section asks for the preparatory refactor to land as its own commit (behaviour identical, tests green either side) before the change it enables, and says to label which kind a commit is so review and revert stay cheap.

The practical rules are grounded in this repo's actual seams: extend `validation.ts` / `*.functions.ts` / `useResilientSubmit` / `supabase-rpc.ts` / `seo.ts` rather than adding a second way to do the same thing, and raise it with the user if a change seems to need one. Plus: extraction into a pure module is usually the whole "make it easy" step (that is why `validation.ts` and `submit-resilience.ts` exist), do not abstract on the second occurrence, no speculative generality, delete what the change makes dead.

## New: "The UX bar"

Name the person the change is for (prospective member on a phone with bad reception, signed-in member, manager doing admin between classes), then hold it to:

- Build the whole state machine, not the happy path. Loading, empty, error, offline, slow, not-allowed, already-done.
- Reuse what already solves this: `AuthPending`, and `useResilientSubmit` + `SubmitStatus` for **every** form that writes, rather than hand-rolling another `setLoading(true) / catch / toast.error`.
- A toast is not a UI for anything that matters.
- Never lose someone's input, and do not ask for what we already know.
- Errors say what to do next. Irreversible or outward-facing actions confirm, in words, what will happen.
- Mobile first, and accessibility is part of "done".
- Look at the screen before calling it finished, and note what the PR-screenshots job does not catch.

`AGENTS.md` also picks up one sentence tying its copy rules to this: write for the state the person is actually in, and it applies to button labels and error text, not just marketing pages.

## Also

- Repointed the in-code and in-docs references to the moved manager agent docs (`src/lib/manager-agent.ts`, `src/lib/validation.ts`, `src/lib/waiver.functions.ts`, `docs/waivers.md`, `docs/memberships.md`).

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (1531 passed) and `bun run build` all pass. `bun.lock` untouched. No schema change, so nothing is waiting to be applied to the database.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jhxy6BM5V1Avynemabqok2)_