### PR TITLE
Give every button the pointer cursor back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,7 +472,11 @@ hand-produce a public-npm lock.
 - **Styling:** Tailwind utility classes; compose conditionals with `cn()` from
   `@/lib/utils`. Reuse `components/ui` primitives and the `SiteLayout`
   (`SiteHeader`/`SiteFooter`) shell for pages. Theme tokens (`bg-background`,
-  `text-muted-foreground`, etc.) come from `styles.css`.
+  `text-muted-foreground`, etc.) come from `styles.css`. Tailwind v4's preflight
+  makes buttons `cursor: default`; a base rule in `styles.css` puts the pointer
+  back on every enabled `button` / `[role="button"]`, so **don't add
+  `cursor-pointer` to a button** (the `components/ui` primitives carry it only
+  because they are generated that way).
 - **SEO:** every public page sets its own `head()` meta (title/description/og)
   **and its own `rel="canonical"`**; manager and other private pages set
   `robots: noindex`. Match the existing pattern when adding pages, and see the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,10 +473,12 @@ hand-produce a public-npm lock.
   `@/lib/utils`. Reuse `components/ui` primitives and the `SiteLayout`
   (`SiteHeader`/`SiteFooter`) shell for pages. Theme tokens (`bg-background`,
   `text-muted-foreground`, etc.) come from `styles.css`. Tailwind v4's preflight
-  makes buttons `cursor: default`; a base rule in `styles.css` puts the pointer
-  back on every enabled `button` / `[role="button"]`, so **don't add
-  `cursor-pointer` to a button** (the `components/ui` primitives carry it only
-  because they are generated that way).
+  dropped v3's `cursor: pointer` on buttons; an `@layer base` rule in
+  `styles.css` puts it back on every enabled `button` / `[role="button"]`, so
+  **don't add `cursor-pointer` to a button** (the `components/ui` primitives
+  carry it only because they are generated that way). That rule has to stay in
+  the base layer — layer order, not specificity, is what lets a `cursor-*`
+  utility still win over it.
 - **SEO:** every public page sets its own `head()` meta (title/description/og)
   **and its own `rel="canonical"`**; manager and other private pages set
   `robots: noindex`. Match the existing pattern when adding pages, and see the

--- a/src/styles.css
+++ b/src/styles.css
@@ -134,13 +134,17 @@
     letter-spacing: -0.02em;
   }
 
-  /* Tailwind v4's preflight sets buttons to `cursor: default`, matching the
-     browser default rather than the pointer people expect from something
+  /* Tailwind v3's preflight gave buttons `cursor: pointer`; v4 dropped that
+     rule, so a button falls back to the browser's own arrow and stops looking
      clickable. Every `components/ui` primitive puts `cursor-pointer` back one
-     class at a time, so only the hand-written buttons around the site were
-     left with an arrow cursor. Restore it once here instead: utilities still
-     win on specificity, so a button that wants a different cursor (the
-     primitives' own `disabled:cursor-not-allowed`) keeps it. */
+     class at a time, which left only the hand-written buttons around the site
+     showing an arrow. Restore it once here instead.
+
+     This must stay inside `@layer base`. That, not specificity, is what lets a
+     `cursor-*` utility override it: the selector is (0,1,1), so out of the
+     layer it would beat `.cursor-default` and break the buttons that ask for a
+     different cursor on purpose (`MenubarTrigger`, `SidebarRail`'s resize
+     handles, every `disabled:cursor-not-allowed`). */
   button:not(:disabled, [aria-disabled="true"]),
   [role="button"]:not(:disabled, [aria-disabled="true"]) {
     cursor: pointer;

--- a/src/styles.css
+++ b/src/styles.css
@@ -133,4 +133,16 @@
     font-weight: 900;
     letter-spacing: -0.02em;
   }
+
+  /* Tailwind v4's preflight sets buttons to `cursor: default`, matching the
+     browser default rather than the pointer people expect from something
+     clickable. Every `components/ui` primitive puts `cursor-pointer` back one
+     class at a time, so only the hand-written buttons around the site were
+     left with an arrow cursor. Restore it once here instead: utilities still
+     win on specificity, so a button that wants a different cursor (the
+     primitives' own `disabled:cursor-not-allowed`) keeps it. */
+  button:not(:disabled, [aria-disabled="true"]),
+  [role="button"]:not(:disabled, [aria-disabled="true"]) {
+    cursor: pointer;
+  }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -140,11 +140,12 @@
      class at a time, which left only the hand-written buttons around the site
      showing an arrow. Restore it once here instead.
 
-     This must stay inside `@layer base`. That, not specificity, is what lets a
-     `cursor-*` utility override it: the selector is (0,1,1), so out of the
-     layer it would beat `.cursor-default` and break the buttons that ask for a
-     different cursor on purpose (`MenubarTrigger`, `SidebarRail`'s resize
-     handles, every `disabled:cursor-not-allowed`). */
+     This must stay inside `@layer base`. Layer order is the only reason a
+     `cursor-*` utility beats it — an unlayered rule outranks every layer, and
+     the selector is (0,1,1) besides, so lifting it out would override the
+     buttons that ask for a different cursor on purpose: `SidebarRail`'s resize
+     handles, the KB reorder handle's `cursor-grab`, every
+     `disabled:cursor-not-allowed`. */
   button:not(:disabled, [aria-disabled="true"]),
   [role="button"]:not(:disabled, [aria-disabled="true"]) {
     cursor: pointer;


### PR DESCRIPTION
## What changes for people using the site

Hovering anything clickable now shows the hand cursor. The one that prompted this is on the waiver form, under the email field when you are signed in: "Wrong email? **Log out** to sign under a different address" kept the plain arrow cursor, so it did not look pressable. The same was true of every other hand-written button on the site (for example "Start fresh instead" a little further up the same form, "Try again" on a blog post's comments, the manager screens' inline actions).

Nothing else moves, and nothing changes for buttons that are switched off: a disabled button keeps the arrow, and the ones that already show "not allowed" still do.

## Why it was happening

Tailwind v3's preflight gave buttons `cursor: pointer`; v4 dropped that rule, so a button falls back to the browser's own arrow. The generated `components/ui` primitives each put `cursor-pointer` back by hand, so shadcn buttons were fine and anything written directly in a page was not.

Rather than patch the one button, this restores the pointer once in the `@layer base` block of `src/styles.css` for enabled `button` / `[role="button"]`, and excludes `:disabled` / `aria-disabled="true"`. It has to stay in that layer: **cascade-layer order, not specificity**, is what lets a `cursor-*` utility still override it, so lifting the rule out would break the buttons that ask for a different cursor on purpose (`SidebarRail`'s resize handles, the KB reorder handle's `cursor-grab`, every `disabled:cursor-not-allowed`).

`CLAUDE.md` now records the rule, so nobody adds `cursor-pointer` to a button again.

## Verification

- `bun run lint`, `bun run typecheck`, `bun run test` (1559 passing), `bun run build` all green locally and in CI.
- Loaded the built stylesheet in Chromium and read the computed cursor: enabled bare button `pointer`, disabled button `default`, disabled primitive-style button `not-allowed`.
- Two independent reviews: the first caught two wrong claims in the explanatory comment (fixed in `090b442`), the second verified the layer order and selector against the real Tailwind 4.2.4 source and grepped `src/` for cursor conflicts, finding none.