### PR TITLE
Waiver: one answer when a required field is missing

### DIFF
--- a/docs/waivers.md
+++ b/docs/waivers.md
@@ -156,6 +156,36 @@ login record is created (their email, no way to sign in) and their profile is
 seeded with name + phone. An existing person is left untouched. Either way the
 waiver row stores the full submission, and the person is now an applicant.
 
+### When something is missing
+
+Pressing "Sign and download waiver" with anything outstanding always does the
+same two things, whatever was left out:
+
+- **A summary appears at the top of the form**, naming every outstanding field
+  at once and counting them ("3 things are missing before you can sign"). Each
+  line is a link to the field it is about. It stays on screen and re-counts
+  itself as they work down the list, so a field drops off the moment it is
+  filled in rather than waiting for another press.
+- **The page goes to the first one**, in the form's own reading order, top to
+  bottom, and focuses it. That field, and every other one on the list, is
+  outlined and carries a line saying what it needs, because the jump can leave
+  the summary off screen.
+
+Nothing is marked before the first press: a half-filled form is somebody
+part-way through, not a form full of errors.
+
+The rule is one list, in `src/lib/waiver-required-fields.ts`, computed from the
+form's state. The form is `noValidate`, deliberately: the browser's own
+`required` handling would stop at its first blank text input with a bubble that
+fades, and would say nothing at all about the health answers, the
+acknowledgement ticks or the signature, which is how the page used to answer in
+two different voices depending on what you had missed. Email format is checked
+there too, since dropping native validation makes that ours to report.
+
+It is a courtesy, not the gate: `waiverSubmitSchema` on the server still decides
+whether a waiver may be filed. This is what lets the signer hear it in their own
+words before a round trip, instead of as a Zod issue dump.
+
 ### Signing on a bad connection
 
 The waiver is the one form where "it silently did not go through" is expensive:

--- a/src/lib/waiver-health.ts
+++ b/src/lib/waiver-health.ts
@@ -15,6 +15,13 @@ export type HealthQuestion = {
   id: HealthQuestionId;
   /** The question, as asked on the form and printed on the document. */
   question: string;
+  /**
+   * A few words naming the question, for somewhere the whole sentence does not
+   * fit: the "you still have to answer this" list the signing form shows when
+   * someone presses Sign with questions left blank. Five full questions there
+   * would be a wall of text on a phone.
+   */
+  shortLabel: string;
 };
 
 /** The five questions, in the order the form asks them. */
@@ -23,25 +30,30 @@ export const healthQuestions: HealthQuestion[] = [
     id: "drugs",
     question:
       "Is the participant prescribed any drugs which may impair reaction time or judgement?",
+    shortLabel: "prescribed drugs",
   },
   {
     id: "blackouts",
     question:
       "Has the participant, within the past 5 years, suffered any blackout, seizure, convulsion, fainting or dizzy spells, or any incapacity that would render it unsafe to participate in martial arts?",
+    shortLabel: "blackouts, seizures or dizzy spells",
   },
   {
     id: "device",
     question: "Is the participant fitted with any electronic device or shunt?",
+    shortLabel: "electronic device or shunt",
   },
   {
     id: "impairments",
     question:
       "Does the participant have any current physical impairment, injuries or medical conditions (for example back injuries, weak ankles)?",
+    shortLabel: "injuries or medical conditions",
   },
   {
     id: "other",
     question:
       "Is there any other medical information or health needs our instructors should be aware of for the participant's safety?",
+    shortLabel: "anything else we should know",
   },
 ];
 

--- a/src/lib/waiver-required-fields.test.ts
+++ b/src/lib/waiver-required-fields.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from "vitest";
+import {
+  ackAnchorId,
+  missingFieldsSummary,
+  missingWaiverFields,
+  type WaiverFieldState,
+} from "./waiver-required-fields";
+import { healthQuestions } from "./waiver-health";
+
+const allAnswered = {
+  drugs: false,
+  blackouts: false,
+  device: false,
+  impairments: false,
+  other: false,
+};
+
+/** A form with nothing filled in, i.e. what a first-time signer starts from. */
+const emptyForm: WaiverFieldState = {
+  firstName: "",
+  lastName: "",
+  dob: "",
+  phone: "",
+  email: "",
+  address: "",
+  ecName: "",
+  ecRelationship: "",
+  ecPhone: "",
+  health: {},
+  medical: "",
+  ackDefs: [],
+  acks: {},
+  signatureMode: "draw",
+  signatureName: "",
+  signatureImage: "",
+  isMinor: false,
+  guardianSignatureMode: "draw",
+  guardianSignature: "",
+  guardianSignatureImage: "",
+};
+
+/** A form that is ready to send: every required field filled, signed by hand. */
+const completeForm: WaiverFieldState = {
+  ...emptyForm,
+  firstName: "Sam",
+  lastName: "Nguyen",
+  dob: "1995-04-02",
+  phone: "0400 000 000",
+  email: "sam@example.com",
+  address: "1 Broadway, Ultimo NSW 2007",
+  ecName: "Alex Nguyen",
+  ecRelationship: "Partner",
+  ecPhone: "0400 111 111",
+  health: allAnswered,
+  signatureImage: "data:image/png;base64,AAAA",
+};
+
+const form = (over: Partial<WaiverFieldState> = {}): WaiverFieldState => ({
+  ...completeForm,
+  ...over,
+});
+
+describe("missingWaiverFields", () => {
+  it("is empty for a form that is ready to send", () => {
+    expect(missingWaiverFields(completeForm)).toEqual([]);
+  });
+
+  // The whole point of the list: one press of Sign names everything that is
+  // outstanding, not just the first thing the browser happened to notice.
+  it("names every outstanding field at once, not one at a time", () => {
+    const missing = missingWaiverFields(emptyForm);
+    expect(missing.length).toBeGreaterThan(10);
+    expect(missing.map((f) => f.label)).toContain("First name");
+    expect(missing.map((f) => f.label)).toContain("Your signature");
+  });
+
+  // The order is what "jump to the first missing field" means. Reading order,
+  // top to bottom, so the first entry is the one nearest the top of the page.
+  it("lists fields in the order the form asks for them", () => {
+    const missing = missingWaiverFields(emptyForm).map((f) => f.anchorId);
+    expect(missing).toEqual([
+      "first_name",
+      "last_name",
+      "date_of_birth",
+      "phone",
+      "email",
+      "address",
+      "emergency_contact_name",
+      "emergency_contact_relationship",
+      "emergency_contact_phone",
+      ...healthQuestions.map((q) => `${q.id}_yes`),
+      "signature_field",
+    ]);
+  });
+
+  it("puts a missing field further down the form after the ones above it", () => {
+    const missing = missingWaiverFields(form({ address: "", ecPhone: "" }));
+    expect(missing.map((f) => f.anchorId)).toEqual(["address", "emergency_contact_phone"]);
+  });
+
+  it("treats whitespace as blank", () => {
+    const missing = missingWaiverFields(form({ firstName: "   " }));
+    expect(missing.map((f) => f.anchorId)).toEqual(["first_name"]);
+  });
+
+  it("gives every entry an anchor and a label", () => {
+    for (const field of missingWaiverFields(emptyForm)) {
+      expect(field.anchorId).toBeTruthy();
+      expect(field.label).toBeTruthy();
+    }
+  });
+
+  // The form drops the browser's own checking (one bubble, on one field), so an
+  // address that is present but not an address has to be caught here or it
+  // reaches the server and comes back as a Zod issue.
+  it("flags an email that is filled in but is not an email address", () => {
+    const missing = missingWaiverFields(form({ email: "sam.example.com" }));
+    expect(missing).toHaveLength(1);
+    expect(missing[0].anchorId).toBe("email");
+    expect(missing[0].hint).toBeTruthy();
+  });
+
+  it("accepts an email with surrounding whitespace", () => {
+    expect(missingWaiverFields(form({ email: "  sam@example.com  " }))).toEqual([]);
+  });
+
+  describe("health declaration", () => {
+    it("lists each unanswered question separately, in the order asked", () => {
+      const missing = missingWaiverFields(form({ health: { drugs: true, device: false } }));
+      expect(missing.map((f) => f.anchorId)).toEqual([
+        "blackouts_yes",
+        "impairments_yes",
+        "other_yes",
+        // The "yes" to drugs is what makes the details box required.
+        "medical_notes",
+      ]);
+    });
+
+    it("names a question in a few words rather than repeating the sentence", () => {
+      const [first] = missingWaiverFields(form({ health: {} }));
+      expect(first.label).toBe("Health question: prescribed drugs");
+    });
+
+    it("requires the details box once anything is answered yes", () => {
+      const yes = { ...allAnswered, impairments: true };
+      expect(missingWaiverFields(form({ health: yes })).map((f) => f.anchorId)).toEqual([
+        "medical_notes",
+      ]);
+      expect(missingWaiverFields(form({ health: yes, medical: "Sore left knee" }))).toEqual([]);
+    });
+
+    it("leaves the details box optional when every answer is no", () => {
+      expect(missingWaiverFields(form({ health: allAnswered, medical: "" }))).toEqual([]);
+    });
+  });
+
+  describe("acknowledgements", () => {
+    const ackDefs = [
+      { id: "risk", label: "I accept the risks of training.", required: true },
+      { id: "media", label: "Photos of me may be used.", required: false },
+    ];
+
+    it("lists a required acknowledgement that has not been ticked", () => {
+      const missing = missingWaiverFields(form({ ackDefs, acks: {} }));
+      expect(missing.map((f) => f.anchorId)).toEqual([ackAnchorId("risk")]);
+      expect(missing[0].label).toBe("I accept the risks of training.");
+    });
+
+    it("ignores an optional acknowledgement", () => {
+      expect(missingWaiverFields(form({ ackDefs, acks: { risk: true } }))).toEqual([]);
+    });
+
+    it("shortens a long acknowledgement so the summary stays readable", () => {
+      const long = "I ".padEnd(200, "acknowledge and agree ");
+      const [entry] = missingWaiverFields(
+        form({ ackDefs: [{ id: "long", label: long, required: true }], acks: {} }),
+      );
+      expect(entry.label.length).toBeLessThanOrEqual(73);
+      expect(entry.label.endsWith("...")).toBe(true);
+    });
+  });
+
+  describe("signature", () => {
+    it("points at the pad when they are drawing", () => {
+      const missing = missingWaiverFields(form({ signatureMode: "draw", signatureImage: "" }));
+      expect(missing.map((f) => f.anchorId)).toEqual(["signature_field"]);
+    });
+
+    it("points at the name box when they are typing", () => {
+      const missing = missingWaiverFields(
+        form({ signatureMode: "type", signatureName: "", signatureImage: "" }),
+      );
+      expect(missing.map((f) => f.anchorId)).toEqual(["signature_name"]);
+    });
+
+    // Only the active tab counts, the same way only the active tab is sent.
+    it("does not accept a drawing while the typed tab is showing", () => {
+      const missing = missingWaiverFields(
+        form({ signatureMode: "type", signatureName: "", signatureImage: "data:image/png;x" }),
+      );
+      expect(missing.map((f) => f.anchorId)).toEqual(["signature_name"]);
+    });
+
+    it("accepts a typed name", () => {
+      expect(
+        missingWaiverFields(form({ signatureMode: "type", signatureName: "Sam Nguyen" })),
+      ).toEqual([]);
+    });
+  });
+
+  describe("participant under 18", () => {
+    it("asks for a guardian signature, after the applicant's own", () => {
+      const missing = missingWaiverFields(
+        form({ isMinor: true, signatureImage: "", guardianSignatureImage: "" }),
+      );
+      expect(missing.map((f) => f.anchorId)).toEqual([
+        "signature_field",
+        "guardian_signature_field",
+      ]);
+    });
+
+    it("points at the guardian name box when the guardian is typing", () => {
+      const missing = missingWaiverFields(form({ isMinor: true, guardianSignatureMode: "type" }));
+      expect(missing.map((f) => f.anchorId)).toEqual(["guardian_signature_name"]);
+    });
+
+    it("is satisfied by a guardian signature", () => {
+      expect(
+        missingWaiverFields(
+          form({ isMinor: true, guardianSignatureImage: "data:image/png;base64,BBBB" }),
+        ),
+      ).toEqual([]);
+    });
+
+    it("asks for nothing extra from an adult", () => {
+      expect(missingWaiverFields(form({ isMinor: false }))).toEqual([]);
+    });
+  });
+});
+
+describe("missingFieldsSummary", () => {
+  it("counts, so the signer knows how far off they are", () => {
+    expect(missingFieldsSummary(1)).toBe("One thing is missing before you can sign");
+    expect(missingFieldsSummary(4)).toBe("4 things are missing before you can sign");
+  });
+});

--- a/src/lib/waiver-required-fields.ts
+++ b/src/lib/waiver-required-fields.ts
@@ -1,0 +1,184 @@
+// What the waiver form is still waiting on, in the order it asks for it.
+//
+// The signing form used to answer "you missed something" in two different
+// voices. The plain text inputs carried the browser's own `required` attribute,
+// so a missing name got a native bubble on one field and whatever scrolling the
+// browser felt like; everything the browser cannot check (the five health
+// answers, the acknowledgement ticks, the signature) got a toast that named one
+// problem at a time and then faded. Someone with three things left blank found
+// out about them one press at a time, and on a phone the toast was often gone
+// before they had finished scrolling.
+//
+// So the form does its own checking, and this module is the whole rule: one
+// ordered list of what is missing, computed from the form's state, with the id
+// of the control to jump to for each entry. The order IS the form's reading
+// order, top to bottom, which is what makes "jump to the first one" mean the
+// first one a person would have filled in.
+//
+// It deliberately mirrors `waiverSubmitSchema` in `validation.ts` rather than
+// replacing it: the server is still the thing that decides whether a waiver may
+// be filed. This exists so the signer hears it in their own words, before a
+// round trip, instead of as a Zod issue dump.
+//
+// Kept side-effect-free and server-import-free so it stays unit-testable.
+import { z } from "zod";
+import { anyHealthConcern, missingHealthAnswers, type HealthAnswerDraft } from "./waiver-health";
+import {
+  missingRequiredAcks,
+  type AcknowledgementAnswers,
+  type TemplateAcknowledgement,
+} from "./waiver-acknowledgements";
+
+/** One thing the signer still has to do before the form can be sent. */
+export type MissingWaiverField = {
+  /**
+   * The `id` of the element to scroll to and focus. Every entry has one, which
+   * is what lets the summary list double as a set of jump links.
+   */
+  anchorId: string;
+  /** What it is called, in the same words as the label on the form. */
+  label: string;
+  /** How to satisfy it, when "fill this in" is not the whole story. */
+  hint?: string;
+};
+
+/** The form's state, as far as "is this fillable in" is concerned. */
+export type WaiverFieldState = {
+  firstName: string;
+  lastName: string;
+  dob: string;
+  phone: string;
+  email: string;
+  address: string;
+  ecName: string;
+  ecRelationship: string;
+  ecPhone: string;
+  health: HealthAnswerDraft;
+  medical: string;
+  /** The current template's acknowledgements, labels already substituted. */
+  ackDefs: TemplateAcknowledgement[];
+  acks: AcknowledgementAnswers;
+  signatureMode: "draw" | "type";
+  signatureName: string;
+  signatureImage: string;
+  isMinor: boolean;
+  guardianSignatureMode: "draw" | "type";
+  guardianSignature: string;
+  guardianSignatureImage: string;
+};
+
+/** The dom id of an acknowledgement's tick box. */
+export const ackAnchorId = (id: string) => `ack_${id}`;
+
+/** Where the signature block jumps to, which depends on how they are signing. */
+export const signatureAnchorId = (mode: "draw" | "type") =>
+  mode === "type" ? "signature_name" : "signature_field";
+
+/** Same, for the parent/guardian block shown for a participant under 18. */
+export const guardianSignatureAnchorId = (mode: "draw" | "type") =>
+  mode === "type" ? "guardian_signature_name" : "guardian_signature_field";
+
+// Same rule the submission schema applies, so the form cannot wave through an
+// address the server will reject. The form's own `maxLength` caps the length.
+const emailField = z.string().trim().email();
+
+/** An acknowledgement label is a whole sentence; the summary shows the start. */
+function shorten(label: string, max = 70): string {
+  const text = label.trim();
+  return text.length <= max ? text : `${text.slice(0, max).trimEnd()}...`;
+}
+
+/**
+ * Everything the signer still has to do, top to bottom.
+ *
+ * Empty means the form is ready to send. The first entry is the one to jump to.
+ */
+export function missingWaiverFields(state: WaiverFieldState): MissingWaiverField[] {
+  const missing: MissingWaiverField[] = [];
+  const require = (anchorId: string, label: string, value: string) => {
+    if (!value.trim()) missing.push({ anchorId, label });
+  };
+
+  // ---- Your details ----
+  require("first_name", "First name", state.firstName);
+  require("last_name", "Last name", state.lastName);
+  require("date_of_birth", "Date of birth", state.dob);
+  require("phone", "Phone", state.phone);
+  if (!state.email.trim()) {
+    missing.push({ anchorId: "email", label: "Email" });
+  } else if (!emailField.safeParse(state.email).success) {
+    // Listed with the missing fields on purpose: to the person filling the form
+    // these are the same problem, "this one is not right yet". Dropping the
+    // browser's native checking is what makes it ours to report.
+    missing.push({
+      anchorId: "email",
+      label: "Email",
+      hint: "Check the address, it should look like name@example.com",
+    });
+  }
+  require("address", "Address", state.address);
+
+  // ---- Emergency contact / guardian ----
+  require("emergency_contact_name", "Emergency contact name", state.ecName);
+  require("emergency_contact_relationship", "Emergency contact relationship", state.ecRelationship);
+  require("emergency_contact_phone", "Emergency contact mobile", state.ecPhone);
+
+  // ---- Health declaration ----
+  for (const question of missingHealthAnswers(state.health)) {
+    missing.push({
+      anchorId: `${question.id}_yes`,
+      label: `Health question: ${question.shortLabel}`,
+      hint: "Answer yes or no",
+    });
+  }
+  if (anyHealthConcern(state.health) && !state.medical.trim()) {
+    missing.push({
+      anchorId: "medical_notes",
+      label: "Details of anything you answered yes to",
+    });
+  }
+
+  // ---- Acknowledgements ----
+  for (const ack of missingRequiredAcks(state.ackDefs, state.acks)) {
+    missing.push({
+      anchorId: ackAnchorId(ack.id),
+      label: shorten(ack.label),
+      hint: "Please read this and tick it",
+    });
+  }
+
+  // ---- Signature ----
+  const signature = state.signatureMode === "draw" ? state.signatureImage : state.signatureName;
+  if (!signature.trim()) {
+    missing.push({
+      anchorId: signatureAnchorId(state.signatureMode),
+      label: "Your signature",
+      hint: "Draw it or type your full name",
+    });
+  }
+  if (state.isMinor) {
+    const guardian =
+      state.guardianSignatureMode === "draw"
+        ? state.guardianSignatureImage
+        : state.guardianSignature;
+    if (!guardian.trim()) {
+      missing.push({
+        anchorId: guardianSignatureAnchorId(state.guardianSignatureMode),
+        label: "Parent or guardian signature",
+        hint: "A parent or guardian signs for participants under 18",
+      });
+    }
+  }
+
+  return missing;
+}
+
+/**
+ * The heading over the summary. Counted, because "3 things" tells someone at a
+ * glance whether they are one tick or half a form away from signing.
+ */
+export function missingFieldsSummary(count: number): string {
+  return count === 1
+    ? "One thing is missing before you can sign"
+    : `${count} things are missing before you can sign`;
+}

--- a/src/lib/waiver-required-fields.ts
+++ b/src/lib/waiver-required-fields.ts
@@ -70,13 +70,27 @@ export type WaiverFieldState = {
 /** The dom id of an acknowledgement's tick box. */
 export const ackAnchorId = (id: string) => `ack_${id}`;
 
+/**
+ * The ids of the two signature blocks, invented here rather than being a
+ * field's own name. The form puts them on the elements, so both sides read them
+ * from this one place: an id that only matched by convention would come apart
+ * silently, as a jump that goes nowhere and a field that is never marked, with
+ * nothing in a typecheck or a test to notice.
+ */
+export const WAIVER_ANCHORS = {
+  signaturePad: "signature_field",
+  signatureName: "signature_name",
+  guardianPad: "guardian_signature_field",
+  guardianName: "guardian_signature_name",
+} as const;
+
 /** Where the signature block jumps to, which depends on how they are signing. */
 export const signatureAnchorId = (mode: "draw" | "type") =>
-  mode === "type" ? "signature_name" : "signature_field";
+  mode === "type" ? WAIVER_ANCHORS.signatureName : WAIVER_ANCHORS.signaturePad;
 
 /** Same, for the parent/guardian block shown for a participant under 18. */
 export const guardianSignatureAnchorId = (mode: "draw" | "type") =>
-  mode === "type" ? "guardian_signature_name" : "guardian_signature_field";
+  mode === "type" ? WAIVER_ANCHORS.guardianName : WAIVER_ANCHORS.guardianPad;
 
 // Same rule the submission schema applies, so the form cannot wave through an
 // address the server will reject. The form's own `maxLength` caps the length.

--- a/src/routes/waiver.test.tsx
+++ b/src/routes/waiver.test.tsx
@@ -225,22 +225,35 @@ describe("/waiver missing fields", () => {
 
   // The jump can leave the summary scrolled off screen, and a red border is a
   // colour: whoever lands on the field has to be able to read why they are here.
-  it("gives every flagged field a message of its own, tied to the field", async () => {
+  // Tied to the control, not merely rendered near it, or a screen reader
+  // announces an invalid field and nothing about what it wants. This has to
+  // hold for the controls the browser could never have checked too, which is
+  // exactly where an earlier version of this only rendered the text.
+  it("gives every flagged control a message of its own, tied to the control", async () => {
     const user = userEvent.setup();
     renderWaiver();
     await screen.findByLabelText("First name");
 
     await user.click(screen.getByRole("button", { name: /Sign and download waiver/i }));
 
-    const firstName = await screen.findByLabelText("First name");
-    await waitFor(() => expect(firstName).toHaveAccessibleDescription("Please fill this in."));
-    expect(document.getElementById("drugs_yes_needed")).toHaveTextContent("Answer yes or no.");
-    expect(document.getElementById("signature_field_needed")).toHaveTextContent(
-      "Draw it or type your full name.",
+    await waitFor(() =>
+      expect(screen.getByLabelText("First name")).toHaveAccessibleDescription(
+        "Please fill this in.",
+      ),
     );
-    expect(document.getElementById(`${ackAnchorId("risk")}_needed`)).toHaveTextContent(
-      "Please read this and tick it.",
-    );
+    // A radio group, a checkbox and the signature pad's wrapper, none of which
+    // are inputs, and the last of which is what focus lands on while drawing.
+    expect(
+      screen.getByRole("radiogroup", { name: /prescribed any drugs/i }),
+    ).toHaveAccessibleDescription("Answer yes or no.");
+    expect(
+      screen.getByRole("checkbox", { name: /I accept the risks of training/i }),
+    ).toHaveAccessibleDescription("Please read this and tick it.");
+    const pad = screen.getByRole("group", { name: "Your signature" });
+    expect(pad).toHaveAccessibleDescription("Draw it or type your full name.");
+    expect(pad).toHaveAttribute("aria-invalid", "true");
+    // And the ids the messages carry are the ones the controls point at.
+    expect(document.getElementById(`${ackAnchorId("risk")}_needed`)).toBeInTheDocument();
   });
 
   it("explains a malformed email on the field as well as in the summary", async () => {

--- a/src/routes/waiver.test.tsx
+++ b/src/routes/waiver.test.tsx
@@ -1,0 +1,237 @@
+// Pressing Sign with something missing has to answer the same way every time.
+//
+// It used to answer in two voices: the browser's own `required` bubble on the
+// first blank text input, and a toast, one problem at a time, for everything
+// the browser cannot see (the health answers, the acknowledgement ticks, the
+// signature). Which one you got depended on what you had left blank. This pins
+// the two things the page now always does: name everything that is outstanding
+// in a summary that stays on screen, and take the person to the first one.
+//
+// The router, the site chrome, Supabase and the signature pad are mocked out:
+// what is under test is this page's submit guard, not any of those.
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const submitWaiverWithPdf = vi.fn();
+const getCurrentWaiverTemplate = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => ({
+    ...opts,
+    useSearch: () => ({}),
+  }),
+  Link: ({ children, ...rest }: { children: ReactNode }) => <a {...rest}>{children}</a>,
+}));
+
+vi.mock("@tanstack/react-start", () => ({
+  useServerFn: (fn: unknown) => fn,
+}));
+
+vi.mock("@/lib/waiver.functions", () => ({
+  submitWaiverWithPdf: (...args: unknown[]) => submitWaiverWithPdf(...args),
+  getCurrentWaiverTemplate: (...args: unknown[]) => getCurrentWaiverTemplate(...args),
+  getMyProfile: vi.fn(),
+  checkWaiverSubmission: vi.fn(),
+}));
+
+vi.mock("@/lib/email-verification.functions", () => ({
+  redeemWaiverEmailVerification: vi.fn(),
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: { auth: { signOut: vi.fn() } },
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: null, session: null, loading: false }),
+}));
+
+vi.mock("@/components/site/SiteLayout", () => ({
+  SiteLayout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+// The real pad needs a canvas 2d context, which jsdom has none of, and the
+// element the summary jumps to for a drawn signature belongs to the page.
+vi.mock("@/components/site/SignaturePad", () => ({
+  SignaturePad: ({ ariaLabel }: { ariaLabel?: string }) => (
+    <canvas aria-label={ariaLabel ?? "Signature pad"} />
+  ),
+}));
+
+const { Route } = await import("./waiver");
+const Waiver = (Route as unknown as { component: () => ReactNode }).component;
+
+function renderWaiver() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <Waiver />
+    </QueryClientProvider>,
+  );
+}
+
+/** The summary banner, once it is on screen. */
+function summary() {
+  return screen.getByRole("alert");
+}
+
+beforeEach(() => {
+  submitWaiverWithPdf.mockReset();
+  getCurrentWaiverTemplate.mockReset();
+  getCurrentWaiverTemplate.mockResolvedValue({
+    id: "t1",
+    version: 3,
+    title: "Training waiver",
+    body_md: "The waiver text.",
+    acknowledgements: [
+      { id: "risk", label: "I accept the risks of training.", required: true },
+      { id: "media", label: "Photos of me may be used.", required: false },
+    ],
+  });
+  sessionStorage.clear();
+  // jsdom implements neither, and both run on the jump to a missing field.
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe("/waiver missing fields", () => {
+  it("says nothing is wrong before they have pressed Sign", async () => {
+    renderWaiver();
+    await screen.findByLabelText("First name");
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("lists everything that is missing, and sends nothing", async () => {
+    const user = userEvent.setup();
+    renderWaiver();
+    await screen.findByLabelText("First name");
+
+    await user.click(screen.getByRole("button", { name: /Sign and download waiver/i }));
+
+    const banner = await screen.findByRole("alert");
+    expect(banner).toHaveTextContent(/things are missing before you can sign/i);
+    for (const label of [
+      "First name",
+      "Last name",
+      "Date of birth",
+      "Phone",
+      "Email",
+      "Address",
+      "Emergency contact name",
+      "Health question: prescribed drugs",
+      "I accept the risks of training.",
+      "Your signature",
+    ]) {
+      expect(within(banner).getByRole("button", { name: label })).toBeInTheDocument();
+    }
+    // An optional acknowledgement is not something they are missing.
+    expect(within(banner).queryByRole("button", { name: /Photos of me/ })).not.toBeInTheDocument();
+    expect(submitWaiverWithPdf).not.toHaveBeenCalled();
+  });
+
+  it("takes them to the first missing field, top to bottom", async () => {
+    const user = userEvent.setup();
+    renderWaiver();
+    const firstName = await screen.findByLabelText("First name");
+
+    await user.click(screen.getByRole("button", { name: /Sign and download waiver/i }));
+
+    await waitFor(() => expect(firstName.scrollIntoView).toHaveBeenCalled());
+    expect(firstName).toHaveFocus();
+  });
+
+  it("skips over the fields that are filled in", async () => {
+    const user = userEvent.setup();
+    renderWaiver();
+    const firstName = await screen.findByLabelText("First name");
+    await user.type(firstName, "Ada");
+    await user.type(screen.getByLabelText("Last name"), "Lovelace");
+
+    await user.click(screen.getByRole("button", { name: /Sign and download waiver/i }));
+
+    await waitFor(() => expect(screen.getByLabelText("Date of birth")).toHaveFocus());
+  });
+
+  // Whatever the browser could never have checked has to behave the same way as
+  // a blank text box: named in the summary, and jumped to when it is first.
+  it("treats an unanswered health question like any other missing field", async () => {
+    const user = userEvent.setup();
+    renderWaiver();
+    await screen.findByLabelText("First name");
+    await user.type(screen.getByLabelText("First name"), "Ada");
+    await user.type(screen.getByLabelText("Last name"), "Lovelace");
+    await user.type(screen.getByLabelText("Date of birth"), "1990-01-01");
+    await user.type(screen.getByLabelText("Phone"), "0400000000");
+    await user.type(screen.getByLabelText("Email"), "ada@example.com");
+    await user.type(screen.getByLabelText("Address"), "1 Broadway");
+    await user.type(screen.getByLabelText("Contact name"), "Alex");
+    await user.type(screen.getByLabelText("Relationship"), "Partner");
+    await user.type(screen.getByLabelText("Contact mobile"), "0400111111");
+
+    await user.click(screen.getByRole("button", { name: /Sign and download waiver/i }));
+
+    await waitFor(() => expect(document.getElementById("drugs_yes")).toHaveFocus());
+    expect(summary()).toHaveTextContent("Health question: prescribed drugs");
+  });
+
+  it("drops a field off the list as soon as it is filled in", async () => {
+    const user = userEvent.setup();
+    renderWaiver();
+    await screen.findByLabelText("First name");
+
+    await user.click(screen.getByRole("button", { name: /Sign and download waiver/i }));
+    const banner = await screen.findByRole("alert");
+    expect(within(banner).getByRole("button", { name: "First name" })).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("First name"), "Ada");
+
+    await waitFor(() =>
+      expect(
+        within(summary()).queryByRole("button", { name: "First name" }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(summary()).toHaveTextContent(/missing before you can sign/i);
+  });
+
+  it("jumps to a field from its line in the summary", async () => {
+    const user = userEvent.setup();
+    renderWaiver();
+    await screen.findByLabelText("First name");
+
+    await user.click(screen.getByRole("button", { name: /Sign and download waiver/i }));
+    const banner = await screen.findByRole("alert");
+    await user.click(within(banner).getByRole("button", { name: "Address" }));
+
+    await waitFor(() => expect(screen.getByLabelText("Address")).toHaveFocus());
+  });
+
+  it("marks the fields it is pointing at, for whoever lands on one", async () => {
+    const user = userEvent.setup();
+    renderWaiver();
+    await screen.findByLabelText("First name");
+
+    await user.click(screen.getByRole("button", { name: /Sign and download waiver/i }));
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("First name")).toHaveAttribute("aria-invalid", "true"),
+    );
+    // Optional fields are never marked.
+    expect(screen.getByLabelText(/Middle name/)).not.toHaveAttribute("aria-invalid");
+  });
+
+  it("catches an email that is filled in but is not an address", async () => {
+    const user = userEvent.setup();
+    renderWaiver();
+    await screen.findByLabelText("First name");
+    await user.type(screen.getByLabelText("Email"), "ada.example.com");
+
+    await user.click(screen.getByRole("button", { name: /Sign and download waiver/i }));
+
+    const banner = await screen.findByRole("alert");
+    expect(within(banner).getByRole("button", { name: "Email" })).toBeInTheDocument();
+    expect(banner).toHaveTextContent(/name@example.com/);
+  });
+});

--- a/src/routes/waiver.test.tsx
+++ b/src/routes/waiver.test.tsx
@@ -14,6 +14,7 @@ import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
+import { ackAnchorId } from "@/lib/waiver-required-fields";
 
 const submitWaiverWithPdf = vi.fn();
 const getCurrentWaiverTemplate = vi.fn();
@@ -220,6 +221,39 @@ describe("/waiver missing fields", () => {
     );
     // Optional fields are never marked.
     expect(screen.getByLabelText(/Middle name/)).not.toHaveAttribute("aria-invalid");
+  });
+
+  // The jump can leave the summary scrolled off screen, and a red border is a
+  // colour: whoever lands on the field has to be able to read why they are here.
+  it("gives every flagged field a message of its own, tied to the field", async () => {
+    const user = userEvent.setup();
+    renderWaiver();
+    await screen.findByLabelText("First name");
+
+    await user.click(screen.getByRole("button", { name: /Sign and download waiver/i }));
+
+    const firstName = await screen.findByLabelText("First name");
+    await waitFor(() => expect(firstName).toHaveAccessibleDescription("Please fill this in."));
+    expect(document.getElementById("drugs_yes_needed")).toHaveTextContent("Answer yes or no.");
+    expect(document.getElementById("signature_field_needed")).toHaveTextContent(
+      "Draw it or type your full name.",
+    );
+    expect(document.getElementById(`${ackAnchorId("risk")}_needed`)).toHaveTextContent(
+      "Please read this and tick it.",
+    );
+  });
+
+  it("explains a malformed email on the field as well as in the summary", async () => {
+    const user = userEvent.setup();
+    renderWaiver();
+    await screen.findByLabelText("First name");
+    await user.type(screen.getByLabelText("Email"), "ada.example.com");
+
+    await user.click(screen.getByRole("button", { name: /Sign and download waiver/i }));
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Email")).toHaveAccessibleDescription(/name@example.com/),
+    );
   });
 
   it("catches an email that is filled in but is not an address", async () => {

--- a/src/routes/waiver.tsx
+++ b/src/routes/waiver.tsx
@@ -488,13 +488,19 @@ function Waiver() {
   /** The id its message carries, so the control can point at it. */
   const messageId = (anchorId: string) => `${anchorId}_needed`;
   /**
-   * How a flagged input looks and reads. The summary can be scrolled off screen
-   * by the jump itself, so the field they land on has to say for itself that it
-   * is the one being asked for.
+   * What a flagged control has to say about itself, whatever kind of control it
+   * is. The jump is the point: focus lands on the field with the summary
+   * possibly scrolled away, so the control has to carry both the state and the
+   * sentence, or a screen reader announces an invalid field and nothing about
+   * what it wants. Every flagged control gets these, not just the text inputs.
    */
-  const fieldProps = (anchorId: string) => ({
+  const flaggedProps = (anchorId: string) => ({
     "aria-invalid": flagged(anchorId) || undefined,
     "aria-describedby": flagged(anchorId) ? messageId(anchorId) : undefined,
+  });
+  /** The same, plus how a flagged input looks. */
+  const fieldProps = (anchorId: string) => ({
+    ...flaggedProps(anchorId),
     className: cn(
       "mt-1.5",
       flagged(anchorId) && "border-destructive focus-visible:ring-destructive",
@@ -1072,7 +1078,7 @@ function Waiver() {
                   <RadioGroup
                     className="flex gap-6"
                     aria-label={q.question}
-                    aria-invalid={flagged(`${q.id}_yes`) || undefined}
+                    {...flaggedProps(`${q.id}_yes`)}
                     value={health[q.id] === null ? "" : health[q.id] ? "yes" : "no"}
                     onValueChange={(v) => setHealth((prev) => ({ ...prev, [q.id]: v === "yes" }))}
                   >
@@ -1124,7 +1130,7 @@ function Waiver() {
                       <Checkbox
                         id={ackAnchorId(ack.id)}
                         checked={acks[ack.id] === true}
-                        aria-invalid={flagged(ackAnchorId(ack.id)) || undefined}
+                        {...flaggedProps(ackAnchorId(ack.id))}
                         onCheckedChange={(v) =>
                           setAcks((prev) => ({ ...prev, [ack.id]: v === true }))
                         }
@@ -1201,6 +1207,9 @@ function Waiver() {
               <div
                 id={WAIVER_ANCHORS.signaturePad}
                 tabIndex={-1}
+                role="group"
+                aria-label="Your signature"
+                {...flaggedProps(WAIVER_ANCHORS.signaturePad)}
                 className={cn(
                   "rounded-lg outline-none",
                   flagged(WAIVER_ANCHORS.signaturePad) && "border border-destructive p-3",
@@ -1259,6 +1268,9 @@ function Waiver() {
                   <div
                     id={WAIVER_ANCHORS.guardianPad}
                     tabIndex={-1}
+                    role="group"
+                    aria-label="Parent or guardian signature"
+                    {...flaggedProps(WAIVER_ANCHORS.guardianPad)}
                     className={cn(
                       "rounded-lg outline-none",
                       flagged(WAIVER_ANCHORS.guardianPad) && "border border-destructive p-3",

--- a/src/routes/waiver.tsx
+++ b/src/routes/waiver.tsx
@@ -32,6 +32,7 @@ import {
   ackAnchorId,
   missingFieldsSummary,
   missingWaiverFields,
+  WAIVER_ANCHORS,
 } from "@/lib/waiver-required-fields";
 import { useAuth } from "@/hooks/useAuth";
 import { useResilientSubmit } from "@/hooks/use-resilient-submit";
@@ -481,9 +482,11 @@ function Waiver() {
     guardianSignatureImage,
   });
   const showMissing = attemptedSubmit && missing.length > 0;
-  const missingAnchors = new Set(missing.map((field) => field.anchorId));
+  const missingByAnchor = new Map(missing.map((field) => [field.anchorId, field]));
   /** True for a control the summary is currently pointing at. */
-  const flagged = (anchorId: string) => showMissing && missingAnchors.has(anchorId);
+  const flagged = (anchorId: string) => showMissing && missingByAnchor.has(anchorId);
+  /** The id its message carries, so the control can point at it. */
+  const messageId = (anchorId: string) => `${anchorId}_needed`;
   /**
    * How a flagged input looks and reads. The summary can be scrolled off screen
    * by the jump itself, so the field they land on has to say for itself that it
@@ -491,11 +494,29 @@ function Waiver() {
    */
   const fieldProps = (anchorId: string) => ({
     "aria-invalid": flagged(anchorId) || undefined,
+    "aria-describedby": flagged(anchorId) ? messageId(anchorId) : undefined,
     className: cn(
       "mt-1.5",
       flagged(anchorId) && "border-destructive focus-visible:ring-destructive",
     ),
   });
+  /**
+   * The line under a flagged control, in the same words the summary used.
+   *
+   * Every flagged control gets one: a red border is a colour, and somebody who
+   * cannot pick it out, or who arrived by jumping straight to the field with
+   * the summary now scrolled away, would otherwise have nothing telling them
+   * what this field wants.
+   */
+  const fieldMessage = (anchorId: string) => {
+    const field = flagged(anchorId) ? missingByAnchor.get(anchorId) : undefined;
+    if (!field) return null;
+    return (
+      <p id={messageId(anchorId)} className="mt-1.5 text-xs font-medium text-destructive">
+        {field.hint ? `${field.hint}.` : "Please fill this in."}
+      </p>
+    );
+  };
 
   /**
    * Take the signer to a field, the same way from the summary's jump links and
@@ -759,11 +780,16 @@ function Waiver() {
 
             {/* Everything outstanding, in the order the form asks for it. It
                 stays on screen and re-counts itself as they work down it, and
-                every line is a link back to the field it is about. */}
+                every line is a link back to the field it is about.
+
+                `polite` overrides the assertive that role="alert" implies:
+                because the list re-counts on every keystroke, assertive would
+                interrupt a screen reader each time a field is completed, which
+                is the opposite of helpful while somebody is working down it. */}
             {showMissing && (
               <div
                 role="alert"
-                aria-live="assertive"
+                aria-live="polite"
                 className="rounded-lg border border-destructive/40 bg-destructive/5 p-4"
               >
                 <p className="flex items-center gap-2 text-sm font-semibold text-destructive">
@@ -800,6 +826,7 @@ function Waiver() {
                     onChange={(e) => setFirstName(e.target.value)}
                     {...fieldProps("first_name")}
                   />
+                  {fieldMessage("first_name")}
                 </div>
                 <div>
                   <Label htmlFor="middle_name">
@@ -823,6 +850,7 @@ function Waiver() {
                     onChange={(e) => setLastName(e.target.value)}
                     {...fieldProps("last_name")}
                   />
+                  {fieldMessage("last_name")}
                 </div>
               </div>
               <div>
@@ -853,6 +881,7 @@ function Waiver() {
                     onChange={(e) => setDob(e.target.value)}
                     {...fieldProps("date_of_birth")}
                   />
+                  {fieldMessage("date_of_birth")}
                   {/* The paper form's "participant type" tick box. It follows
                       from the date of birth, so we show which one applies
                       rather than asking the same thing twice. */}
@@ -875,6 +904,7 @@ function Waiver() {
                     onChange={(e) => setPhone(e.target.value)}
                     {...fieldProps("phone")}
                   />
+                  {fieldMessage("phone")}
                   <label className="mt-2 flex items-start gap-2 text-xs text-muted-foreground">
                     <Checkbox
                       checked={smsConsent}
@@ -900,6 +930,7 @@ function Waiver() {
                   disabled={Boolean(user)}
                   {...fieldProps("email")}
                 />
+                {fieldMessage("email")}
                 {user && (
                   <p className="mt-1.5 text-xs text-muted-foreground">
                     You're signed in, so the waiver uses your account email.
@@ -930,6 +961,7 @@ function Waiver() {
                   onChange={(e) => setAddress(e.target.value)}
                   {...fieldProps("address")}
                 />
+                {fieldMessage("address")}
               </div>
               <div>
                 <Label htmlFor="uts_student_number">
@@ -998,6 +1030,7 @@ function Waiver() {
                     onChange={(e) => setEcName(e.target.value)}
                     {...fieldProps("emergency_contact_name")}
                   />
+                  {fieldMessage("emergency_contact_name")}
                 </div>
                 <div>
                   <Label htmlFor="emergency_contact_relationship">Relationship</Label>
@@ -1010,6 +1043,7 @@ function Waiver() {
                     placeholder="Parent, partner, friend"
                     {...fieldProps("emergency_contact_relationship")}
                   />
+                  {fieldMessage("emergency_contact_relationship")}
                 </div>
                 <div>
                   <Label htmlFor="emergency_contact_phone">Contact mobile</Label>
@@ -1022,6 +1056,7 @@ function Waiver() {
                     onChange={(e) => setEcPhone(e.target.value)}
                     {...fieldProps("emergency_contact_phone")}
                   />
+                  {fieldMessage("emergency_contact_phone")}
                 </div>
               </div>
             </fieldset>
@@ -1050,9 +1085,7 @@ function Waiver() {
                       No
                     </label>
                   </RadioGroup>
-                  {flagged(`${q.id}_yes`) && (
-                    <p className="text-xs font-medium text-destructive">Please answer yes or no.</p>
-                  )}
+                  {fieldMessage(`${q.id}_yes`)}
                 </div>
               ))}
               <div>
@@ -1074,11 +1107,7 @@ function Waiver() {
                   placeholder="Medication, injuries, conditions, anything else our instructors should know"
                   {...fieldProps("medical_notes")}
                 />
-                {flagged("medical_notes") && (
-                  <p className="mt-1.5 text-xs font-medium text-destructive">
-                    You answered yes to at least one question, so please tell us about it.
-                  </p>
-                )}
+                {fieldMessage("medical_notes")}
               </div>
               <p className="text-xs text-muted-foreground">
                 Privacy note: we collect this health information only to keep you (or the minor)
@@ -1111,11 +1140,7 @@ function Waiver() {
                         )}
                       </span>
                     </label>
-                    {flagged(ackAnchorId(ack.id)) && (
-                      <p className="mt-1 pl-7 text-xs font-medium text-destructive">
-                        Please tick this to continue.
-                      </p>
-                    )}
+                    <div className="pl-7">{fieldMessage(ackAnchorId(ack.id))}</div>
                   </div>
                 ))}
               </fieldset>
@@ -1174,11 +1199,11 @@ function Waiver() {
                   and the id has to land on something focusable for the jump to
                   read as arriving somewhere. */}
               <div
-                id="signature_field"
+                id={WAIVER_ANCHORS.signaturePad}
                 tabIndex={-1}
                 className={cn(
                   "rounded-lg outline-none",
-                  flagged("signature_field") && "border border-destructive p-3",
+                  flagged(WAIVER_ANCHORS.signaturePad) && "border border-destructive p-3",
                 )}
               >
                 <Tabs
@@ -1204,21 +1229,17 @@ function Waiver() {
                   <TabsContent value="type" className="mt-3">
                     <Label htmlFor="signature_name">Type your full name to sign</Label>
                     <Input
-                      id="signature_name"
+                      id={WAIVER_ANCHORS.signatureName}
                       maxLength={120}
                       value={signatureName}
                       onChange={(e) => setSignatureName(e.target.value)}
                       placeholder="Your full name"
-                      {...fieldProps("signature_name")}
+                      {...fieldProps(WAIVER_ANCHORS.signatureName)}
                     />
+                    {fieldMessage(WAIVER_ANCHORS.signatureName)}
                   </TabsContent>
                 </Tabs>
-                {(flagged("signature_field") || flagged("signature_name")) && (
-                  <p className="mt-2 text-xs font-medium text-destructive">
-                    Please sign: draw your signature above, or switch to Type and enter your full
-                    name.
-                  </p>
-                )}
+                {fieldMessage(WAIVER_ANCHORS.signaturePad)}
               </div>
               <p className="text-xs text-muted-foreground">
                 By signing and submitting this form, you agree it constitutes an electronic
@@ -1236,11 +1257,11 @@ function Waiver() {
                     emergency contact section above. Change it there if someone else is signing.
                   </p>
                   <div
-                    id="guardian_signature_field"
+                    id={WAIVER_ANCHORS.guardianPad}
                     tabIndex={-1}
                     className={cn(
                       "rounded-lg outline-none",
-                      flagged("guardian_signature_field") && "border border-destructive p-3",
+                      flagged(WAIVER_ANCHORS.guardianPad) && "border border-destructive p-3",
                     )}
                   >
                     <Label>Parent/guardian signature</Label>
@@ -1264,23 +1285,17 @@ function Waiver() {
                       </TabsContent>
                       <TabsContent value="type" className="mt-3">
                         <Input
-                          id="guardian_signature_name"
+                          id={WAIVER_ANCHORS.guardianName}
                           maxLength={120}
                           value={guardianSignature}
                           onChange={(e) => setGuardianSignature(e.target.value)}
                           placeholder="Guardian full name"
-                          aria-invalid={flagged("guardian_signature_name") || undefined}
-                          className={cn(flagged("guardian_signature_name") && "border-destructive")}
+                          {...fieldProps(WAIVER_ANCHORS.guardianName)}
                         />
+                        {fieldMessage(WAIVER_ANCHORS.guardianName)}
                       </TabsContent>
                     </Tabs>
-                    {(flagged("guardian_signature_field") ||
-                      flagged("guardian_signature_name")) && (
-                      <p className="mt-2 text-xs font-medium text-destructive">
-                        A parent or guardian signs here: draw the signature, or switch to Type and
-                        enter their full name.
-                      </p>
-                    )}
+                    {fieldMessage(WAIVER_ANCHORS.guardianPad)}
                   </div>
                 </div>
               )}

--- a/src/routes/waiver.tsx
+++ b/src/routes/waiver.tsx
@@ -2,7 +2,6 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { useQuery } from "@tanstack/react-query";
-import { toast } from "sonner";
 import { SiteLayout } from "@/components/site/SiteLayout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -11,7 +10,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { CheckCircle2, Download } from "lucide-react";
+import { AlertCircle, CheckCircle2, Download } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { SignaturePad, type SignaturePadHandle } from "@/components/site/SignaturePad";
 import { GI_SIZE_HINT, GiSizeSelect } from "@/components/site/KitSizeSelect";
@@ -27,8 +26,13 @@ import {
 } from "@/lib/waiver.functions";
 import { redeemWaiverEmailVerification } from "@/lib/email-verification.functions";
 import { applyWaiverPlaceholders, buildWaiverPlaceholders } from "@/lib/waiver-document";
-import { missingRequiredAcks, resolveAcknowledgements } from "@/lib/waiver-acknowledgements";
-import { anyHealthConcern, healthQuestions, missingHealthAnswers } from "@/lib/waiver-health";
+import { resolveAcknowledgements } from "@/lib/waiver-acknowledgements";
+import { anyHealthConcern, healthQuestions } from "@/lib/waiver-health";
+import {
+  ackAnchorId,
+  missingFieldsSummary,
+  missingWaiverFields,
+} from "@/lib/waiver-required-fields";
 import { useAuth } from "@/hooks/useAuth";
 import { useResilientSubmit } from "@/hooks/use-resilient-submit";
 import { WAIVER_SUBMIT } from "@/lib/submit-resilience";
@@ -46,6 +50,7 @@ import {
   type HealthQuestionId,
 } from "@/lib/validation";
 import { buildPageMeta } from "@/lib/seo";
+import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/waiver")({
   // Optional prefill carried over from Step 1 of the "Start your free trial" flow.
@@ -164,7 +169,15 @@ function Waiver() {
 
   const sigPadRef = useRef<SignaturePadHandle | null>(null);
   const gSigPadRef = useRef<SignaturePadHandle | null>(null);
-  const healthQuestionRefs = useRef<Partial<Record<HealthQuestionId, HTMLDivElement | null>>>({});
+  /**
+   * Whether they have pressed Sign yet.
+   *
+   * Nothing is marked wrong before that: a half-filled form is not a form full
+   * of errors, it is somebody part-way through. From the first press the
+   * summary and the field markers track the live state, so each thing they fix
+   * drops off the list instead of waiting for another press to be re-checked.
+   */
+  const [attemptedSubmit, setAttemptedSubmit] = useState(false);
 
   const fullName = useMemo(
     () =>
@@ -438,6 +451,69 @@ function Waiver() {
     signedDate: new Date(previewSignedAt).toLocaleDateString("en-AU"),
   });
 
+  // What is still outstanding, recomputed every render so the summary and the
+  // field markers below can never disagree with the form. Labels are
+  // substituted first, so the summary names an acknowledgement the way the
+  // signer just read it rather than showing them a raw {{token}}.
+  const missing = missingWaiverFields({
+    firstName,
+    lastName,
+    dob,
+    phone,
+    email,
+    address,
+    ecName,
+    ecRelationship,
+    ecPhone,
+    health,
+    medical,
+    ackDefs: ackDefs.map((ack) => ({
+      ...ack,
+      label: applyWaiverPlaceholders(ack.label, ackPlaceholders),
+    })),
+    acks,
+    signatureMode,
+    signatureName,
+    signatureImage,
+    isMinor,
+    guardianSignatureMode,
+    guardianSignature,
+    guardianSignatureImage,
+  });
+  const showMissing = attemptedSubmit && missing.length > 0;
+  const missingAnchors = new Set(missing.map((field) => field.anchorId));
+  /** True for a control the summary is currently pointing at. */
+  const flagged = (anchorId: string) => showMissing && missingAnchors.has(anchorId);
+  /**
+   * How a flagged input looks and reads. The summary can be scrolled off screen
+   * by the jump itself, so the field they land on has to say for itself that it
+   * is the one being asked for.
+   */
+  const fieldProps = (anchorId: string) => ({
+    "aria-invalid": flagged(anchorId) || undefined,
+    className: cn(
+      "mt-1.5",
+      flagged(anchorId) && "border-destructive focus-visible:ring-destructive",
+    ),
+  });
+
+  /**
+   * Take the signer to a field, the same way from the summary's jump links and
+   * from pressing Sign.
+   *
+   * A frame first: the summary appears in the same commit that calls this, and
+   * measuring before it has laid out scrolls to where the field used to be.
+   * `preventScroll` then stops the focus from fighting the smooth scroll.
+   */
+  function goToField(anchorId: string) {
+    requestAnimationFrame(() => {
+      const el = document.getElementById(anchorId);
+      if (!el) return;
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      el.focus({ preventScroll: true });
+    });
+  }
+
   /**
    * Send the waiver, and keep sending it.
    *
@@ -548,42 +624,15 @@ function Waiver() {
    * date of birth now makes the signer a minor with no guardian signature. The
    * server would reject it, and the signer would be shown a raw Zod issue dump
    * instead of the plain sentence they get here.
+   *
+   * One answer for every field: the summary lists all of them at once and the
+   * page goes to the first, whether the browser could have checked it or not.
    */
   function readyToSend(): boolean {
-    const missingHealth = missingHealthAnswers(health);
-    if (missingHealth.length > 0) {
-      toast.error("Please answer yes or no to every health question.");
-      const firstMissing = missingHealth[0];
-      healthQuestionRefs.current[firstMissing.id]?.scrollIntoView({
-        behavior: "smooth",
-        block: "center",
-      });
-      document.getElementById(`${firstMissing.id}_yes`)?.focus();
-      return false;
-    }
-    if (anyHealthConcern(health) && !medical.trim()) {
-      toast.error("Please give details of anything you answered yes to.");
-      return false;
-    }
-    if (missingRequiredAcks(ackDefs, acks).length > 0) {
-      toast.error("Please read and accept the required acknowledgements.");
-      return false;
-    }
-    const sigImg = signatureMode === "draw" ? signatureImage : "";
-    const sigName = signatureMode === "type" ? signatureName : "";
-    if (!sigImg && !sigName.trim()) {
-      toast.error("Please add your signature by drawing it or typing your name.");
-      return false;
-    }
-    if (isMinor) {
-      const gImg = guardianSignatureMode === "draw" ? guardianSignatureImage : "";
-      const gName = guardianSignatureMode === "type" ? guardianSignature : "";
-      if (!gImg && !gName.trim()) {
-        toast.error("A parent or guardian must sign for participants under 18.");
-        return false;
-      }
-    }
-    return true;
+    setAttemptedSubmit(true);
+    if (missing.length === 0) return true;
+    goToField(missing[0].anchorId);
+    return false;
   }
 
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
@@ -678,7 +727,15 @@ function Waiver() {
         </p>
 
         <div className="mt-8">
-          <form onSubmit={onSubmit} className="space-y-6 rounded-2xl border bg-card p-6 md:p-8">
+          {/* noValidate because the checking is ours: the browser would stop the
+              submit at its own first `required` field with a bubble that fades,
+              and the fields it cannot see (health answers, ticks, signature)
+              would still be reported separately. One set of rules, one summary. */}
+          <form
+            onSubmit={onSubmit}
+            noValidate
+            className="space-y-6 rounded-2xl border bg-card p-6 md:p-8"
+          >
             <input type="hidden" name="hp" value="" />
 
             {restored && (
@@ -700,6 +757,36 @@ function Waiver() {
               </p>
             )}
 
+            {/* Everything outstanding, in the order the form asks for it. It
+                stays on screen and re-counts itself as they work down it, and
+                every line is a link back to the field it is about. */}
+            {showMissing && (
+              <div
+                role="alert"
+                aria-live="assertive"
+                className="rounded-lg border border-destructive/40 bg-destructive/5 p-4"
+              >
+                <p className="flex items-center gap-2 text-sm font-semibold text-destructive">
+                  <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+                  {missingFieldsSummary(missing.length)}
+                </p>
+                <ul className="mt-2 space-y-1.5 text-sm">
+                  {missing.map((field) => (
+                    <li key={field.anchorId}>
+                      <button
+                        type="button"
+                        onClick={() => goToField(field.anchorId)}
+                        className="text-left underline underline-offset-2 hover:no-underline"
+                      >
+                        {field.label}
+                      </button>
+                      {field.hint && <span className="text-muted-foreground"> ({field.hint})</span>}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
             <fieldset className="space-y-5">
               <legend className="text-sm font-semibold">Your details</legend>
               <div className="grid gap-5 sm:grid-cols-3">
@@ -711,7 +798,7 @@ function Waiver() {
                     maxLength={60}
                     value={firstName}
                     onChange={(e) => setFirstName(e.target.value)}
-                    className="mt-1.5"
+                    {...fieldProps("first_name")}
                   />
                 </div>
                 <div>
@@ -734,7 +821,7 @@ function Waiver() {
                     maxLength={60}
                     value={lastName}
                     onChange={(e) => setLastName(e.target.value)}
-                    className="mt-1.5"
+                    {...fieldProps("last_name")}
                   />
                 </div>
               </div>
@@ -764,7 +851,7 @@ function Waiver() {
                     required
                     value={dob}
                     onChange={(e) => setDob(e.target.value)}
-                    className="mt-1.5"
+                    {...fieldProps("date_of_birth")}
                   />
                   {/* The paper form's "participant type" tick box. It follows
                       from the date of birth, so we show which one applies
@@ -786,7 +873,7 @@ function Waiver() {
                     maxLength={30}
                     value={phone}
                     onChange={(e) => setPhone(e.target.value)}
-                    className="mt-1.5"
+                    {...fieldProps("phone")}
                   />
                   <label className="mt-2 flex items-start gap-2 text-xs text-muted-foreground">
                     <Checkbox
@@ -811,7 +898,7 @@ function Waiver() {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   disabled={Boolean(user)}
-                  className="mt-1.5"
+                  {...fieldProps("email")}
                 />
                 {user && (
                   <p className="mt-1.5 text-xs text-muted-foreground">
@@ -841,7 +928,7 @@ function Waiver() {
                   maxLength={300}
                   value={address}
                   onChange={(e) => setAddress(e.target.value)}
-                  className="mt-1.5"
+                  {...fieldProps("address")}
                 />
               </div>
               <div>
@@ -909,7 +996,7 @@ function Waiver() {
                     maxLength={120}
                     value={ecName}
                     onChange={(e) => setEcName(e.target.value)}
-                    className="mt-1.5"
+                    {...fieldProps("emergency_contact_name")}
                   />
                 </div>
                 <div>
@@ -921,7 +1008,7 @@ function Waiver() {
                     value={ecRelationship}
                     onChange={(e) => setEcRelationship(e.target.value)}
                     placeholder="Parent, partner, friend"
-                    className="mt-1.5"
+                    {...fieldProps("emergency_contact_relationship")}
                   />
                 </div>
                 <div>
@@ -933,7 +1020,7 @@ function Waiver() {
                     maxLength={30}
                     value={ecPhone}
                     onChange={(e) => setEcPhone(e.target.value)}
-                    className="mt-1.5"
+                    {...fieldProps("emergency_contact_phone")}
                   />
                 </div>
               </div>
@@ -945,17 +1032,12 @@ function Waiver() {
                 Please answer all five. Your instructors read these before you train.
               </p>
               {healthQuestions.map((q) => (
-                <div
-                  key={q.id}
-                  ref={(el) => {
-                    healthQuestionRefs.current[q.id] = el;
-                  }}
-                  className="space-y-2"
-                >
+                <div key={q.id} className="space-y-2">
                   <p className="text-sm">{q.question}</p>
                   <RadioGroup
                     className="flex gap-6"
                     aria-label={q.question}
+                    aria-invalid={flagged(`${q.id}_yes`) || undefined}
                     value={health[q.id] === null ? "" : health[q.id] ? "yes" : "no"}
                     onValueChange={(v) => setHealth((prev) => ({ ...prev, [q.id]: v === "yes" }))}
                   >
@@ -968,6 +1050,9 @@ function Waiver() {
                       No
                     </label>
                   </RadioGroup>
+                  {flagged(`${q.id}_yes`) && (
+                    <p className="text-xs font-medium text-destructive">Please answer yes or no.</p>
+                  )}
                 </div>
               ))}
               <div>
@@ -987,8 +1072,13 @@ function Waiver() {
                   value={medical}
                   onChange={(e) => setMedical(e.target.value)}
                   placeholder="Medication, injuries, conditions, anything else our instructors should know"
-                  className="mt-1.5"
+                  {...fieldProps("medical_notes")}
                 />
+                {flagged("medical_notes") && (
+                  <p className="mt-1.5 text-xs font-medium text-destructive">
+                    You answered yes to at least one question, so please tell us about it.
+                  </p>
+                )}
               </div>
               <p className="text-xs text-muted-foreground">
                 Privacy note: we collect this health information only to keep you (or the minor)
@@ -1000,19 +1090,33 @@ function Waiver() {
               <fieldset className="space-y-4 border-t pt-6">
                 <legend className="text-sm font-semibold">Acknowledgements</legend>
                 {ackDefs.map((ack) => (
-                  <label key={ack.id} className="flex items-start gap-3 text-sm">
-                    <Checkbox
-                      checked={acks[ack.id] === true}
-                      onCheckedChange={(v) =>
-                        setAcks((prev) => ({ ...prev, [ack.id]: v === true }))
-                      }
-                      className="mt-0.5"
-                    />
-                    <span>
-                      {applyWaiverPlaceholders(ack.label, ackPlaceholders)}
-                      {!ack.required && <span className="text-muted-foreground"> (optional)</span>}
-                    </span>
-                  </label>
+                  <div key={ack.id}>
+                    <label className="flex items-start gap-3 text-sm">
+                      <Checkbox
+                        id={ackAnchorId(ack.id)}
+                        checked={acks[ack.id] === true}
+                        aria-invalid={flagged(ackAnchorId(ack.id)) || undefined}
+                        onCheckedChange={(v) =>
+                          setAcks((prev) => ({ ...prev, [ack.id]: v === true }))
+                        }
+                        className={cn(
+                          "mt-0.5",
+                          flagged(ackAnchorId(ack.id)) && "border-destructive",
+                        )}
+                      />
+                      <span>
+                        {applyWaiverPlaceholders(ack.label, ackPlaceholders)}
+                        {!ack.required && (
+                          <span className="text-muted-foreground"> (optional)</span>
+                        )}
+                      </span>
+                    </label>
+                    {flagged(ackAnchorId(ack.id)) && (
+                      <p className="mt-1 pl-7 text-xs font-medium text-destructive">
+                        Please tick this to continue.
+                      </p>
+                    )}
+                  </div>
                 ))}
               </fieldset>
             )}
@@ -1065,38 +1169,57 @@ function Waiver() {
               <p className="text-sm text-muted-foreground">
                 By signing below, you confirm you've read and agree to the waiver above.
               </p>
-              <Tabs
-                value={signatureMode}
-                onValueChange={(v) => setSignatureMode(v as "draw" | "type")}
+              {/* tabIndex so the summary can send someone here while they are
+                  drawing: the pad is a canvas, which takes no focus of its own,
+                  and the id has to land on something focusable for the jump to
+                  read as arriving somewhere. */}
+              <div
+                id="signature_field"
+                tabIndex={-1}
+                className={cn(
+                  "rounded-lg outline-none",
+                  flagged("signature_field") && "border border-destructive p-3",
+                )}
               >
-                <TabsList className="grid w-full max-w-xs grid-cols-2">
-                  <TabsTrigger value="draw">Draw</TabsTrigger>
-                  <TabsTrigger value="type">Type</TabsTrigger>
-                </TabsList>
-                <TabsContent value="draw" className="mt-3">
-                  {/* The pad mounts before the draft restore effect runs, so a
-                      restored signature would arrive too late for it. Keying on
-                      `restored` remounts it once, with the signature showing. */}
-                  <SignaturePad
-                    key={restored ? "restored" : "fresh"}
-                    ref={sigPadRef}
-                    onChange={setSignatureImage}
-                    initialDataUrl={signatureImage}
-                    ariaLabel="Your signature"
-                  />
-                </TabsContent>
-                <TabsContent value="type" className="mt-3">
-                  <Label htmlFor="signature_name">Type your full name to sign</Label>
-                  <Input
-                    id="signature_name"
-                    maxLength={120}
-                    value={signatureName}
-                    onChange={(e) => setSignatureName(e.target.value)}
-                    placeholder="Your full name"
-                    className="mt-1.5"
-                  />
-                </TabsContent>
-              </Tabs>
+                <Tabs
+                  value={signatureMode}
+                  onValueChange={(v) => setSignatureMode(v as "draw" | "type")}
+                >
+                  <TabsList className="grid w-full max-w-xs grid-cols-2">
+                    <TabsTrigger value="draw">Draw</TabsTrigger>
+                    <TabsTrigger value="type">Type</TabsTrigger>
+                  </TabsList>
+                  <TabsContent value="draw" className="mt-3">
+                    {/* The pad mounts before the draft restore effect runs, so a
+                        restored signature would arrive too late for it. Keying on
+                        `restored` remounts it once, with the signature showing. */}
+                    <SignaturePad
+                      key={restored ? "restored" : "fresh"}
+                      ref={sigPadRef}
+                      onChange={setSignatureImage}
+                      initialDataUrl={signatureImage}
+                      ariaLabel="Your signature"
+                    />
+                  </TabsContent>
+                  <TabsContent value="type" className="mt-3">
+                    <Label htmlFor="signature_name">Type your full name to sign</Label>
+                    <Input
+                      id="signature_name"
+                      maxLength={120}
+                      value={signatureName}
+                      onChange={(e) => setSignatureName(e.target.value)}
+                      placeholder="Your full name"
+                      {...fieldProps("signature_name")}
+                    />
+                  </TabsContent>
+                </Tabs>
+                {(flagged("signature_field") || flagged("signature_name")) && (
+                  <p className="mt-2 text-xs font-medium text-destructive">
+                    Please sign: draw your signature above, or switch to Type and enter your full
+                    name.
+                  </p>
+                )}
+              </div>
               <p className="text-xs text-muted-foreground">
                 By signing and submitting this form, you agree it constitutes an electronic
                 signature dated {new Date().toLocaleDateString()}.
@@ -1112,7 +1235,14 @@ function Waiver() {
                     {ecRelationship ? ` (${ecRelationship})` : ""} signs below, taken from the
                     emergency contact section above. Change it there if someone else is signing.
                   </p>
-                  <div>
+                  <div
+                    id="guardian_signature_field"
+                    tabIndex={-1}
+                    className={cn(
+                      "rounded-lg outline-none",
+                      flagged("guardian_signature_field") && "border border-destructive p-3",
+                    )}
+                  >
                     <Label>Parent/guardian signature</Label>
                     <Tabs
                       value={guardianSignatureMode}
@@ -1134,13 +1264,23 @@ function Waiver() {
                       </TabsContent>
                       <TabsContent value="type" className="mt-3">
                         <Input
+                          id="guardian_signature_name"
                           maxLength={120}
                           value={guardianSignature}
                           onChange={(e) => setGuardianSignature(e.target.value)}
                           placeholder="Guardian full name"
+                          aria-invalid={flagged("guardian_signature_name") || undefined}
+                          className={cn(flagged("guardian_signature_name") && "border-destructive")}
                         />
                       </TabsContent>
                     </Tabs>
+                    {(flagged("guardian_signature_field") ||
+                      flagged("guardian_signature_name")) && (
+                      <p className="mt-2 text-xs font-medium text-destructive">
+                        A parent or guardian signs here: draw the signature, or switch to Type and
+                        enter their full name.
+                      </p>
+                    )}
                   </div>
                 </div>
               )}


### PR DESCRIPTION
## What changes for the person signing

Pressing **Sign and download waiver** with something left blank now always does the same two things, whatever was missed:

1. **A summary appears at the top of the form** naming everything that is outstanding, counted ("3 things are missing before you can sign"). Every line is a link to the field it is about. It stays on screen and re-counts itself as they work down the list, so a field drops off the moment it is filled in.
2. **The page goes to the first one**, in the form's own reading order (top to bottom), and focuses it. That field, and every other one on the list, is outlined and carries a short line saying what it needs, because the jump can leave the summary off screen.

Nothing is marked before the first press: a half-filled form is somebody part-way through, not a form full of errors.

### Why it needed doing

The page answered in two voices. The plain text inputs carried the browser's own `required` attribute, so a blank name got a native bubble on whichever field the browser reached first, with whatever scrolling that browser felt like. Everything the browser cannot see (the five health answers, the acknowledgement ticks, the signature) got a toast that named one problem at a time and then faded. Someone with three things left blank found out about them one press at a time, and on a phone the toast was often gone before they had finished scrolling.

### What they will feel

- No more native browser bubbles on this form. Everything reads in the club's own words.
- An email that is typed but is not an address is now caught here instead of coming back from the server as a validation error.
- Nothing else about signing changes: no extra step, no new field, and a completed form submits exactly as before.

## How it is built

- New pure module `src/lib/waiver-required-fields.ts` holds the whole rule: one ordered list of what is missing, computed from the form's state, each entry carrying the id of the control to jump to. The order **is** the form's reading order, which is what makes "jump to the first one" mean the first one a person would have filled in.
- `src/routes/waiver.tsx` is now `noValidate` and renders the summary plus per-field markers from that list. The old `readyToSend` chain of toasts is gone, and with it the last `toast.error` on the page.
- `healthQuestions` gain a `shortLabel` so five of them in a summary read as a list rather than a wall of text.
- This stays a courtesy, not the gate: `waiverSubmitSchema` on the server still decides whether a waiver may be filed.

## Testing

- `src/lib/waiver-required-fields.test.ts` (new) pins the ordering, the health/acknowledgement/signature rules, the minor's guardian signature, and the email format check.
- `src/routes/waiver.test.tsx` (new) pins the two guarantees end to end: the summary lists everything at once and sends nothing, and the page lands focus on the first missing field, including when that field is a health question the browser could never have checked.
- `bun run lint`, `bun run typecheck`, `bun run test` (88 files, 1592 tests) and `bun run build` all pass locally.
- Looked at it in the browser at 390px and 1280px, empty and part-filled.

## Docs

`docs/waivers.md` gains a "When something is missing" section describing the behaviour and why the form opts out of native validation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ud1uNzbAvmmkQEixUpsbK6)_