### PR TITLE
Show both sign-up steps on the manager notifications page

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -906,14 +906,18 @@ grants off.
 `key` PK, `value`, `updated_at`, `updated_by → auth.users(id)`. **RLS:**
 manager-only. Keys in use:
 
-| Key                            | Holds                                                                                                                                                   |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `invoice_payment_instructions` | Markdown shown on an invoice. Falls back to a built-in stub when unset.                                                                                 |
-| `contact_messages_seen_at`     | ISO instant a manager last opened `/manager/contact-messages`. Club-wide, not per manager. Unset means nobody ever has, so every message counts unread. |
+| Key                              | Holds                                                                                                                                                                                            |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `invoice_payment_instructions`   | Markdown shown on an invoice. Falls back to a built-in stub when unset.                                                                                                                          |
+| `contact_messages_seen_at`       | ISO instant a manager last opened `/manager/contact-messages`. Club-wide, not per manager. Unset means nobody ever has, so every message counts unread.                                          |
+| `interest_registrations_seen_at` | ISO instant of the newest interest registration on file when a manager last opened `/manager/users`. Same club-wide watermark shape; anything newer counts as a new sign-up on `/notifications`. |
 
-Being key/value is what let the contact-message unread count ship without a
-migration. It is also its limit: a value here is a single club-wide fact, so
-anything that needs to differ per manager needs a real table.
+Being key/value is what let the contact-message unread count, and later the
+new-registration count, ship without a migration. It is also its limit: a value
+here is a single club-wide fact, so anything that needs to differ per manager
+needs a real table. Both watermarks are read and written through
+`src/lib/seen-markers.ts`, which holds the only-moves-forward and
+never-into-the-future guards.
 
 ### `email_verification_tokens` — proof that someone can read an address
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -97,6 +97,18 @@ Counted from `waivers.approval_status = 'pending'`, which is the stored fact.
 The waivers screen's third state, `superseded`, is derived from a person's other
 **approved** waivers, so it can never hide work from this count.
 
+> [!WARNING]
+> **A pending waiver has exactly one exit, and it is approval.** `approval_status`
+> is `pending | approved` with no reject, and approving one row leaves any other
+> pending row of that person's alone. So a second submission nobody wants
+> approved (a bogus public signing, or a paper form filed for somebody who then
+> signed online outside the same-day duplicate probe) keeps this item and the
+> badge up for good. Clearing it means approving a duplicate, and for a stranger's
+> submission that activates an account, emails them and grants a trial. Nothing
+> counted pending waivers before this, which is why it never surfaced. The fix is
+> a real dismissal state on `waivers`, which is a schema change and a product
+> decision of its own, so it is not in this change.
+
 #### The registration watermark
 
 Interest registrations have no per-row read state to hang a badge on:

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -68,6 +68,58 @@ written whether or not the person wants it emailed.
 
 ## Flows
 
+### Somebody signs up
+
+Signing up is two steps, and until this existed neither of them reached the
+notifications page at all. A manager found out by opening `/manager/users` or
+`/manager/waivers` on the off chance, or by spotting the best-effort email.
+
+Both are **attention items**, and they are deliberately different shapes:
+
+| Step         | Item                                                | Verb    | Clears when                      |
+| ------------ | --------------------------------------------------- | ------- | -------------------------------- |
+| **Register** | "Sam registered interest in training"               | Read it | a manager opens `/manager/users` |
+| **Waiver**   | "Sam signed the waiver and is waiting for approval" | Approve | the waiver is approved           |
+
+The register step is **news, not work**. Nobody is waiting on anything, so it
+carries a reading verb and nothing else, and its copy says so in as many words.
+The waiver step is the opposite: somebody has signed and cannot start until a
+manager presses the button, which is why it sits at the top of the queue (see
+`composeManagerNotifications` for the full ordering and why).
+
+The waiver item's body says what approving leads to before the manager gets
+anywhere near the button: it activates the person's account, emails them to say
+so, and assigns the free trial. That is outward-facing and cannot be taken back
+quietly, and "anything irreversible gets a confirm that says what will happen"
+is the club's own UX rule.
+
+Counted from `waivers.approval_status = 'pending'`, which is the stored fact.
+The waivers screen's third state, `superseded`, is derived from a person's other
+**approved** waivers, so it can never hide work from this count.
+
+#### The registration watermark
+
+Interest registrations have no per-row read state to hang a badge on:
+`interest_registrations` grants `anon` INSERT and deliberately nothing else. So
+"new" means everything created after one club-wide watermark,
+`club_settings.interest_registrations_seen_at`, exactly as unanswered contact
+messages work. `src/lib/seen-markers.ts` owns both.
+
+Two things about it differ from the contact inbox, and both are on purpose:
+
+- **Opening `/manager/users` at all clears it**, not opening some leads-only
+  view. That screen is the whole funnel, one row per person, and it is where a
+  registration ends up whether or not that person is still a lead.
+- **The watermark is stamped from the newest registration in the database**,
+  not from a boundary the browser hands back. The users screen aggregates one
+  row per person, so a lead who has since signed a waiver appears there as an
+  applicant and the rendered rows cannot supply "the newest registration". The
+  cost is a registration landing in the gap between that screen loading and the
+  stamp: it is marked seen without ever being badged. Nothing is lost when that
+  happens, which is the difference that makes it acceptable. A registration is a
+  person, and that person stays on the users list for good, whereas a contact
+  message exists nowhere else and its watermark is therefore stricter.
+
 ### Somebody replies to you
 
 `postComment` (`src/lib/blog-comments.functions.ts`) and `createAnnotation`
@@ -201,10 +253,18 @@ choice to a member would be a lie about what they can turn on.
 - **No per-thread mute.** The switches are per kind. If one thread turns noisy,
   the answer today is to turn thread activity off.
 - **No in-app bell or toast.** The sidebar badge is the only in-app signal.
-- **The attention list has two checks**: the club's training dates running out,
-  and unanswered contact messages. Pending waiver approvals, unmatched bank
-  transactions and unpaid invoices are all obvious next entries and the shape
-  supports them, but widening the manager queue further is separate work.
+- **The attention list has four checks**: waivers waiting for approval, unanswered
+  contact messages, new interest registrations, and the club's training dates
+  running out. Unmatched bank transactions and unpaid invoices are the obvious
+  next entries and the shape supports them, but widening the manager queue
+  further is separate work.
+- **Signing up notifies managers by email at the moment it happens** (a new-lead
+  email on registration, a copy of the waiver on signing), and none of that is
+  changed by the attention items. Neither item claims a copy was emailed: those
+  sends are best-effort, and on the day this shipped the club's whole existing
+  backlog counted as new without anybody having been emailed about it.
+- **Neither sign-up item is per person.** Ten registrations are one line saying
+  ten, not ten lines. The page points at the screen that lists them.
 - **No digest for somebody with nothing.** An empty digest is not sent, and the
   rows are stamped anyway so tomorrow's run is not re-reading them forever.
 
@@ -238,6 +298,9 @@ Two consequences worth knowing:
 | The rules (pure, tested)     | `src/lib/notifications.ts`                                             |
 | The attention list           | `src/lib/manager-notifications.functions.ts`                           |
 | Contact messages             | `src/lib/contact-messages.functions.ts`, `contact-email.server.ts`     |
+| Interest registrations       | `src/lib/leads.functions.ts`                                           |
+| Waivers waiting on a manager | `countWaiversAwaitingApproval` in `src/lib/waiver.functions.ts`        |
+| The club-wide watermarks     | `src/lib/seen-markers.ts`                                              |
 | Who hears about what         | `src/lib/notification-events.server.ts`                                |
 | Sending, and the digest run  | `src/lib/notification-email.server.ts`                                 |
 | Page and settings server fns | `src/lib/notifications.functions.ts`                                   |

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -108,6 +108,13 @@ The waivers screen's third state, `superseded`, is derived from a person's other
 > counted pending waivers before this, which is why it never surfaced. The fix is
 > a real dismissal state on `waivers`, which is a schema change and a product
 > decision of its own, so it is not in this change.
+>
+> The count is also unbounded while `listWaivers` caps at 500 rows, newest
+> `signed_at` first. Past 500 waivers the club could have a pending one that
+> `/manager/waivers` does not list, and the item would point at a screen without
+> the row on it. Not reachable at the club's current size, and the fix when it is
+> would be paging that screen, the same answer `docs/database.md` gives for the
+> contact inbox.
 
 #### The registration watermark
 
@@ -131,6 +138,24 @@ Two things about it differ from the contact inbox, and both are on purpose:
   happens, which is the difference that makes it acceptable. A registration is a
   person, and that person stays on the users list for good, whereas a contact
   message exists nowhere else and its watermark is therefore stricter.
+
+Two more things follow from the watermark being a bare "everything after this":
+
+- **Acknowledging hands the addresses back**, and the users table pills those
+  rows **new**. Clearing the badge otherwise destroys the only record of what it
+  was about: that screen is one row per person for the whole club, sorted by
+  name, with nothing marking an arrival. `manager.contact-messages.tsx` keeps its
+  unread ids for the same reason, and this is the same move one layer down.
+- **Every query is bounded at both ends**, newer than the watermark AND not in
+  the future. `interest_registrations` grants `anon` a bare INSERT and its RLS
+  `WITH CHECK` constrains only the person fields, so the publishable key in the
+  browser bundle is enough to file a row stamped 2099. Since the watermark is
+  clamped to the present, such a row could never be brought under it: it would
+  count as new for good, pinning an item that by design has no read state and no
+  way to be dismissed. Bounded, a future row is simply not news yet. The same
+  hole is still open on `contact_messages`, which has the identical grant and
+  the identical clamp; closing it is a one-line change in
+  `countUnreadContactMessages` and belongs in its own PR.
 
 ### Somebody replies to you
 

--- a/docs/waivers.md
+++ b/docs/waivers.md
@@ -343,6 +343,11 @@ the person detail page (with the date), and on the member's account page.
 
 ### Manager reviews and approves
 
+Both steps of signing up now reach the manager on `/notifications`: a read-only
+item for the registration, and one carrying **Approve** for every waiver still
+`pending`. Neither replaces the emails that already go out at the moment each
+step happens. See `docs/notifications.md` for the two items and how each clears.
+
 The manager waivers screen lists submissions newest first with the submitted
 name/email, date, template version, status badge (pending / active /
 superseded), the PDF, and Approve / Unapprove. Approve = promote + unlock +

--- a/src/lib/contact-messages.functions.ts
+++ b/src/lib/contact-messages.functions.ts
@@ -13,17 +13,14 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/integrations/supabase/types";
 import { requireSupabaseAuth } from "@/integrations/supabase/auth-middleware";
 import { requireManager } from "@/lib/require-manager";
+import { CONTACT_SEEN_KEY, readSeenMarker, stampSeenMarker } from "@/lib/seen-markers";
 import {
-  advanceSeenMarker,
   listContactMessagesSchema,
   markContactMessagesSeenSchema,
   unreadSince,
 } from "@/lib/validation";
 
 type AdminClient = SupabaseClient<Database>;
-
-/** `club_settings` key holding the instant a manager last opened the inbox. */
-export const CONTACT_SEEN_KEY = "contact_messages_seen_at";
 
 export type ContactMessage = {
   id: string;
@@ -37,31 +34,6 @@ export type ContactMessage = {
 async function adminClient(): Promise<AdminClient> {
   const { supabaseAdmin } = await import("@/integrations/supabase/client.server");
   return supabaseAdmin;
-}
-
-/**
- * Read the club-wide seen marker.
- *
- * `failed` exists because the two callers need opposite things from an error.
- * Counting wants to degrade to "everything is unread": over-reporting is a nudge
- * to go and look, while reporting zero would hide the thing the count exists to
- * surface. Stamping must NOT degrade that way — treating a failed read as "never
- * set" skips the only-moves-forward guard and lets a stale tab drag the marker
- * backwards. So it reports the failure and the caller decides.
- */
-export async function readSeenMarker(
-  admin: AdminClient,
-): Promise<{ marker: string | null; failed: boolean }> {
-  const { data, error } = await admin
-    .from("club_settings")
-    .select("value")
-    .eq("key", CONTACT_SEEN_KEY)
-    .maybeSingle();
-  if (error) {
-    console.error("[contact-messages] could not read the seen marker:", error);
-    return { marker: null, failed: true };
-  }
-  return { marker: data?.value?.trim() ? data.value : null, failed: false };
 }
 
 /**
@@ -87,7 +59,7 @@ export const listContactMessages = createServerFn({ method: "GET" })
     const admin = await adminClient();
 
     const [seen, { data: rows, error, count }] = await Promise.all([
-      readSeenMarker(admin),
+      readSeenMarker(admin, CONTACT_SEEN_KEY),
       admin
         .from("contact_messages")
         .select("id, name, email, subject, message, created_at", { count: "exact" })
@@ -114,15 +86,8 @@ export const listContactMessages = createServerFn({ method: "GET" })
 /**
  * Move the club-wide marker up to the newest message the caller actually saw.
  *
- * It takes that instant rather than stamping `now()`, because "now" is a moment
- * later than the list it is acknowledging: a message arriving in the gap between
- * the two calls would be marked read without ever having been listed, badged or
- * counted, which is the one way this feature could lose a message outright.
- *
- * Two guards, because the boundary arrives from the browser: it is clamped to
- * the present (nobody can mark future messages read), and it only ever moves
- * forward, so a stale tab finishing late cannot drag the marker back and make
- * already-read messages reappear.
+ * The boundary comes from the browser, and the guards that make that safe live
+ * in `stampSeenMarker`.
  */
 export const markContactMessagesSeen = createServerFn({ method: "POST" })
   .middleware([requireSupabaseAuth])
@@ -130,30 +95,13 @@ export const markContactMessagesSeen = createServerFn({ method: "POST" })
   .handler(async ({ data, context }) => {
     await requireManager(context);
     const admin = await adminClient();
-
-    const current = await readSeenMarker(admin);
-    // Could not read the current marker, so there is nothing to compare against
-    // and the only-moves-forward guard is not available. Writing anyway would be
-    // the one way this operation can lose ground. Leave it; the badge stays up,
-    // which is the safe direction, and the next visit tries again.
-    if (current.failed) return { ok: true as const, marker: null, skipped: true as const };
-
-    const value = advanceSeenMarker(current.marker, data.seen_at, new Date().toISOString());
-    if (value === current.marker) {
-      return { ok: true as const, marker: current.marker, skipped: true as const };
-    }
-
-    const { error } = await admin.from("club_settings").upsert(
-      {
-        key: CONTACT_SEEN_KEY,
-        value,
-        updated_at: new Date().toISOString(),
-        updated_by: context.userId,
-      },
-      { onConflict: "key" },
+    const { marker, skipped } = await stampSeenMarker(
+      admin,
+      CONTACT_SEEN_KEY,
+      data.seen_at,
+      context.userId,
     );
-    if (error) throw new Error(error.message);
-    return { ok: true as const, marker: value, skipped: false as const };
+    return { ok: true as const, marker, skipped };
   });
 
 /**
@@ -168,7 +116,7 @@ export async function countUnreadContactMessages(admin: AdminClient): Promise<{
 }> {
   // A failed read degrades to null here on purpose: everything counts as unread,
   // which over-reports rather than going quiet. See `readSeenMarker`.
-  const { marker: seenAt } = await readSeenMarker(admin);
+  const { marker: seenAt } = await readSeenMarker(admin, CONTACT_SEEN_KEY);
 
   let countQuery = admin.from("contact_messages").select("id", { count: "exact", head: true });
   if (seenAt) countQuery = countQuery.gt("created_at", seenAt);

--- a/src/lib/leads.functions.test.ts
+++ b/src/lib/leads.functions.test.ts
@@ -1,13 +1,17 @@
 // The register step of the "needs attention" list.
 //
-// `countNewInterestRegistrations` is reachable from a unit test because it takes
-// its client as a parameter; the `markInterestRegistrationsSeen` handler around
-// it is a `createServerFn` and dies on "No Start context found in
-// AsyncLocalStorage" when called from the runner (see membership.functions.test.ts).
+// Both functions here take their client as a parameter, which is why they are
+// reachable from the runner at all; the `markInterestRegistrationsSeen` wrapper
+// around `acknowledgeInterestRegistrations` is a `createServerFn` and dies on
+// "No Start context found in AsyncLocalStorage" (see membership.functions.test.ts).
+// Pulling the body out was exactly so the watermark could be tested.
 //
-// What is worth pinning here is the marker, not the SQL: the whole item exists
-// to clear itself, so a count that ignores the watermark would leave a badge a
-// manager can never put down.
+// What is worth pinning here is the marker, not the SQL. The whole item exists
+// to clear itself, and there are three separate ways it could stop doing that:
+// a count that ignores the watermark, a stamp that picks the OLDEST row instead
+// of the newest (the marker would barely move and the count never reach zero),
+// and a row dated in the future, which the clamp in `advanceSeenMarker` can
+// never bring under the marker.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/integrations/supabase/types";
@@ -16,13 +20,17 @@ type QueryResult = { data: unknown; error: { message: string } | null; count?: n
 
 /**
  * A PostgREST chain answering each `from()` with the next queued result, and
- * recording the filters it was given so a test can prove the watermark reached
- * the query. Thenable because the count is awaited directly rather than through
- * `.maybeSingle()`.
+ * recording the filters and ordering it was given. The ordering matters as much
+ * as the filters: a fake that swallowed `.order()` would let `ascending: false`
+ * flip to `true` with every test still green, which on the stamp is the
+ * difference between a badge that clears and one that never does. Thenable
+ * because the count is awaited directly rather than through `.maybeSingle()`.
  */
 function fakeAdmin(results: QueryResult[]) {
   const queue = [...results];
   const filters: Array<[string, string, unknown]> = [];
+  const orders: Array<[string, string, boolean | undefined]> = [];
+  const upserts: unknown[] = [];
   const tables: string[] = [];
   const admin = {
     from(table: string) {
@@ -39,8 +47,19 @@ function fakeAdmin(results: QueryResult[]) {
           filters.push([table, `gt:${col}`, value]);
           return chain;
         },
-        order: () => chain,
+        lte: (col: string, value: unknown) => {
+          filters.push([table, `lte:${col}`, value]);
+          return chain;
+        },
+        order: (col: string, opts?: { ascending?: boolean }) => {
+          orders.push([table, col, opts?.ascending]);
+          return chain;
+        },
         limit: () => chain,
+        upsert: (row: unknown) => {
+          upserts.push(row);
+          return Promise.resolve({ data: null, error: null });
+        },
         maybeSingle: () => Promise.resolve(result),
         then: (
           onFulfilled?: (value: QueryResult) => unknown,
@@ -50,7 +69,7 @@ function fakeAdmin(results: QueryResult[]) {
       return chain;
     },
   };
-  return { admin: admin as unknown as SupabaseClient<Database>, filters, tables };
+  return { admin: admin as unknown as SupabaseClient<Database>, filters, orders, upserts, tables };
 }
 
 const MARKER = "2026-08-05T09:00:00.000Z";
@@ -78,6 +97,27 @@ describe("countNewInterestRegistrations", () => {
     expect(
       filters.filter(([t, f]) => t === "interest_registrations" && f === "gt:created_at"),
     ).toHaveLength(2);
+  });
+
+  it("ignores anything dated in the future, on both reads", async () => {
+    const { countNewInterestRegistrations } = await import("./leads.functions");
+    const { admin, filters, orders } = fakeAdmin([
+      { data: { value: MARKER }, error: null },
+      { data: null, error: null, count: 1 },
+      { data: { name: "Sam Lee", created_at: "2026-08-05T10:00:00.000Z" }, error: null },
+    ]);
+    await countNewInterestRegistrations(admin);
+    // `anon` can INSERT a registration and the RLS check does not constrain
+    // `created_at`, so a row stamped 2099 is filable from the browser bundle.
+    // The stamp is clamped to the present, so without this upper bound that row
+    // would count as new for good, pinning an item that cannot be dismissed.
+    const upper = filters.filter(([, f]) => f === "lte:created_at");
+    expect(upper).toHaveLength(2);
+    for (const [, , value] of upper) {
+      expect(new Date(String(value)).getTime()).toBeLessThanOrEqual(Date.now());
+    }
+    // Newest first, or the item would name whoever registered longest ago.
+    expect(orders).toEqual([["interest_registrations", "created_at", false]]);
   });
 
   it("counts everything when nobody has ever opened the users list", async () => {
@@ -148,5 +188,87 @@ describe("countNewInterestRegistrations", () => {
       latestName: null,
       latestAt: null,
     });
+  });
+});
+
+describe("acknowledgeInterestRegistrations", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  const NEWEST = "2026-08-06T11:00:00.000Z";
+  const rows = [
+    { email: "Sam@Example.com", created_at: NEWEST },
+    { email: "kim@example.com", created_at: "2026-08-06T09:00:00.000Z" },
+  ];
+
+  it("moves the watermark to the NEWEST registration, not the oldest", async () => {
+    const { acknowledgeInterestRegistrations } = await import("./leads.functions");
+    const { admin, orders, upserts } = fakeAdmin([
+      { data: { value: MARKER }, error: null }, // current marker
+      { data: rows, error: null }, // the new registrations
+      { data: { value: MARKER }, error: null }, // marker re-read inside the stamp
+    ]);
+    const result = await acknowledgeInterestRegistrations(admin, "manager-1");
+
+    // The one line that decides whether this item can ever be put down. Stamping
+    // the oldest row would leave everything after it counted as new on the next
+    // visit, forever.
+    expect(result.marker).toBe(NEWEST);
+    expect(upserts).toEqual([
+      expect.objectContaining({
+        key: "interest_registrations_seen_at",
+        value: NEWEST,
+        updated_by: "manager-1",
+      }),
+    ]);
+    expect(orders).toEqual([["interest_registrations", "created_at", false]]);
+  });
+
+  it("hands back who the badge was about, normalized, before the marker moves", async () => {
+    const { acknowledgeInterestRegistrations } = await import("./leads.functions");
+    const { admin, filters } = fakeAdmin([
+      { data: { value: MARKER }, error: null },
+      { data: rows, error: null },
+      { data: { value: MARKER }, error: null },
+    ]);
+    const result = await acknowledgeInterestRegistrations(admin, "manager-1");
+
+    // Clearing the badge must not destroy the only record of what it meant. The
+    // users screen matches these against a person's auth email too, so case and
+    // whitespace are normalized the same way the profile identity key is.
+    expect(result.newEmails).toEqual(["sam@example.com", "kim@example.com"]);
+    // Read strictly after the old marker: a registration the marker already
+    // covered was seen on an earlier visit and must not be pilled "new" again.
+    expect(filters).toContainEqual(["interest_registrations", "gt:created_at", MARKER]);
+  });
+
+  it("writes nothing when there is nothing new", async () => {
+    const { acknowledgeInterestRegistrations } = await import("./leads.functions");
+    const { admin, upserts } = fakeAdmin([
+      { data: { value: MARKER }, error: null },
+      { data: [], error: null },
+    ]);
+    // Stamping `now()` on an empty result is the one way this could mark a
+    // registration seen before it arrives.
+    expect(await acknowledgeInterestRegistrations(admin, "manager-1")).toEqual({
+      marker: MARKER,
+      skipped: true,
+      newEmails: [],
+    });
+    expect(upserts).toEqual([]);
+  });
+
+  it("throws rather than pretending it acknowledged anything", async () => {
+    const { acknowledgeInterestRegistrations } = await import("./leads.functions");
+    const { admin, upserts } = fakeAdmin([
+      { data: { value: MARKER }, error: null },
+      { data: null, error: { message: "boom" } },
+    ]);
+    // The opposite call from the count next door. Nobody is waiting on this
+    // answer, so a failure that silently reported success would move the badge
+    // without anybody having seen anything.
+    await expect(acknowledgeInterestRegistrations(admin, "manager-1")).rejects.toThrow("boom");
+    expect(upserts).toEqual([]);
   });
 });

--- a/src/lib/leads.functions.test.ts
+++ b/src/lib/leads.functions.test.ts
@@ -1,0 +1,152 @@
+// The register step of the "needs attention" list.
+//
+// `countNewInterestRegistrations` is reachable from a unit test because it takes
+// its client as a parameter; the `markInterestRegistrationsSeen` handler around
+// it is a `createServerFn` and dies on "No Start context found in
+// AsyncLocalStorage" when called from the runner (see membership.functions.test.ts).
+//
+// What is worth pinning here is the marker, not the SQL: the whole item exists
+// to clear itself, so a count that ignores the watermark would leave a badge a
+// manager can never put down.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/integrations/supabase/types";
+
+type QueryResult = { data: unknown; error: { message: string } | null; count?: number | null };
+
+/**
+ * A PostgREST chain answering each `from()` with the next queued result, and
+ * recording the filters it was given so a test can prove the watermark reached
+ * the query. Thenable because the count is awaited directly rather than through
+ * `.maybeSingle()`.
+ */
+function fakeAdmin(results: QueryResult[]) {
+  const queue = [...results];
+  const filters: Array<[string, string, unknown]> = [];
+  const tables: string[] = [];
+  const admin = {
+    from(table: string) {
+      tables.push(table);
+      const result = queue.shift() ?? { data: null, error: null, count: 0 };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const chain: any = {
+        select: () => chain,
+        eq: (col: string, value: unknown) => {
+          filters.push([table, `eq:${col}`, value]);
+          return chain;
+        },
+        gt: (col: string, value: unknown) => {
+          filters.push([table, `gt:${col}`, value]);
+          return chain;
+        },
+        order: () => chain,
+        limit: () => chain,
+        maybeSingle: () => Promise.resolve(result),
+        then: (
+          onFulfilled?: (value: QueryResult) => unknown,
+          onRejected?: (reason: unknown) => unknown,
+        ) => Promise.resolve(result).then(onFulfilled, onRejected),
+      };
+      return chain;
+    },
+  };
+  return { admin: admin as unknown as SupabaseClient<Database>, filters, tables };
+}
+
+const MARKER = "2026-08-05T09:00:00.000Z";
+
+describe("countNewInterestRegistrations", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("counts only what arrived after the marker, and names the newest", async () => {
+    const { countNewInterestRegistrations } = await import("./leads.functions");
+    const { admin, filters } = fakeAdmin([
+      { data: { value: MARKER }, error: null },
+      { data: null, error: null, count: 2 },
+      { data: { name: "Sam Lee", created_at: "2026-08-05T10:00:00.000Z" }, error: null },
+    ]);
+    expect(await countNewInterestRegistrations(admin)).toEqual({
+      unread: 2,
+      latestName: "Sam Lee",
+      latestAt: "2026-08-05T10:00:00.000Z",
+    });
+    // Strictly newer than the marker, on BOTH reads. Naming a registration the
+    // marker already covers would report a person who has been seen.
+    expect(filters).toContainEqual(["interest_registrations", "gt:created_at", MARKER]);
+    expect(
+      filters.filter(([t, f]) => t === "interest_registrations" && f === "gt:created_at"),
+    ).toHaveLength(2);
+  });
+
+  it("counts everything when nobody has ever opened the users list", async () => {
+    const { countNewInterestRegistrations } = await import("./leads.functions");
+    // No `club_settings` row: right on the day this ships, and right again if
+    // the marker is ever cleared.
+    const { admin, filters } = fakeAdmin([
+      { data: null, error: null },
+      { data: null, error: null, count: 5 },
+      { data: { name: "Sam Lee", created_at: "2026-08-05T10:00:00.000Z" }, error: null },
+    ]);
+    expect((await countNewInterestRegistrations(admin)).unread).toBe(5);
+    expect(filters.filter(([, f]) => f === "gt:created_at")).toEqual([]);
+  });
+
+  it("stays quiet without going looking for a name", async () => {
+    const { countNewInterestRegistrations } = await import("./leads.functions");
+    const { admin, tables } = fakeAdmin([
+      { data: { value: MARKER }, error: null },
+      { data: null, error: null, count: 0 },
+    ]);
+    expect(await countNewInterestRegistrations(admin)).toEqual({
+      unread: 0,
+      latestName: null,
+      latestAt: null,
+    });
+    expect(tables).toEqual(["club_settings", "interest_registrations"]);
+  });
+
+  it("over-reports rather than going quiet when the marker cannot be read", async () => {
+    const { countNewInterestRegistrations } = await import("./leads.functions");
+    // A failed marker read degrades to "nothing has ever been seen", which
+    // nudges a manager to go and look. Reporting zero would hide the very thing
+    // the count exists to surface.
+    const { admin, filters } = fakeAdmin([
+      { data: null, error: { message: "boom" } },
+      { data: null, error: null, count: 3 },
+      { data: { name: "Sam Lee", created_at: "2026-08-05T10:00:00.000Z" }, error: null },
+    ]);
+    expect((await countNewInterestRegistrations(admin)).unread).toBe(3);
+    expect(filters.filter(([, f]) => f === "gt:created_at")).toEqual([]);
+  });
+
+  it("degrades to zero rather than throwing, so one bad read cannot empty the queue", async () => {
+    const { countNewInterestRegistrations } = await import("./leads.functions");
+    const { admin } = fakeAdmin([
+      { data: { value: MARKER }, error: null },
+      { data: null, error: { message: "boom" }, count: null },
+    ]);
+    // It runs inside the attention list's Promise.all beside the waiver
+    // approvals and the training-dates warning; throwing takes those down too.
+    await expect(countNewInterestRegistrations(admin)).resolves.toEqual({
+      unread: 0,
+      latestName: null,
+      latestAt: null,
+    });
+  });
+
+  it("degrades to a bare count when the newest registration cannot be read", async () => {
+    const { countNewInterestRegistrations } = await import("./leads.functions");
+    const { admin } = fakeAdmin([
+      { data: { value: MARKER }, error: null },
+      { data: null, error: null, count: 4 },
+      { data: null, error: { message: "boom" } },
+    ]);
+    expect(await countNewInterestRegistrations(admin)).toEqual({
+      unread: 4,
+      latestName: null,
+      latestAt: null,
+    });
+  });
+});

--- a/src/lib/leads.functions.ts
+++ b/src/lib/leads.functions.ts
@@ -16,13 +16,33 @@ import type { Database } from "@/integrations/supabase/types";
 import { requireSupabaseAuth } from "@/integrations/supabase/auth-middleware";
 import { requireManager } from "@/lib/require-manager";
 import { INTEREST_SEEN_KEY, readSeenMarker, stampSeenMarker } from "@/lib/seen-markers";
+import { normalizeEmail } from "@/lib/validation";
 
 type AdminClient = SupabaseClient<Database>;
+
+/**
+ * How many of the just-seen registrations the users screen is told about, so it
+ * can point at them. Far above any real visit; it exists so a bad row cannot
+ * make the response unbounded.
+ */
+const NEW_EMAILS_LIMIT = 200;
 
 async function adminClient(): Promise<AdminClient> {
   const { supabaseAdmin } = await import("@/integrations/supabase/client.server");
   return supabaseAdmin;
 }
+
+// Every query below is bounded at BOTH ends: newer than the watermark, and not
+// in the future.
+//
+// The upper bound is not defensive padding. `interest_registrations` grants
+// `anon` a bare INSERT and its RLS `WITH CHECK` constrains only the person
+// fields, so the publishable key in the browser bundle is enough to file a row
+// stamped 2099. The watermark is clamped to the present (`advanceSeenMarker`),
+// so without the bound such a row could never be brought under the marker: it
+// would count as new for good, pinning an attention item that by design has no
+// read state and no way to be dismissed. Bounded, a future row is simply not
+// news yet.
 
 /**
  * How many people have registered interest since a manager last opened the
@@ -36,13 +56,15 @@ export async function countNewInterestRegistrations(admin: AdminClient): Promise
   latestName: string | null;
   latestAt: string | null;
 }> {
+  const now = new Date().toISOString();
   // A failed marker read degrades to null on purpose: everything counts as new,
   // which over-reports rather than going quiet. See `readSeenMarker`.
   const { marker: seenAt } = await readSeenMarker(admin, INTEREST_SEEN_KEY);
 
   let countQuery = admin
     .from("interest_registrations")
-    .select("id", { count: "exact", head: true });
+    .select("id", { count: "exact", head: true })
+    .lte("created_at", now);
   if (seenAt) countQuery = countQuery.gt("created_at", seenAt);
   const { count, error } = await countQuery;
   // Degrade rather than throw. This runs inside the attention list's
@@ -59,6 +81,7 @@ export async function countNewInterestRegistrations(admin: AdminClient): Promise
   let latestQuery = admin
     .from("interest_registrations")
     .select("name, created_at")
+    .lte("created_at", now)
     .order("created_at", { ascending: false })
     .limit(1);
   if (seenAt) latestQuery = latestQuery.gt("created_at", seenAt);
@@ -77,43 +100,74 @@ export async function countNewInterestRegistrations(admin: AdminClient): Promise
 }
 
 /**
- * Mark the interest registrations seen, up to the newest one on file right now.
+ * Acknowledge the registrations, and hand back who they were.
  *
- * Stamped from the database rather than from a boundary the browser passes back,
- * which is the one place this differs from `markContactMessagesSeen` and it is a
- * deliberate trade. The users list aggregates one row per PERSON: a lead who has
- * since signed a waiver is on that screen as an applicant, not as a lead, so the
- * rendered rows cannot supply "the newest registration" without the screen
- * re-deriving what the count was made of.
+ * A plain function rather than the `createServerFn` body so it is reachable
+ * from a unit test: picking the NEWEST row is the highest-consequence line in
+ * this file, and picking the oldest instead would barely move the marker,
+ * leaving an item a manager can never put down.
  *
- * What that costs: a registration landing between the users list loading and
- * this call is marked seen without having been badged. Unlike a contact message,
- * nothing is lost when that happens. A registration is a person, and that person
- * stays on the users list for good; only the badge misses them.
+ * The emails are read BEFORE the marker moves, and that is the point of
+ * returning them at all. Clearing the badge otherwise destroys the only record
+ * of which people the badge was about: the users screen is one row per person
+ * across the whole club, sorted by name, with nothing marking a new arrival.
+ * `manager.contact-messages.tsx` captures its unread ids for exactly this
+ * reason, and this is the same move one layer down.
+ *
+ * The watermark is taken from the newest row on file rather than from a
+ * boundary the browser passes back, which is the one place this differs from
+ * `markContactMessagesSeen`. The users screen aggregates one row per PERSON: a
+ * lead who has since signed a waiver appears there as an applicant, so the
+ * rendered rows cannot supply "the newest registration". What that costs is a
+ * registration landing between the screen loading and this call, marked seen
+ * without having been badged. Nothing is lost when that happens. A registration
+ * is a person, and that person stays on the users list for good; only the badge
+ * misses them.
  */
+export async function acknowledgeInterestRegistrations(
+  admin: AdminClient,
+  userId: string,
+): Promise<{ marker: string | null; skipped: boolean; newEmails: string[] }> {
+  const now = new Date().toISOString();
+  const { marker: seenAt } = await readSeenMarker(admin, INTEREST_SEEN_KEY);
+
+  let query = admin
+    .from("interest_registrations")
+    .select("email, created_at")
+    .lte("created_at", now)
+    .order("created_at", { ascending: false })
+    .limit(NEW_EMAILS_LIMIT);
+  if (seenAt) query = query.gt("created_at", seenAt);
+  const { data: rows, error } = await query;
+  if (error) throw new Error(error.message);
+
+  const fresh = rows ?? [];
+  // Nothing new, so there is no watermark to move. Writing `now()` here would
+  // be the one way to mark a registration seen before it exists.
+  if (fresh.length === 0) return { marker: seenAt, skipped: true, newEmails: [] };
+
+  // Ordered newest-first, so the first row is the boundary that was seen.
+  const { marker, skipped } = await stampSeenMarker(
+    admin,
+    INTEREST_SEEN_KEY,
+    fresh[0].created_at,
+    userId,
+  );
+  return {
+    marker,
+    skipped,
+    // Normalized, because the users screen matches these against a person's
+    // auth email as well as a lead's registration email.
+    newEmails: [...new Set(fresh.map((r) => normalizeEmail(r.email)))],
+  };
+}
+
+/** Mark the interest registrations seen, up to the newest one on file. */
 export const markInterestRegistrationsSeen = createServerFn({ method: "POST" })
   .middleware([requireSupabaseAuth])
   .handler(async ({ context }) => {
     await requireManager(context);
     const admin = await adminClient();
-
-    const { data: latest, error } = await admin
-      .from("interest_registrations")
-      .select("created_at")
-      .order("created_at", { ascending: false })
-      .limit(1)
-      .maybeSingle();
-    if (error) throw new Error(error.message);
-    // Nothing has ever been registered, so there is no watermark to set. Writing
-    // `now()` here would be the one way to mark a registration seen before it
-    // exists.
-    if (!latest) return { ok: true as const, marker: null, skipped: true as const };
-
-    const { marker, skipped } = await stampSeenMarker(
-      admin,
-      INTEREST_SEEN_KEY,
-      latest.created_at,
-      context.userId,
-    );
-    return { ok: true as const, marker, skipped };
+    const result = await acknowledgeInterestRegistrations(admin, context.userId);
+    return { ok: true as const, ...result };
   });

--- a/src/lib/leads.functions.ts
+++ b/src/lib/leads.functions.ts
@@ -1,0 +1,119 @@
+// The first step of signing up, as a manager sees it: somebody filled in the
+// interest form.
+//
+// `interest_registrations` grants `anon` INSERT and deliberately nothing else,
+// so every read here goes through the service role behind the manager gate.
+// Same shape as `contact-messages.functions.ts`, and for the same reason: there
+// is no per-row read state to hang a badge on, so "new" is everything created
+// after one club-wide watermark in `club_settings` (see `seen-markers.ts`).
+//
+// The counterpart to this file's count is `countWaiversAwaitingApproval` in
+// `waiver.functions.ts`. Together they are the two steps of signing up that a
+// manager needs to see: one is news, the other is work.
+import { createServerFn } from "@tanstack/react-start";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/integrations/supabase/types";
+import { requireSupabaseAuth } from "@/integrations/supabase/auth-middleware";
+import { requireManager } from "@/lib/require-manager";
+import { INTEREST_SEEN_KEY, readSeenMarker, stampSeenMarker } from "@/lib/seen-markers";
+
+type AdminClient = SupabaseClient<Database>;
+
+async function adminClient(): Promise<AdminClient> {
+  const { supabaseAdmin } = await import("@/integrations/supabase/client.server");
+  return supabaseAdmin;
+}
+
+/**
+ * How many people have registered interest since a manager last opened the
+ * users list, and enough about the newest one to name them.
+ *
+ * Counted in the database rather than by fetching the rows: the notification
+ * never shows the registrations themselves, it points at the list.
+ */
+export async function countNewInterestRegistrations(admin: AdminClient): Promise<{
+  unread: number;
+  latestName: string | null;
+  latestAt: string | null;
+}> {
+  // A failed marker read degrades to null on purpose: everything counts as new,
+  // which over-reports rather than going quiet. See `readSeenMarker`.
+  const { marker: seenAt } = await readSeenMarker(admin, INTEREST_SEEN_KEY);
+
+  let countQuery = admin
+    .from("interest_registrations")
+    .select("id", { count: "exact", head: true });
+  if (seenAt) countQuery = countQuery.gt("created_at", seenAt);
+  const { count, error } = await countQuery;
+  // Degrade rather than throw. This runs inside the attention list's
+  // Promise.all, so throwing here would take down the whole manager queue,
+  // including the waiver approvals and the training-dates warning, which have
+  // nothing to do with interest registrations.
+  if (error) {
+    console.error("[leads] could not count new interest registrations:", error);
+    return { unread: 0, latestName: null, latestAt: null };
+  }
+  const unread = count ?? 0;
+  if (unread === 0) return { unread: 0, latestName: null, latestAt: null };
+
+  let latestQuery = admin
+    .from("interest_registrations")
+    .select("name, created_at")
+    .order("created_at", { ascending: false })
+    .limit(1);
+  if (seenAt) latestQuery = latestQuery.gt("created_at", seenAt);
+  const { data: latest, error: latestError } = await latestQuery.maybeSingle();
+  // The count is the part the notification cannot do without; a missing name
+  // only makes the copy vaguer.
+  if (latestError) {
+    console.error("[leads] could not read the newest interest registration:", latestError);
+    return { unread, latestName: null, latestAt: null };
+  }
+  return {
+    unread,
+    latestName: latest?.name ?? null,
+    latestAt: latest?.created_at ?? null,
+  };
+}
+
+/**
+ * Mark the interest registrations seen, up to the newest one on file right now.
+ *
+ * Stamped from the database rather than from a boundary the browser passes back,
+ * which is the one place this differs from `markContactMessagesSeen` and it is a
+ * deliberate trade. The users list aggregates one row per PERSON: a lead who has
+ * since signed a waiver is on that screen as an applicant, not as a lead, so the
+ * rendered rows cannot supply "the newest registration" without the screen
+ * re-deriving what the count was made of.
+ *
+ * What that costs: a registration landing between the users list loading and
+ * this call is marked seen without having been badged. Unlike a contact message,
+ * nothing is lost when that happens. A registration is a person, and that person
+ * stays on the users list for good; only the badge misses them.
+ */
+export const markInterestRegistrationsSeen = createServerFn({ method: "POST" })
+  .middleware([requireSupabaseAuth])
+  .handler(async ({ context }) => {
+    await requireManager(context);
+    const admin = await adminClient();
+
+    const { data: latest, error } = await admin
+      .from("interest_registrations")
+      .select("created_at")
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    // Nothing has ever been registered, so there is no watermark to set. Writing
+    // `now()` here would be the one way to mark a registration seen before it
+    // exists.
+    if (!latest) return { ok: true as const, marker: null, skipped: true as const };
+
+    const { marker, skipped } = await stampSeenMarker(
+      admin,
+      INTEREST_SEEN_KEY,
+      latest.created_at,
+      context.userId,
+    );
+    return { ok: true as const, marker, skipped };
+  });

--- a/src/lib/manager-notifications.functions.ts
+++ b/src/lib/manager-notifications.functions.ts
@@ -4,7 +4,9 @@
 // stored, which is what makes them clear by being FIXED rather than by being
 // dismissed — see docs/notifications.md. That is also why unanswered contact
 // messages belong here rather than among the stored activity rows: they clear
-// when a manager opens the inbox, and there is no per-message read state.
+// when a manager opens the inbox, and there is no per-message read state. The
+// two sign-up steps arrive the same way: a waiver clears by being approved, and
+// a registration by a manager opening the users list.
 //
 // This is a composition point, not a feature: each source contributes its own
 // items and this module decides what order a manager meets them in. The rules
@@ -23,12 +25,16 @@
 import {
   composeManagerNotifications,
   contactMessageNotifications,
+  interestRegistrationNotifications,
   sellableWindowNotifications,
+  waiverApprovalNotifications,
 } from "@/lib/validation";
 import type { ManagerNotification } from "@/lib/validation";
 import type { MembershipClient, MembershipPlanRow } from "@/lib/membership-types";
 import { listMembershipPlanRows } from "@/lib/membership.functions";
 import { countUnreadContactMessages } from "@/lib/contact-messages.functions";
+import { countNewInterestRegistrations } from "@/lib/leads.functions";
+import { countWaiversAwaitingApproval } from "@/lib/waiver.functions";
 
 /**
  * "Nothing is defined after the current training period, so enrolments stop
@@ -51,13 +57,19 @@ export async function managerAttentionItems(
   admin: MembershipClient,
 ): Promise<ManagerNotification[]> {
   // Sources are independent, so fetch them together rather than in sequence.
-  const [windows, unreadContact] = await Promise.all([
+  // Each one degrades to "nothing to report" on its own failure rather than
+  // throwing, so a bad query in one cannot empty the whole queue.
+  const [windows, unreadContact, waitingWaivers, newLeads] = await Promise.all([
     membershipWindowNotifications(admin),
     countUnreadContactMessages(admin),
+    countWaiversAwaitingApproval(admin),
+    countNewInterestRegistrations(admin),
   ]);
 
   return composeManagerNotifications({
+    waiverApprovals: waiverApprovalNotifications(waitingWaivers),
     contactMessages: contactMessageNotifications(unreadContact),
+    interestRegistrations: interestRegistrationNotifications(newLeads),
     membershipWindows: windows,
   });
 }

--- a/src/lib/manager-notifications.functions.ts
+++ b/src/lib/manager-notifications.functions.ts
@@ -57,8 +57,12 @@ export async function managerAttentionItems(
   admin: MembershipClient,
 ): Promise<ManagerNotification[]> {
   // Sources are independent, so fetch them together rather than in sequence.
-  // Each one degrades to "nothing to report" on its own failure rather than
-  // throwing, so a bad query in one cannot empty the whole queue.
+  //
+  // The three counts degrade to "nothing to report" on their own failed reads,
+  // so one bad query cannot empty the queue around it. The membership windows
+  // are the exception and still throw, which `Promise.all` turns into a failed
+  // notifications payload: the page then says it could not load and offers a
+  // retry, which is honest, rather than reporting all quiet.
   const [windows, unreadContact, waitingWaivers, newLeads] = await Promise.all([
     membershipWindowNotifications(admin),
     countUnreadContactMessages(admin),

--- a/src/lib/seen-markers.test.ts
+++ b/src/lib/seen-markers.test.ts
@@ -1,0 +1,120 @@
+// The two branches this module's own doc comment calls non-guessable, and which
+// nothing covered before: a failed read must NOT write, and an unchanged marker
+// must NOT write.
+//
+// Both matter because a watermark can only be wrong in one direction safely.
+// Moving it forward on bad information silently marks things seen that nobody
+// saw; leaving it where it is only costs a badge that clears next visit. The
+// arithmetic underneath (`advanceSeenMarker`) is pure and covered in
+// validation.test.ts; what is tested here is whether the write happens at all.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/integrations/supabase/types";
+
+import {
+  CONTACT_SEEN_KEY,
+  INTEREST_SEEN_KEY,
+  readSeenMarker,
+  stampSeenMarker,
+} from "./seen-markers";
+
+type Row = { value: string } | null;
+
+/** A `club_settings` stub: one read result, and a record of any upsert. */
+function fakeAdmin(read: { data: Row; error: { message: string } | null }) {
+  const upserts: unknown[] = [];
+  const keysRead: unknown[] = [];
+  const admin = {
+    from() {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const chain: any = {
+        select: () => chain,
+        eq: (_col: string, key: unknown) => {
+          keysRead.push(key);
+          return chain;
+        },
+        maybeSingle: () => Promise.resolve(read),
+        upsert: (row: unknown) => {
+          upserts.push(row);
+          return Promise.resolve({ data: null, error: null });
+        },
+      };
+      return chain;
+    },
+  };
+  return { admin: admin as unknown as SupabaseClient<Database>, upserts, keysRead };
+}
+
+const EARLIER = "2026-08-05T09:00:00.000Z";
+const LATER = "2026-08-05T11:00:00.000Z";
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("readSeenMarker", () => {
+  it("reports a failed read rather than passing it off as 'never set'", async () => {
+    const { admin } = fakeAdmin({ data: null, error: { message: "boom" } });
+    // The two callers need opposite things from this. Counting degrades to
+    // "everything is new"; stamping must not, because treating a failed read as
+    // "never set" skips the only-moves-forward guard.
+    expect(await readSeenMarker(admin, CONTACT_SEEN_KEY)).toEqual({ marker: null, failed: true });
+  });
+
+  it("treats a blank value as unset, and reads the key it was given", async () => {
+    const { admin, keysRead } = fakeAdmin({ data: { value: "   " }, error: null });
+    expect(await readSeenMarker(admin, INTEREST_SEEN_KEY)).toEqual({ marker: null, failed: false });
+    // The two watermarks share this module and must not share a row.
+    expect(keysRead).toEqual([INTEREST_SEEN_KEY]);
+    expect(CONTACT_SEEN_KEY).not.toBe(INTEREST_SEEN_KEY);
+  });
+});
+
+describe("stampSeenMarker", () => {
+  it("does not write when the current marker could not be read", async () => {
+    const { admin, upserts } = fakeAdmin({ data: null, error: { message: "boom" } });
+    // Writing here is the one way this can lose ground: with nothing to compare
+    // against, the only-moves-forward guard is unavailable. Leaving the badge up
+    // is the safe direction.
+    expect(await stampSeenMarker(admin, CONTACT_SEEN_KEY, LATER, "manager-1")).toEqual({
+      marker: null,
+      skipped: true,
+    });
+    expect(upserts).toEqual([]);
+  });
+
+  it("does not write when the marker would not move", async () => {
+    const { admin, upserts } = fakeAdmin({ data: { value: LATER }, error: null });
+    // A stale tab finishing late must not drag the marker back and make
+    // already-read things reappear.
+    expect(await stampSeenMarker(admin, CONTACT_SEEN_KEY, EARLIER, "manager-1")).toEqual({
+      marker: LATER,
+      skipped: true,
+    });
+    expect(upserts).toEqual([]);
+  });
+
+  it("writes the key, the value and who moved it when it does move", async () => {
+    const { admin, upserts } = fakeAdmin({ data: { value: EARLIER }, error: null });
+    expect(await stampSeenMarker(admin, INTEREST_SEEN_KEY, LATER, "manager-1")).toEqual({
+      marker: LATER,
+      skipped: false,
+    });
+    expect(upserts).toEqual([
+      expect.objectContaining({
+        key: INTEREST_SEEN_KEY,
+        value: LATER,
+        updated_by: "manager-1",
+      }),
+    ]);
+  });
+
+  it("never stamps the future, whatever boundary it is handed", async () => {
+    const { admin, upserts } = fakeAdmin({ data: { value: EARLIER }, error: null });
+    const result = await stampSeenMarker(admin, CONTACT_SEEN_KEY, "2099-01-01T00:00:00.000Z", "m1");
+    // Marking things read before they arrive is the one failure that loses
+    // something for good, so the candidate is clamped to now.
+    expect(new Date(String(result.marker)).getTime()).toBeLessThanOrEqual(Date.now());
+    expect(upserts).toHaveLength(1);
+  });
+});

--- a/src/lib/seen-markers.ts
+++ b/src/lib/seen-markers.ts
@@ -1,0 +1,94 @@
+// Club-wide "seen up to here" watermarks, kept in `club_settings`.
+//
+// A marker is one ISO instant under one key: everything in some table created
+// after it has not been looked at yet. That is what turns a table nobody can
+// mark read (the public intake tables grant `anon` INSERT and nothing else)
+// into a "needs attention" count that clears itself.
+//
+// It is deliberately club-wide rather than per manager. The club shares one
+// inbox and one funnel, and a per-manager watermark would need a table of its
+// own. See docs/database.md under `club_settings`.
+//
+// Extracted from `contact-messages.functions.ts` when interest registrations
+// grew the same need. The reasoning in `readSeenMarker` about which caller may
+// degrade and which may not is the part worth having in one place: it is not
+// guessable from the code, and getting it backwards loses a message.
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/integrations/supabase/types";
+import { advanceSeenMarker } from "@/lib/validation";
+
+type AdminClient = SupabaseClient<Database>;
+
+/** `club_settings` key holding the instant a manager last opened the inbox. */
+export const CONTACT_SEEN_KEY = "contact_messages_seen_at";
+
+/** `club_settings` key holding the instant a manager last opened the users list. */
+export const INTEREST_SEEN_KEY = "interest_registrations_seen_at";
+
+/**
+ * Read a marker.
+ *
+ * `failed` exists because the two kinds of caller need opposite things from an
+ * error. Counting wants to degrade to "everything is unread": over-reporting is
+ * a nudge to go and look, while reporting zero would hide the thing the count
+ * exists to surface. Stamping must NOT degrade that way, since treating a failed
+ * read as "never set" skips the only-moves-forward guard and lets a stale tab
+ * drag the marker backwards. So it reports the failure and the caller decides.
+ */
+export async function readSeenMarker(
+  admin: AdminClient,
+  key: string,
+): Promise<{ marker: string | null; failed: boolean }> {
+  const { data, error } = await admin
+    .from("club_settings")
+    .select("value")
+    .eq("key", key)
+    .maybeSingle();
+  if (error) {
+    console.error(`[seen-markers] could not read ${key}:`, error);
+    return { marker: null, failed: true };
+  }
+  return { marker: data?.value?.trim() ? data.value : null, failed: false };
+}
+
+/**
+ * Move a marker up to the newest thing the caller actually saw.
+ *
+ * `seenAt` is that thing's own timestamp rather than `now()`, because "now" is a
+ * moment later than the list it is acknowledging: a row arriving in the gap
+ * between reading the list and stamping would be marked seen without ever having
+ * been rendered, badged or counted.
+ *
+ * Two guards, because the boundary usually arrives from a browser: it is clamped
+ * to the present (nobody marks the future read), and it only ever moves forward,
+ * so a stale tab finishing late cannot drag the marker back and make already-read
+ * rows reappear.
+ */
+export async function stampSeenMarker(
+  admin: AdminClient,
+  key: string,
+  seenAt: string,
+  userId: string,
+): Promise<{ marker: string | null; skipped: boolean }> {
+  const current = await readSeenMarker(admin, key);
+  // Could not read the current marker, so there is nothing to compare against
+  // and the only-moves-forward guard is not available. Writing anyway would be
+  // the one way this operation can lose ground. Leave it; the badge stays up,
+  // which is the safe direction, and the next visit tries again.
+  if (current.failed) return { marker: null, skipped: true };
+
+  const value = advanceSeenMarker(current.marker, seenAt, new Date().toISOString());
+  if (value === current.marker) return { marker: current.marker, skipped: true };
+
+  const { error } = await admin.from("club_settings").upsert(
+    {
+      key,
+      value,
+      updated_at: new Date().toISOString(),
+      updated_by: userId,
+    },
+    { onConflict: "key" },
+  );
+  if (error) throw new Error(error.message);
+  return { marker: value, skipped: false };
+}

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -18,8 +18,10 @@ import {
   contactSchema,
   coverageSources,
   listContactMessagesSchema,
+  interestRegistrationNotifications,
   sellableWindowNotifications,
   unreadSince,
+  waiverApprovalNotifications,
   createAnnotationSchema,
   kbSlugSchema,
   resolveAnnotationSchema,
@@ -1037,32 +1039,162 @@ describe("contactMessageNotifications", () => {
   });
 });
 
-describe("composeManagerNotifications", () => {
-  const contact = contactMessageNotifications({ unread: 1, latestName: "Sam" });
-  const windows = sellableWindowNotifications([], "2026-08-03T10:00:00.000Z");
+describe("interestRegistrationNotifications", () => {
+  it("stays quiet when nothing is new rather than reporting a zero", () => {
+    expect(interestRegistrationNotifications({ unread: 0 })).toEqual([]);
+    expect(interestRegistrationNotifications({ unread: -1 })).toEqual([]);
+  });
 
-  it("puts unanswered messages above the membership window chore", () => {
-    // A person waiting on a reply outranks a training window that announces
-    // itself weeks ahead. This is the whole reason the order is a function.
+  it("names the person and offers a reading verb, not a fix", () => {
+    // The register step is news, not work: nobody is blocked and nothing is
+    // broken, so the only thing to do with it is read it.
+    const [n] = interestRegistrationNotifications({
+      unread: 1,
+      latestName: "Sam",
+      latestAt: "2026-08-05T10:00:00.000Z",
+    });
+    expect(n.type).toBe("new_interest_registrations");
+    expect(n.title).toBe("Sam registered interest in training");
+    expect(n.href).toBe("/manager/users");
+    expect(n.actionLabel).toBe("Read it");
+  });
+
+  it("counts and speaks plural for several", () => {
+    const [n] = interestRegistrationNotifications({
+      unread: 4,
+      latestName: "Sam",
+      latestAt: "2026-08-05T10:00:00.000Z",
+    });
+    expect(n.title).toBe("4 people registered interest in training");
+    expect(n.body).toContain("Sam");
+    expect(n.actionLabel).toBe("Read them");
+  });
+
+  it("claims nothing about emails having been sent", () => {
+    // Registrations do email the managers, but best-effort: a failed send, and
+    // the whole backlog that counts as new on the day this ships, both make
+    // "you were emailed this too" false. Same rule as the contact item.
+    for (const unread of [1, 4]) {
+      const [n] = interestRegistrationNotifications({ unread, latestName: "Sam" });
+      expect(`${n.title} ${n.body}`.toLowerCase()).not.toContain("email");
+    }
+  });
+
+  it("names the CLUB's day and survives a missing name or date", () => {
+    // 9am Sydney on the 6th is still the 5th in UTC, and the count degrades to
+    // a bare number when the newest row cannot be read.
+    const [dated] = interestRegistrationNotifications({
+      unread: 1,
+      latestName: "Sam",
+      latestAt: "2026-08-05T23:00:00.000Z",
+    });
+    expect(dated.body).toContain("06/08/2026");
+    const [bare] = interestRegistrationNotifications({
+      unread: 2,
+      latestName: null,
+      latestAt: null,
+    });
+    expect(bare.title).toBe("2 people registered interest in training");
+    expect(bare.body).toContain("Someone");
+    expect(bare.body).not.toContain("undefined");
+  });
+});
+
+describe("waiverApprovalNotifications", () => {
+  it("stays quiet when nothing is waiting rather than reporting a zero", () => {
+    expect(waiverApprovalNotifications({ pending: 0 })).toEqual([]);
+    expect(waiverApprovalNotifications({ pending: -1 })).toEqual([]);
+  });
+
+  it("names the signer and asks for the approval", () => {
+    const [n] = waiverApprovalNotifications({
+      pending: 1,
+      latestName: "Sam",
+      latestAt: "2026-08-05T10:00:00.000Z",
+    });
+    expect(n.type).toBe("waivers_awaiting_approval");
+    expect(n.title).toBe("Sam signed the waiver and is waiting for approval");
+    expect(n.href).toBe("/manager/waivers");
+    expect(n.actionLabel).toBe("Approve");
+  });
+
+  it("says what approving does, before the manager gets to the button", () => {
+    // Approving emails the person and unlocks their login, so it cannot be
+    // undone quietly. The consequence belongs in front of the click.
+    for (const pending of [1, 3]) {
+      const [n] = waiverApprovalNotifications({ pending, latestName: "Sam" });
+      expect(n.body).toContain("activates their account");
+      expect(n.body).toContain("emails them");
+      expect(n.body).toContain("free trial");
+    }
+  });
+
+  it("counts and speaks plural for several", () => {
+    const [n] = waiverApprovalNotifications({
+      pending: 3,
+      latestName: "Sam",
+      latestAt: "2026-08-05T10:00:00.000Z",
+    });
+    expect(n.title).toBe("3 signed waivers are waiting for approval");
+    expect(n.body).toContain("Sam");
+    expect(n.actionLabel).toBe("Approve them");
+  });
+
+  it("falls back to 'Someone' rather than printing a blank name", () => {
+    expect(waiverApprovalNotifications({ pending: 1, latestName: "  " })[0].title).toBe(
+      "Someone signed the waiver and is waiting for approval",
+    );
+    expect(waiverApprovalNotifications({ pending: 1, latestName: null })[0].title).toBe(
+      "Someone signed the waiver and is waiting for approval",
+    );
+  });
+});
+
+describe("composeManagerNotifications", () => {
+  const waivers = waiverApprovalNotifications({ pending: 1, latestName: "Ada" });
+  const contact = contactMessageNotifications({ unread: 1, latestName: "Sam" });
+  const leads = interestRegistrationNotifications({ unread: 1, latestName: "Kim" });
+  const windows = sellableWindowNotifications([], "2026-08-03T10:00:00.000Z");
+  const quiet = {
+    waiverApprovals: [],
+    contactMessages: [],
+    interestRegistrations: [],
+    membershipWindows: [],
+  };
+
+  it("orders the queue by who is held up, and for how long", () => {
+    // A signed waiver blocks somebody from starting, an unanswered message has
+    // somebody waiting on a reply, a new registration has nobody waiting on
+    // anything, and the training window is a chore that announces itself weeks
+    // ahead. This is the whole reason the order is a function.
     const all = composeManagerNotifications({
+      waiverApprovals: waivers,
       contactMessages: contact,
+      interestRegistrations: leads,
       membershipWindows: windows,
     });
-    expect(all.map((n) => n.type)).toEqual(["unread_contact_messages", "define_membership_window"]);
+    expect(all.map((n) => n.type)).toEqual([
+      "waivers_awaiting_approval",
+      "unread_contact_messages",
+      "new_interest_registrations",
+      "define_membership_window",
+    ]);
   });
 
   it("contributes nothing for a source that is quiet", () => {
     expect(
-      composeManagerNotifications({ contactMessages: [], membershipWindows: windows }).map(
-        (n) => n.type,
-      ),
+      composeManagerNotifications({ ...quiet, membershipWindows: windows }).map((n) => n.type),
     ).toEqual(["define_membership_window"]);
     expect(
-      composeManagerNotifications({ contactMessages: contact, membershipWindows: [] }).map(
-        (n) => n.type,
-      ),
+      composeManagerNotifications({ ...quiet, contactMessages: contact }).map((n) => n.type),
     ).toEqual(["unread_contact_messages"]);
-    expect(composeManagerNotifications({ contactMessages: [], membershipWindows: [] })).toEqual([]);
+    expect(
+      composeManagerNotifications({ ...quiet, waiverApprovals: waivers }).map((n) => n.type),
+    ).toEqual(["waivers_awaiting_approval"]);
+    expect(
+      composeManagerNotifications({ ...quiet, interestRegistrations: leads }).map((n) => n.type),
+    ).toEqual(["new_interest_registrations"]);
+    expect(composeManagerNotifications(quiet)).toEqual([]);
   });
 });
 

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1123,9 +1123,20 @@ describe("waiverApprovalNotifications", () => {
     // undone quietly. The consequence belongs in front of the click.
     for (const pending of [1, 3]) {
       const [n] = waiverApprovalNotifications({ pending, latestName: "Sam" });
-      expect(n.body).toContain("activates their account");
+      expect(n.body).toContain("activates that person's account");
       expect(n.body).toContain("emails them");
       expect(n.body).toContain("free trial");
+    }
+  });
+
+  it("scopes the consequence to a FIRST waiver rather than promising it for every one", () => {
+    // A returning member re-signing gets none of the three: `setWaiverApproval`
+    // only unbans and emails somebody still locked, and the trial is one per
+    // person ever. The plural line has to survive a mixed batch as well.
+    for (const pending of [1, 3]) {
+      const [n] = waiverApprovalNotifications({ pending, latestName: "Sam" });
+      expect(n.body).toContain("a first waiver");
+      expect(n.body).not.toMatch(/Approving activates/);
     }
   });
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1314,6 +1314,15 @@ export function interestRegistrationNotifications(input: {
  * what pressing through to it leads to. Approving is outward-facing and cannot
  * be taken back quietly (it emails the person and unlocks their login), so the
  * consequence belongs in front of the manager before the click, not after it.
+ *
+ * "A first waiver" is doing real work in that sentence, not hedging.
+ * `setWaiverApproval` lifts the ban and sends the account-activated email only
+ * for somebody still locked, and `assignTrialMembership` is one per person ever,
+ * so none of the three happens when a returning member re-signs. Stating them
+ * flatly would promise a manager an email and a trial that never go out. The
+ * plural line has to hold for a mixed batch too, which is the other reason it is
+ * written as what approving a first waiver does rather than what this batch will
+ * do.
  */
 export function waiverApprovalNotifications(input: {
   pending: number;
@@ -1325,7 +1334,7 @@ export function waiverApprovalNotifications(input: {
   const who = personOrSomeone(latestName);
   const when = clubDaySuffix(latestAt);
   const consequence =
-    "Approving activates their account, emails them to say so, and gives them the free trial.";
+    "Approving a first waiver activates that person's account, emails them to say so, and gives them the free trial.";
   return [
     {
       type: "waivers_awaiting_approval",

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1185,7 +1185,11 @@ export function insuranceSelection(input: {
  * club data into these, so tests pin the messages without rendering.
  */
 export type ManagerNotification = {
-  type: "define_membership_window" | "unread_contact_messages";
+  type:
+    | "define_membership_window"
+    | "unread_contact_messages"
+    | "waivers_awaiting_approval"
+    | "new_interest_registrations";
   title: string;
   body: string;
   href: string;
@@ -1242,6 +1246,104 @@ export function sellableWindowNotifications<
 }
 
 /**
+ * " on 06/08/2026" for a notification body, resolved to the CLUB's day rather
+ * than the server's, or "" when the timestamp could not be read.
+ *
+ * These strings are built inside `listMyNotifications`, so they render on the
+ * server (UTC) while the screen each one links to formats the same timestamp in
+ * the manager's browser. Something at 9am Sydney is still the previous date in
+ * UTC, so a plain `toLocaleDateString` had the two screens naming different days
+ * for one message. `clubLocalDate` gives the `YYYY-MM-DD` the club was actually
+ * on, which is exactly what `formatDateOnly` is for, and being pure it also
+ * drops the dependency on the runtime having full ICU.
+ */
+function clubDaySuffix(at: string | null | undefined): string {
+  return at ? ` on ${formatDateOnly(clubLocalDate(new Date(at), CLUB_TIME_ZONE))}` : "";
+}
+
+/**
+ * Somebody's name for notification copy, or "Someone" when it is blank. Every
+ * one of these counts degrades to a name-less count rather than failing the
+ * whole attention list, so the copy has to survive having no name.
+ */
+function personOrSomeone(name: string | null | undefined): string {
+  return name?.trim() || "Someone";
+}
+
+/**
+ * The first step of signing up: somebody filled in the interest form. Read-only
+ * on purpose. Nothing is broken and nothing is blocked, a manager just needs to
+ * know who has come in, so the item carries a reading verb and no other action.
+ *
+ * Says nothing about the emails that go out on a registration. Those are
+ * best-effort, and the whole existing backlog counts as new on the day this
+ * ships, so "you were emailed this too" is false exactly when it matters.
+ */
+export function interestRegistrationNotifications(input: {
+  unread: number;
+  latestName?: string | null;
+  latestAt?: string | null;
+}): ManagerNotification[] {
+  const { unread, latestName, latestAt } = input;
+  if (unread <= 0) return [];
+  const who = personOrSomeone(latestName);
+  const when = clubDaySuffix(latestAt);
+  return [
+    {
+      type: "new_interest_registrations",
+      title:
+        unread === 1
+          ? `${who} registered interest in training`
+          : `${unread} people registered interest in training`,
+      body:
+        unread === 1
+          ? `They left their details${when}. Nothing has to happen yet, this is just so you know who has come in.`
+          : `The most recent is ${who}${when}. Nothing has to happen yet, this is just so you know who has come in.`,
+      // The whole funnel, one row per person, which is where a registration
+      // ends up whether or not that person has moved on from being a lead. It
+      // is also where the new-lead email already sends managers.
+      href: "/manager/users",
+      actionLabel: unread === 1 ? "Read it" : "Read them",
+    },
+  ];
+}
+
+/**
+ * The second step of signing up: somebody signed the waiver and is waiting on a
+ * manager. Unlike the two items above, this one is real work, and the body says
+ * what pressing through to it leads to. Approving is outward-facing and cannot
+ * be taken back quietly (it emails the person and unlocks their login), so the
+ * consequence belongs in front of the manager before the click, not after it.
+ */
+export function waiverApprovalNotifications(input: {
+  pending: number;
+  latestName?: string | null;
+  latestAt?: string | null;
+}): ManagerNotification[] {
+  const { pending, latestName, latestAt } = input;
+  if (pending <= 0) return [];
+  const who = personOrSomeone(latestName);
+  const when = clubDaySuffix(latestAt);
+  const consequence =
+    "Approving activates their account, emails them to say so, and gives them the free trial.";
+  return [
+    {
+      type: "waivers_awaiting_approval",
+      title:
+        pending === 1
+          ? `${who} signed the waiver and is waiting for approval`
+          : `${pending} signed waivers are waiting for approval`,
+      body:
+        pending === 1
+          ? `They signed${when}. ${consequence}`
+          : `The most recent is ${who}${when}. ${consequence}`,
+      href: "/manager/waivers",
+      actionLabel: pending === 1 ? "Approve" : "Approve them",
+    },
+  ];
+}
+
+/**
  * How many contact-form messages have arrived since a manager last opened the
  * inbox. `seenAt` is the club-wide marker (`club_settings.contact_messages_seen_at`);
  * absent means nobody has ever opened it, so everything counts — which is right
@@ -1273,19 +1375,8 @@ export function contactMessageNotifications(input: {
 }): ManagerNotification[] {
   const { unread, latestName, latestAt } = input;
   if (unread <= 0) return [];
-  const who = latestName?.trim() || "Someone";
-  // Resolved to the CLUB's day, not the server's.
-  //
-  // This string is built inside `listMyNotifications`, so it renders on the
-  // server (UTC) while the inbox screen it links to formats the same timestamp
-  // in the manager's browser. A message at 9am Sydney is still the previous
-  // date in UTC, so a plain `toLocaleDateString` had the two screens naming
-  // different days for one message. `clubLocalDate` gives the `YYYY-MM-DD` the
-  // club was actually on, which is exactly what `formatDateOnly` is for — and
-  // being pure, it also drops the dependency on the runtime having full ICU.
-  const when = latestAt
-    ? ` on ${formatDateOnly(clubLocalDate(new Date(latestAt), CLUB_TIME_ZONE))}`
-    : "";
+  const who = personOrSomeone(latestName);
+  const when = clubDaySuffix(latestAt);
   return [
     {
       type: "unread_contact_messages",
@@ -1311,16 +1402,31 @@ export function contactMessageNotifications(input: {
 /**
  * The order a manager meets the "needs attention" items in.
  *
- * Unanswered messages come first: a person is waiting on a reply, whereas an
- * unset training window is a chore that announces itself weeks ahead. Kept as a
- * function rather than an inline spread in the handler so the priority is a
- * decision with a test on it, not an accident of argument order.
+ * Sorted by who is held up and for how long:
+ *
+ * 1. **Waiver approvals.** Somebody has signed and cannot start until a manager
+ *    presses the button. They are stuck, and only this list says so.
+ * 2. **Unanswered messages.** Somebody is waiting on a reply, but nothing about
+ *    them is blocked in the meantime.
+ * 3. **New interest registrations.** Nobody is waiting on anything. It is news,
+ *    and it sits below the two items that are work.
+ * 4. **The membership window.** A chore that announces itself weeks ahead.
+ *
+ * Kept as a function rather than an inline spread in the handler so the priority
+ * is a decision with a test on it, not an accident of argument order.
  */
 export function composeManagerNotifications(sources: {
+  waiverApprovals: ManagerNotification[];
   contactMessages: ManagerNotification[];
+  interestRegistrations: ManagerNotification[];
   membershipWindows: ManagerNotification[];
 }): ManagerNotification[] {
-  return [...sources.contactMessages, ...sources.membershipWindows];
+  return [
+    ...sources.waiverApprovals,
+    ...sources.contactMessages,
+    ...sources.interestRegistrations,
+    ...sources.membershipWindows,
+  ];
 }
 
 // ---- Member: start a membership ----

--- a/src/lib/waiver.functions.test.ts
+++ b/src/lib/waiver.functions.test.ts
@@ -1213,3 +1213,107 @@ describe("filePaperWaiver", () => {
     expect(row).not.toHaveProperty("health_answers");
   });
 });
+
+/**
+ * A PostgREST chain that answers each `from()` with the next queued result.
+ *
+ * Deliberately order-dependent: `countWaiversAwaitingApproval` makes two reads
+ * of the same table (the count, then the newest row), so keying the fake by
+ * table name could not tell them apart. The chain is thenable because the count
+ * query is awaited directly rather than through `.maybeSingle()`.
+ */
+type QueryResult = { data: unknown; error: { message: string } | null; count?: number | null };
+
+function fakeCountAdmin(results: QueryResult[]) {
+  const queue = [...results];
+  const tables: string[] = [];
+  const next = () => queue.shift() ?? { data: null, error: null, count: 0 };
+  const admin = {
+    from(table: string) {
+      tables.push(table);
+      const result = next();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const chain: any = {
+        select: () => chain,
+        eq: () => chain,
+        order: () => chain,
+        limit: () => chain,
+        maybeSingle: () => Promise.resolve(result),
+        then: (
+          onFulfilled?: (value: QueryResult) => unknown,
+          onRejected?: (reason: unknown) => unknown,
+        ) => Promise.resolve(result).then(onFulfilled, onRejected),
+      };
+      return chain;
+    },
+  };
+  return { admin: admin as unknown as SupabaseClient<Database>, tables };
+}
+
+describe("countWaiversAwaitingApproval", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("reports nothing waiting without going looking for a name", async () => {
+    const { countWaiversAwaitingApproval } = await import("./waiver.functions");
+    const { admin, tables } = fakeCountAdmin([{ data: null, error: null, count: 0 }]);
+    expect(await countWaiversAwaitingApproval(admin)).toEqual({
+      pending: 0,
+      latestName: null,
+      latestAt: null,
+    });
+    // One read, not two: with nothing waiting there is no newest signer.
+    expect(tables).toEqual(["waivers"]);
+  });
+
+  it("names the newest signer the way the waivers screen does", async () => {
+    const { countWaiversAwaitingApproval } = await import("./waiver.functions");
+    const { admin } = fakeCountAdmin([
+      { data: null, error: null, count: 3 },
+      {
+        data: {
+          first_name: "Alexandra",
+          middle_name: "",
+          last_name: "Nguyen",
+          preferred_name: "Alex",
+          signed_at: "2026-08-05T10:00:00.000Z",
+        },
+        error: null,
+      },
+    ]);
+    expect(await countWaiversAwaitingApproval(admin)).toEqual({
+      pending: 3,
+      latestName: 'Alexandra "Alex" Nguyen',
+      latestAt: "2026-08-05T10:00:00.000Z",
+    });
+  });
+
+  it("degrades to a bare count when the newest row cannot be read", async () => {
+    const { countWaiversAwaitingApproval } = await import("./waiver.functions");
+    const { admin } = fakeCountAdmin([
+      { data: null, error: null, count: 2 },
+      { data: null, error: { message: "boom" } },
+    ]);
+    // The count is the part the notification cannot do without; a missing name
+    // only makes the copy vaguer.
+    expect(await countWaiversAwaitingApproval(admin)).toEqual({
+      pending: 2,
+      latestName: null,
+      latestAt: null,
+    });
+  });
+
+  it("degrades to zero rather than throwing, so one bad read cannot empty the queue", async () => {
+    const { countWaiversAwaitingApproval } = await import("./waiver.functions");
+    const { admin } = fakeCountAdmin([{ data: null, error: { message: "boom" }, count: null }]);
+    // This runs inside the attention list's Promise.all next to the contact
+    // messages and the training-dates warning. Throwing here would take those
+    // down with it.
+    await expect(countWaiversAwaitingApproval(admin)).resolves.toEqual({
+      pending: 0,
+      latestName: null,
+      latestAt: null,
+    });
+  });
+});

--- a/src/lib/waiver.functions.test.ts
+++ b/src/lib/waiver.functions.test.ts
@@ -1227,6 +1227,8 @@ type QueryResult = { data: unknown; error: { message: string } | null; count?: n
 function fakeCountAdmin(results: QueryResult[]) {
   const queue = [...results];
   const tables: string[] = [];
+  const filters: Array<[string, unknown]> = [];
+  const orders: Array<[string, boolean | undefined]> = [];
   const next = () => queue.shift() ?? { data: null, error: null, count: 0 };
   const admin = {
     from(table: string) {
@@ -1235,8 +1237,17 @@ function fakeCountAdmin(results: QueryResult[]) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const chain: any = {
         select: () => chain,
-        eq: () => chain,
-        order: () => chain,
+        eq: (col: string, value: unknown) => {
+          filters.push([col, value]);
+          return chain;
+        },
+        // Recorded, not swallowed: a fake that ignored this would let
+        // `ascending: false` flip to `true` with every test still green, and
+        // the item would name whoever signed longest ago.
+        order: (col: string, opts?: { ascending?: boolean }) => {
+          orders.push([col, opts?.ascending]);
+          return chain;
+        },
         limit: () => chain,
         maybeSingle: () => Promise.resolve(result),
         then: (
@@ -1247,7 +1258,7 @@ function fakeCountAdmin(results: QueryResult[]) {
       return chain;
     },
   };
-  return { admin: admin as unknown as SupabaseClient<Database>, tables };
+  return { admin: admin as unknown as SupabaseClient<Database>, tables, filters, orders };
 }
 
 describe("countWaiversAwaitingApproval", () => {
@@ -1269,7 +1280,7 @@ describe("countWaiversAwaitingApproval", () => {
 
   it("names the newest signer the way the waivers screen does", async () => {
     const { countWaiversAwaitingApproval } = await import("./waiver.functions");
-    const { admin } = fakeCountAdmin([
+    const { admin, filters, orders } = fakeCountAdmin([
       { data: null, error: null, count: 3 },
       {
         data: {
@@ -1287,6 +1298,13 @@ describe("countWaiversAwaitingApproval", () => {
       latestName: 'Alexandra "Alex" Nguyen',
       latestAt: "2026-08-05T10:00:00.000Z",
     });
+    // Both reads ask for the stored fact, and the name comes from the newest
+    // signature rather than the oldest one still waiting.
+    expect(filters).toEqual([
+      ["approval_status", "pending"],
+      ["approval_status", "pending"],
+    ]);
+    expect(orders).toEqual([["signed_at", false]]);
   });
 
   it("degrades to a bare count when the newest row cannot be read", async () => {

--- a/src/lib/waiver.functions.ts
+++ b/src/lib/waiver.functions.ts
@@ -1125,6 +1125,56 @@ export const listWaivers = createServerFn({ method: "GET" })
     }));
   });
 
+/**
+ * How many signed waivers are waiting for a manager, and who signed the newest
+ * one. Feeds the "needs attention" list behind /notifications.
+ *
+ * `approval_status` is the stored fact, and it is the right one to count here.
+ * The list screen's third state, `superseded`, is derived from a person's OTHER
+ * approved waivers and only ever applies to one that is already approved, so it
+ * can never hide work from this count.
+ *
+ * A plain exported function taking its client, like `countUnreadContactMessages`:
+ * the attention list is composed in one place and this is a source for it.
+ */
+export async function countWaiversAwaitingApproval(admin: SupabaseClient<Database>): Promise<{
+  pending: number;
+  latestName: string | null;
+  latestAt: string | null;
+}> {
+  const { count, error } = await admin
+    .from("waivers")
+    .select("id", { count: "exact", head: true })
+    .eq("approval_status", "pending");
+  // Degrade rather than throw: this runs inside the attention list's
+  // Promise.all, and a failed count must not take down the other items with it.
+  if (error) {
+    console.error("[waivers] could not count waivers awaiting approval:", error);
+    return { pending: 0, latestName: null, latestAt: null };
+  }
+  const pending = count ?? 0;
+  if (pending === 0) return { pending: 0, latestName: null, latestAt: null };
+
+  const { data: latest, error: latestError } = await admin
+    .from("waivers")
+    .select("first_name, middle_name, last_name, preferred_name, signed_at")
+    .eq("approval_status", "pending")
+    .order("signed_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  // The count is the part the notification cannot do without; a missing name
+  // only makes the copy vaguer.
+  if (latestError) {
+    console.error("[waivers] could not read the newest waiting waiver:", latestError);
+    return { pending, latestName: null, latestAt: null };
+  }
+  return {
+    pending,
+    latestName: latest ? nameWithPreferred(latest) : null,
+    latestAt: latest?.signed_at ?? null,
+  };
+}
+
 // ---- Manager: file a scanned paper waiver ----
 //
 // The paper equivalent of the public signing page. Someone fills the form at

--- a/src/routes/_authenticated/manager.users.tsx
+++ b/src/routes/_authenticated/manager.users.tsx
@@ -15,7 +15,9 @@ import {
 import { lifecycleStatuses } from "@/lib/validation";
 import { emailVerificationLabel } from "@/lib/email-verification";
 import { listClubUsers } from "@/lib/membership.functions";
+import { markInterestRegistrationsSeen } from "@/lib/leads.functions";
 import { useAuth, useRoles } from "@/hooks/useAuth";
+import { useNotifications } from "@/hooks/useNotifications";
 
 export const Route = createFileRoute("/_authenticated/manager/users")({
   head: () => ({
@@ -36,6 +38,8 @@ function ManagerUsersPage() {
   const { user } = useAuth();
   const { isManager, loading: rolesLoading } = useRoles(user?.id);
   const fetchList = useServerFn(listClubUsers);
+  const markLeadsSeen = useServerFn(markInterestRegistrationsSeen);
+  const { refresh: refreshNotifications } = useNotifications();
 
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);
@@ -63,6 +67,24 @@ function ManagerUsersPage() {
         setLoading(false);
       });
   }, [isManager, fetchList]);
+
+  // This screen is where new interest registrations are read, so opening it is
+  // what clears them off the "needs attention" list. Club-wide, like the contact
+  // inbox: whichever manager looks clears it for all of them.
+  //
+  // Stamped even if the list above failed to load, and even if the manager came
+  // here for something else entirely. Both are deliberate. A registration is a
+  // person, and that person stays on this list for good, so the worst a stamp
+  // can cost is a badge, never the record of who signed up. That is what makes
+  // this looser than the contact inbox, where the message exists nowhere else.
+  useEffect(() => {
+    if (!isManager) return;
+    markLeadsSeen()
+      .then(() => refreshNotifications())
+      // Silent: nobody asked for this, and the only cost of it failing is a
+      // badge that clears on the next visit.
+      .catch((e) => console.error("[manager/users] could not mark registrations seen:", e));
+  }, [isManager, markLeadsSeen, refreshNotifications]);
 
   const visible = useMemo(() => {
     const q = search.trim().toLowerCase();

--- a/src/routes/_authenticated/manager.users.tsx
+++ b/src/routes/_authenticated/manager.users.tsx
@@ -77,6 +77,12 @@ function ManagerUsersPage() {
   // person, and that person stays on this list for good, so the worst a stamp
   // can cost is a badge, never the record of who signed up. That is what makes
   // this looser than the contact inbox, where the message exists nowhere else.
+  //
+  // Once per visit, which is why `isManager` is the only dependency.
+  // `refreshNotifications` is a fresh closure on every render, so listing it
+  // would stamp on every keystroke in the search box AND spin: stamp,
+  // invalidate, refetch, re-render, stamp. Same shape, and the same disable, as
+  // the load effect on /manager/contact-messages.
   useEffect(() => {
     if (!isManager) return;
     markLeadsSeen()
@@ -84,7 +90,8 @@ function ManagerUsersPage() {
       // Silent: nobody asked for this, and the only cost of it failing is a
       // badge that clears on the next visit.
       .catch((e) => console.error("[manager/users] could not mark registrations seen:", e));
-  }, [isManager, markLeadsSeen, refreshNotifications]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isManager]);
 
   const visible = useMemo(() => {
     const q = search.trim().toLowerCase();

--- a/src/routes/_authenticated/manager.users.tsx
+++ b/src/routes/_authenticated/manager.users.tsx
@@ -8,11 +8,12 @@ import { Pill } from "@/components/site/StatusPill";
 import { formatDate } from "@/lib/dates";
 import {
   ROLE_CLASS,
+  UNREAD_CLASS,
   lifecycleClass,
   membershipClass,
   verificationClass,
 } from "@/lib/status-colours";
-import { lifecycleStatuses } from "@/lib/validation";
+import { lifecycleStatuses, normalizeEmail } from "@/lib/validation";
 import { emailVerificationLabel } from "@/lib/email-verification";
 import { listClubUsers } from "@/lib/membership.functions";
 import { markInterestRegistrationsSeen } from "@/lib/leads.functions";
@@ -43,6 +44,10 @@ function ManagerUsersPage() {
 
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);
+  // Who registered interest since a manager last opened this screen, captured
+  // before the watermark moved. Normalized addresses: a lead is keyed by the
+  // address they typed, a person by their auth email.
+  const [newEmails, setNewEmails] = useState<Set<string>>(new Set());
 
   const [search, setSearch] = useState("");
   const [lifecycle, setLifecycle] = useState<string>("all");
@@ -78,6 +83,13 @@ function ManagerUsersPage() {
   // can cost is a badge, never the record of who signed up. That is what makes
   // this looser than the contact inbox, where the message exists nowhere else.
   //
+  // The call hands back WHO the badge was about, and the table pills those rows
+  // "new". Without that, following "Read them" for four registrations lands on
+  // one row per person for the whole club, sorted by name, with nothing marking
+  // the four: clearing the badge would destroy the only record of what it was
+  // telling you. `manager.contact-messages.tsx` keeps its unread ids for the
+  // same reason.
+  //
   // Once per visit, which is why `isManager` is the only dependency.
   // `refreshNotifications` is a fresh closure on every render, so listing it
   // would stamp on every keystroke in the search box AND spin: stamp,
@@ -86,7 +98,10 @@ function ManagerUsersPage() {
   useEffect(() => {
     if (!isManager) return;
     markLeadsSeen()
-      .then(() => refreshNotifications())
+      .then((result) => {
+        setNewEmails(new Set(result.newEmails));
+        refreshNotifications();
+      })
       // Silent: nobody asked for this, and the only cost of it failing is a
       // badge that clears on the next visit.
       .catch((e) => console.error("[manager/users] could not mark registrations seen:", e));
@@ -271,6 +286,13 @@ function ManagerUsersPage() {
                         {r.email ? (
                           <div className="flex flex-wrap items-center gap-1.5">
                             <span>{r.email}</span>
+                            {/* Registered interest since a manager last looked.
+                                On the address, not the name, because that is
+                                what the registration and the person record have
+                                in common. */}
+                            {newEmails.has(normalizeEmail(r.email)) ? (
+                              <Pill label="new" className={UNREAD_CLASS} />
+                            ) : null}
                             {/* Leads have no person record, so nothing has been
                                 proven about them either way. Badging one would
                                 claim more than the club knows. */}

--- a/src/routes/_authenticated/notifications.test.tsx
+++ b/src/routes/_authenticated/notifications.test.tsx
@@ -165,6 +165,46 @@ describe("/notifications", () => {
     expect(screen.queryByRole("link", { name: /fix it/i })).not.toBeInTheDocument();
   });
 
+  it("shows both steps of signing up, one to read and one to approve", async () => {
+    // Somebody signing up used to reach this page not at all. Registering is
+    // news and offers only a reading verb; a signed waiver is work and blocks
+    // the person who signed it, so it comes first and carries the approval.
+    mockPayload({
+      attention: [
+        {
+          ...ATTENTION,
+          type: "waivers_awaiting_approval" as const,
+          title: "Sam signed the waiver and is waiting for approval",
+          href: "/manager/waivers",
+          actionLabel: "Approve",
+        },
+        {
+          ...ATTENTION,
+          type: "new_interest_registrations" as const,
+          title: "Kim registered interest in training",
+          href: "/manager/users",
+          actionLabel: "Read it",
+        },
+      ],
+      isManager: true,
+    });
+    render(<NotificationsPage />);
+
+    expect(
+      await screen.findByText("Sam signed the waiver and is waiting for approval"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /approve/i })).toHaveAttribute(
+      "href",
+      "/manager/waivers",
+    );
+    expect(screen.getByRole("link", { name: /read it/i })).toHaveAttribute(
+      "href",
+      "/manager/users",
+    );
+    // Neither can be dismissed: they clear by being approved and by being read.
+    expect(screen.queryByRole("button", { name: /mark all as read/i })).not.toBeInTheDocument();
+  });
+
   it("offers to mark activity read only while something is unread", async () => {
     mockPayload({ items: [activity({ read_at: "2026-08-06T01:00:00.000Z" })] });
     const { unmount } = render(<NotificationsPage />);

--- a/src/routes/_authenticated/notifications.tsx
+++ b/src/routes/_authenticated/notifications.tsx
@@ -119,8 +119,13 @@ function NotificationsPage() {
               <AlertTriangle className="h-5 w-5" />
               Needs attention
             </CardTitle>
+            {/* Not "things only a manager can fix" any more: a new interest
+                registration is nobody's fault and needs no fixing, it just
+                wants reading. The one thing every item here still has in common
+                is that none of them can be ticked off. */}
             <CardDescription>
-              Things only a manager can fix. They clear themselves once they are sorted.
+              What is waiting on a manager, and who has just come in. Nothing here is ticked off by
+              hand: each one clears once it is sorted.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">


### PR DESCRIPTION
## What changes for the people using the site

Somebody signing up did not reach `/notifications` at all. A manager found out
by opening `/manager/users` or `/manager/waivers` on the off chance, or by
catching the email that goes out at the time.

Managers now see both steps of signing up in "Needs attention":

| Step | What it says | Button | Clears when |
| --- | --- | --- | --- |
| **Register** | "Sam registered interest in training" | Read it → `/manager/users` | a manager opens the users list |
| **Waiver** | "Sam signed the waiver and is waiting for approval" | Approve → `/manager/waivers` | the waiver is approved |

The register item is news, not work. Nobody is waiting on anything, so it only
offers a reading verb. The waiver item is the opposite: the person who signed
cannot start until a manager acts, so it sits at the top of the queue, above
unanswered contact messages, new registrations and the training-dates chore.

The waiver item's body says what approving leads to **before** the manager gets
near the button: approving a first waiver activates that person's account,
emails them to say so, and gives them the free trial. That is outward-facing and
cannot be taken back quietly. It says "a first waiver" because a returning member
re-signing gets none of the three, and promising them would be a lie.

Several waiting people are one line ("3 signed waivers are waiting for
approval"), not one line each, and the newest person is named.

Following **Read them** pills the people it was about as **new** on the users
table, so clearing the badge does not destroy the only record of what it meant.

### What a manager will feel

- The sidebar badge will jump the first time this is live: the club's whole
  existing backlog of pending waivers and unread registrations counts on day
  one. Both clear the normal way (approve; open the users list).
- Nothing new is emailed. The new-lead email and the manager copy of a signed
  waiver already went out and are unchanged. Neither item claims a copy was
  emailed, because those sends are best-effort and were never sent at all for
  the day-one backlog.
- Opening `/manager/users` for any reason clears the registration item. That is
  deliberate: unlike a contact message, a registration is a person who stays on
  that list for good, so the worst a stamp costs is a badge.

## How it works

- **Waivers**: counted from `waivers.approval_status = 'pending'`, the stored
  fact. The list screen's `superseded` state is derived from a person's other
  *approved* waivers, so it can never hide work from this count.
- **Registrations**: `interest_registrations` grants `anon` INSERT and nothing
  else, so there is no per-row read state. "New" is everything after a club-wide
  watermark in `club_settings` (`interest_registrations_seen_at`), the same
  shape as unanswered contact messages. **No migration**: `club_settings` is a
  key/value table that already exists.
  Every query is bounded at both ends, newer than the watermark and not in the
  future: `anon` can file a row stamped 2099 from the browser bundle, and since
  the watermark is clamped to the present, such a row could otherwise never be
  brought under it, pinning an item that has no way to be dismissed. The same
  hole is still open on `contact_messages` and is noted in the docs for its own
  PR.
- Both counts **degrade to "nothing to report"** on a failed read instead of
  throwing, so one bad query cannot empty the whole manager queue.

Five commits: a preparatory refactor pulling the club-wide seen marker out of
`contact-messages.functions.ts` into `src/lib/seen-markers.ts` (behaviour
identical), the feature, two rounds of review fixes, and a merge of `main`.

## Testing

`bun run lint`, `bun run typecheck`, `bun run test` (1627 passing) and
`bun run build` all pass locally on the merged tree.

New coverage:

- `validation.test.ts` — the copy and action label for both items (singular and
  plural, missing name, missing date, club-local day, no claims about email, the
  "first waiver" hedge), and the queue ordering as an explicit decision.
- `notifications.test.tsx` — the page rendering both items, with Approve and
  Read it going to the right screens and neither offering a way to be dismissed.
- `leads.functions.test.ts` — the count and the acknowledgement: the watermark
  reaching both ends of the query, the stamp taking the newest row rather than
  the oldest, the addresses handed back before the marker moves, and the
  degradation paths.
- `waiver.functions.test.ts` — the pending count, its ordering, and its
  degradation.
- `seen-markers.test.ts` — the two branches the refactored module never had
  covered: a failed read must not write, an unchanged marker must not write.

Not run against the live app: `/notifications` needs the service-role key and a
manager session, neither of which the build sandbox has. The rendering path is
the existing attention-item card, covered by the page test above.

### Known limitation, documented not fixed

A pending waiver's only exit is approval (`approval_status` is
`pending | approved`), so a submission nobody wants approved keeps the item and
the badge up. Clearing it would mean approving a duplicate, which for a
stranger's submission activates an account, emails them and grants a trial.
Nothing counted pending waivers before, so this never surfaced. The fix is a real
dismissal state on `waivers`, which is a schema change and a product decision of
its own.

Docs updated in the same change: `docs/notifications.md` (the flow, the
watermark, the four checks, both limitations), `docs/database.md` (the new
`club_settings` key), `docs/waivers.md` (approval now surfaces here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9ybWNJapAdApC1qeMV4bc
