### PR TITLE
Fix the Drive folder picker swallowing the manager's selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -541,9 +541,9 @@ meaningfully). The app reads:
 - Client, for the manager's Google Drive card: `VITE_GOOGLE_OAUTH_CLIENT_ID` and
   `VITE_GOOGLE_PICKER_API_KEY`, both from the **same** Google Cloud project as
   the Drive connector's OAuth client, with the Picker API enabled on it. Missing
-  either one hides "Browse in Drive" (typing a folder name still works), because
-  a picker built without them browses fine and then swallows the selection. See
-  `docs/google-drive.md`.
+  either one disables "Browse in Drive" (typing a folder name still works): a
+  picker without them is expected to browse fine and then swallow the selection.
+  See `docs/google-drive.md`.
 - Server: `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
   (admin client only), plus `LOVABLE_API_KEY` / `LOVABLE_SEND_URL` for auth email.
 - Server: `GOOGLE_DRIVE_APP_USER_CONNECTOR_CLIENT_API_KEY` — authenticates the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,12 @@ owner/manager policies (`20260727120000_waiver_storage_policies.sql`).
   the manifest's `start_url` is `/app`, a route that forwards you to the screen you
   actually wanted (member area when signed in, home page otherwise). Full spec:
   `docs/pwa.md`.
+- **Waivers into a manager's Google Drive** (`lib/google-drive.functions.ts` +
+  `lib/google-picker.ts`): a manager connects their Google account on `/account`
+  and every signed PDF is copied to a folder they choose. The one scope is
+  `drive.file`, so access is per (account, OAuth client, file) and the Google
+  picker is the only way to reach a folder the site did not create itself. Full
+  spec, including the two build-time values it needs: `docs/google-drive.md`.
 - **Auth emails** (`routes/lovable/email/auth/webhook.ts`): a Lovable
   `createAuthEmailHandler` dispatches React-email templates from
   `src/lib/email-templates/` for signup, invite, magic-link, recovery, etc.
@@ -521,8 +527,17 @@ meaningfully). The app reads:
 
 - Client (Vite, build-time): `VITE_SUPABASE_URL`, `VITE_SUPABASE_PUBLISHABLE_KEY`,
   `VITE_SUPABASE_PROJECT_ID`.
+- Client, for the manager's Google Drive card: `VITE_GOOGLE_OAUTH_CLIENT_ID` and
+  `VITE_GOOGLE_PICKER_API_KEY`, both from the **same** Google Cloud project as
+  the Drive connector's OAuth client, with the Picker API enabled on it. Missing
+  either one hides "Browse in Drive" (typing a folder name still works), because
+  a picker built without them browses fine and then swallows the selection. See
+  `docs/google-drive.md`.
 - Server: `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
   (admin client only), plus `LOVABLE_API_KEY` / `LOVABLE_SEND_URL` for auth email.
+- Server: `GOOGLE_DRIVE_APP_USER_CONNECTOR_CLIENT_API_KEY` — authenticates the
+  site to the Lovable connector gateway that holds each manager's Google refresh
+  token (`docs/google-drive.md`).
 - Server, optional: `MANAGER_AGENT_API_KEY` — break-glass bearer token for the
   manager agent API (`/api/manager/agent`). Normally managers mint revocable
   tokens at `/manager/api-tokens` (stored hashed in `manager_api_tokens`); this

--- a/docs/google-drive.md
+++ b/docs/google-drive.md
@@ -90,6 +90,7 @@ to the manager's whole Drive rather than only the files this site touches.
 | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | No "Browse in Drive" button                                          | `VITE_GOOGLE_PICKER_API_KEY` (or the client id) is not set on this deploy                                                                    |
 | "Google signed you in as X, but this site's Drive is connected as Y" | Two Google accounts in one browser. Sign in as Y, or reconnect Drive as X                                                                    |
+| "Google's sign-in window could not open"                             | The browser blocked the pop-up. The sign-in window opens after two scripts load, so it is outside the click that asked for it                |
 | "Could not access that folder from the server"                       | The grant did not reach the connector: wrong Google account, or a client id/appId mismatch                                                   |
 | Select greys out and nothing happens                                 | The key, the app id or the Picker API is wrong on the Cloud project. Google reports these in the browser console, never through the callback |
 

--- a/docs/google-drive.md
+++ b/docs/google-drive.md
@@ -22,10 +22,9 @@ that name (see the scope note below), so it will make a second folder alongside
 it. Browsing is the only way to point waivers at a folder that already exists or
 at a shared drive the committee watches.
 
-**Browsing only appears when the site is configured for it** (both values under
-Setup). Without them, the Google window opens, browses perfectly, and then
-silently refuses to hand the folder back, so the button is not offered at all
-and the card points at the name field instead.
+**Browsing is disabled until the site is configured for it** (both values under
+Setup), and the card points at the name field instead. The button stays visible
+because the person reading this page is usually the person who can fix it.
 
 ### Using the Google window
 
@@ -42,13 +41,29 @@ thing about the flow.
 Both live in the club's own Google Cloud project, and both must come from the
 **same** project as the OAuth client the connector runs on.
 
-| Value                         | What it is                                                                      |
-| ----------------------------- | ------------------------------------------------------------------------------- |
-| `VITE_GOOGLE_OAUTH_CLIENT_ID` | The OAuth **web** client id. The connector runs on this same client             |
-| `VITE_GOOGLE_PICKER_API_KEY`  | A browser **API key**, restricted to the Picker API and to the site's referrers |
+| Value                         | What it is                                                          |
+| ----------------------------- | ------------------------------------------------------------------- |
+| `VITE_GOOGLE_OAUTH_CLIENT_ID` | The OAuth **web** client id. The connector runs on this same client |
+| `VITE_GOOGLE_PICKER_API_KEY`  | A browser **API key**, restricted by HTTP referrer to the site      |
 
 The **Picker API** must be enabled on that project. It is a separate API from
 the Drive API, and a disabled one fails exactly like a missing key.
+
+Both are read at build time (`import.meta.env`), so adding the key needs a
+rebuild and a redeploy, not just a settings change.
+
+> [!NOTE]
+> Restrict the key by **referrer** first. An API restriction that allows only
+> the Picker API is the tighter setting, but reports differ on whether the
+> picker also calls the Drive API with that key, and getting it wrong fails the
+> same silent way as having no key at all. If the picker misbehaves with an API
+> restriction on, widen it before assuming anything else is wrong.
+>
+> The claim that `VITE_GOOGLE_OAUTH_CLIENT_ID` is the connector's own client is
+> an **assumption nothing in this repo can check**: the site sends the gateway
+> only `GOOGLE_DRIVE_APP_USER_CONNECTOR_CLIENT_API_KEY`, and never sees the
+> Google client the connector uses. If the two ever diverge, every pick fails
+> server-side as a folder that cannot be read, with nothing pointing at why.
 
 Server-side, `GOOGLE_DRIVE_APP_USER_CONNECTOR_CLIENT_API_KEY` authenticates the
 site to Lovable's connector gateway, which holds the manager's refresh token and
@@ -86,13 +101,13 @@ to the manager's whole Drive rather than only the files this site touches.
 
 ## When a pick or an upload fails
 
-| What the manager sees                                                | What it means                                                                                                                                |
-| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| No "Browse in Drive" button                                          | `VITE_GOOGLE_PICKER_API_KEY` (or the client id) is not set on this deploy                                                                    |
-| "Google signed you in as X, but this site's Drive is connected as Y" | Two Google accounts in one browser. Sign in as Y, or reconnect Drive as X                                                                    |
-| "Google's sign-in window could not open"                             | The browser blocked the pop-up. The sign-in window opens after two scripts load, so it is outside the click that asked for it                |
-| "Could not access that folder from the server"                       | The grant did not reach the connector: wrong Google account, or a client id/appId mismatch                                                   |
-| Select greys out and nothing happens                                 | The key, the app id or the Picker API is wrong on the Cloud project. Google reports these in the browser console, never through the callback |
+| What the manager sees                                                | What it means                                                                                                                                                                                                                      |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Browse in Drive" greyed out                                         | `VITE_GOOGLE_PICKER_API_KEY` (or the client id) is not set on this deploy                                                                                                                                                          |
+| "Google signed you in as X, but this site's Drive is connected as Y" | Two Google accounts in one browser. Sign in as Y, or reconnect Drive as X                                                                                                                                                          |
+| "Google's sign-in window could not open"                             | The browser blocked the pop-up. It opens a network round trip after the click, which can be long enough to lose the click's activation                                                                                             |
+| "Could not access that folder from the server"                       | The grant did not reach the connector: wrong Google account, or a client id/appId mismatch                                                                                                                                         |
+| Select greys out and nothing happens                                 | Something on the Cloud project is wrong: the API key, its restrictions, the app id, or the Picker API being disabled. Google reports these in the browser console, never through the callback. Press Cancel on the card to get out |
 
 A folder that later disappears is only recreated when it came from a **typed
 name** (`shouldRecreateFolder`). A picked folder is never recreated: its name is

--- a/docs/google-drive.md
+++ b/docs/google-drive.md
@@ -1,0 +1,109 @@
+# Signed waivers in the manager's Google Drive
+
+A manager can connect their Google account on `/account` and have every signed
+waiver PDF land in a folder of their Drive, on top of the copy the site keeps in
+Supabase Storage. Nothing about signing changes for the member, and a member
+never sees any of this.
+
+The card has two things to set: the Google account (Connect / Disconnect) and
+the destination folder.
+
+## Choosing the folder
+
+There are two ways, and they are not equivalent.
+
+| Way                 | What it can reach                                                                  |
+| ------------------- | ---------------------------------------------------------------------------------- |
+| **Type a name**     | A folder in the manager's own My Drive, created by this site if it isn't there yet |
+| **Browse in Drive** | Any folder the manager can already see, including one inside a **shared drive**    |
+
+Typing a name cannot find a folder the manager made by hand, even with exactly
+that name (see the scope note below), so it will make a second folder alongside
+it. Browsing is the only way to point waivers at a folder that already exists or
+at a shared drive the committee watches.
+
+**Browsing only appears when the site is configured for it** (both values under
+Setup). Without them, the Google window opens, browses perfectly, and then
+silently refuses to hand the folder back, so the button is not offered at all
+and the card points at the name field instead.
+
+### Using the Google window
+
+Google's picker has no "choose the folder I'm in". Click a folder **once** to
+highlight it, then press Select. Opening a folder shows its contents and leaves
+Select greyed out, because the thing selected is whatever is highlighted in the
+listing, and inside a folder nothing is.
+
+The card says this next to the button, because it is the single most confusing
+thing about the flow.
+
+## Setup
+
+Both live in the club's own Google Cloud project, and both must come from the
+**same** project as the OAuth client the connector runs on.
+
+| Value                         | What it is                                                                      |
+| ----------------------------- | ------------------------------------------------------------------------------- |
+| `VITE_GOOGLE_OAUTH_CLIENT_ID` | The OAuth **web** client id. The connector runs on this same client             |
+| `VITE_GOOGLE_PICKER_API_KEY`  | A browser **API key**, restricted to the Picker API and to the site's referrers |
+
+The **Picker API** must be enabled on that project. It is a separate API from
+the Drive API, and a disabled one fails exactly like a missing key.
+
+Server-side, `GOOGLE_DRIVE_APP_USER_CONNECTOR_CLIENT_API_KEY` authenticates the
+site to Lovable's connector gateway, which holds the manager's refresh token and
+makes the actual Drive calls (`callAsAppUser`).
+
+## Why the identity is so fussy
+
+The site asks for one Drive scope, `drive.file`, which grants access **per
+file**, not to the Drive. Access is recorded against the triple **(Google
+account, OAuth client, file)**. Everything below follows from that:
+
+- **The picker is the grant.** Picking a folder is what makes that folder
+  reachable by later uploads. There is no other way in: with `drive.file` the
+  server cannot list, search or open a folder nobody handed it, which is why a
+  pasted Drive link would be useless and why typing a name can only find
+  folders this site made itself.
+- **The picker must run on the connector's OAuth client.** A grant recorded for
+  a different client is invisible to the connector, and the pick fails on the
+  server as a folder it cannot read.
+- **The account must match.** A manager signed into two Google accounts gets the
+  browser's default one in the token popup. `pickDriveFolder` passes the
+  connected address as a login hint and checks the account the token came back
+  for, naming both addresses rather than letting the pick fail later as an
+  unreadable folder id.
+- **Never revoke the picker's token.** Revoking an access token revokes the
+  whole grant for that (account, client) pair: it would tear up the per-file
+  access just recorded, and the connector's refresh token with it, disconnecting
+  Drive. The token is short-lived; leave it to expire.
+
+Broadening the scope (`drive.readonly` or `drive`) would let the site render its
+own folder browser and drop the picker entirely, but both are Google
+**restricted** scopes: the club's OAuth client would need Google verification
+and a security assessment first, and the connector would then hold read access
+to the manager's whole Drive rather than only the files this site touches.
+
+## When a pick or an upload fails
+
+| What the manager sees                                                | What it means                                                                                                                                |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| No "Browse in Drive" button                                          | `VITE_GOOGLE_PICKER_API_KEY` (or the client id) is not set on this deploy                                                                    |
+| "Google signed you in as X, but this site's Drive is connected as Y" | Two Google accounts in one browser. Sign in as Y, or reconnect Drive as X                                                                    |
+| "Could not access that folder from the server"                       | The grant did not reach the connector: wrong Google account, or a client id/appId mismatch                                                   |
+| Select greys out and nothing happens                                 | The key, the app id or the Picker API is wrong on the Cloud project. Google reports these in the browser console, never through the callback |
+
+A folder that later disappears is only recreated when it came from a **typed
+name** (`shouldRecreateFolder`). A picked folder is never recreated: its name is
+not where it lives, and guessing would quietly redirect waivers into a new
+folder in My Drive while the shared drive everyone watches goes silent.
+
+## Files
+
+| File                                           | What it is                                           |
+| ---------------------------------------------- | ---------------------------------------------------- |
+| `src/routes/_authenticated/account.tsx`        | The Google Drive card (manager-only)                 |
+| `src/lib/google-picker.ts`                     | The browser-side picker: token, account check, views |
+| `src/lib/google-drive.functions.ts`            | Connect, folder resolution, and the waiver upload    |
+| `src/lib/google-drive.constants.ts`            | Folder mime type, and how the folder was chosen      |
+| `src/integrations/lovable/appUserConnector.ts` | Gateway calls that carry the manager's connection    |

--- a/docs/google-drive.md
+++ b/docs/google-drive.md
@@ -46,19 +46,12 @@ Both live in the club's own Google Cloud project, and both must come from the
 | `VITE_GOOGLE_OAUTH_CLIENT_ID` | The OAuth **web** client id. The connector runs on this same client |
 | `VITE_GOOGLE_PICKER_API_KEY`  | A browser **API key**, restricted by HTTP referrer to the site      |
 
-The **Picker API** must be enabled on that project. It is a separate API from
-the Drive API, and a disabled one fails exactly like a missing key.
-
 Both are read at build time (`import.meta.env`), so adding the key needs a
-rebuild and a redeploy, not just a settings change.
+rebuild and a redeploy, not just a settings change. The key ships inside the
+site's JavaScript and anyone can read it out of the page source, which is
+normal for a browser key: its restrictions are the only thing protecting it.
 
 > [!NOTE]
-> Restrict the key by **referrer** first. An API restriction that allows only
-> the Picker API is the tighter setting, but reports differ on whether the
-> picker also calls the Drive API with that key, and getting it wrong fails the
-> same silent way as having no key at all. If the picker misbehaves with an API
-> restriction on, widen it before assuming anything else is wrong.
->
 > The claim that `VITE_GOOGLE_OAUTH_CLIENT_ID` is the connector's own client is
 > an **assumption nothing in this repo can check**: the site sends the gateway
 > only `GOOGLE_DRIVE_APP_USER_CONNECTOR_CLIENT_API_KEY`, and never sees the
@@ -68,6 +61,65 @@ rebuild and a redeploy, not just a settings change.
 Server-side, `GOOGLE_DRIVE_APP_USER_CONNECTOR_CLIENT_API_KEY` authenticates the
 site to Lovable's connector gateway, which holds the manager's refresh token and
 makes the actual Drive calls (`callAsAppUser`).
+
+### Setting up the Google Cloud project
+
+Once, in the club's own project: the one that **owns the OAuth client**, whose
+number is the digits in front of the client id. Picking the wrong project is
+the easiest mistake here and it fails silently, so check the project picker in
+the console's top bar at every step. Console labels move; the console's own
+search box is quicker than hunting through menus.
+
+**1. Enable two APIs** (search each by name, then Enable):
+
+- **Google Picker API**, for the folder window.
+- **Google Drive API**, for the uploads and for the check that warns you when
+  you are signed in as the wrong Google account. With Drive off that check
+  fails silently and stops warning anybody, while everything else looks fine.
+
+**2. Create the browser API key.** APIs & Services → Credentials → Create
+credentials → API key, then Edit it:
+
+- **Application restrictions**: Websites, with `https://jitsu.au/*` and
+  `https://*.jitsu.au/*`. Referrer restrictions do accept wildcards.
+- **API restrictions**: Restrict key, and tick **both Picker API and Drive
+  API**. Ticking Picker alone may starve the same call the missing key did, and
+  the symptom is identical. To prove the key first, leave the key unrestricted
+  for one test and tighten it after Select works: change one thing at a time.
+- Restriction changes take a few minutes to land.
+
+**3. Check the OAuth client** (Credentials → the web client):
+
+- **Authorised JavaScript origins** needs `https://jitsu.au`. This is what lets
+  the site ask Google for the token the picker runs on, and it is already right
+  if the picker has ever opened. A missing origin does not look like this bug:
+  sign-in fails with `origin_mismatch` and the folder window never opens.
+- Origins take **no wildcards**, so a Lovable preview URL cannot be authorised.
+  **Browsing only works on the live site**; do not debug it on a preview.
+- **Authorised redirect URIs** needs the gateway callback
+  `https://connector-gateway.lovable.dev/api/v1/app-users/oauth2/callback`.
+  If "Connect Google Drive" works today, this is already there.
+
+**4. Check the consent screen.** The three scopes the site asks for
+(`userinfo.email`, `userinfo.profile`, `drive.file`) are all non-sensitive, so
+there is nothing to submit for verification. The picker needs no extra scope;
+if something is asking for one, do not widen to `drive` or `drive.readonly`.
+
+> [!IMPORTANT]
+> **Publishing status matters more than it looks.** While the consent screen is
+> External + **Testing**, every authorisation expires after **7 days**. That
+> includes the connector's stored refresh token, so the club's Drive connection
+> dies about once a week and waivers quietly stop arriving. Publish the app
+> (In production), or use Internal if the club has Workspace.
+
+**5. Add `VITE_GOOGLE_PICKER_API_KEY`** to the Lovable project settings, beside
+`VITE_SUPABASE_URL`, then **rebuild and redeploy**: until a new build ships,
+"Browse in Drive" stays greyed out no matter what the setting says.
+
+**6. Check it.** On `https://jitsu.au/account` as a manager, signed into the
+Google account Drive is connected as: Browse in Drive should be pressable, the
+folder window should open, and clicking a folder once and pressing Select
+should save it.
 
 ## Why the identity is so fussy
 
@@ -108,6 +160,24 @@ to the manager's whole Drive rather than only the files this site touches.
 | "Google's sign-in window could not open"                             | The browser blocked the pop-up. It opens a network round trip after the click, which can be long enough to lose the click's activation                                                                                             |
 | "Could not access that folder from the server"                       | The grant did not reach the connector: wrong Google account, or a client id/appId mismatch                                                                                                                                         |
 | Select greys out and nothing happens                                 | Something on the Cloud project is wrong: the API key, its restrictions, the app id, or the Picker API being disabled. Google reports these in the browser console, never through the callback. Press Cancel on the card to get out |
+
+### Select still does nothing
+
+Google reports every one of these to the **browser console** and none of them to
+the page, so open the console (Chrome `Ctrl/⌘+Shift+J`) _before_ pressing
+Browse, press Cancel on the card to escape the stuck window, and read from the
+top:
+
+| In the console                                  | What it means                                                                                                        |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `API developer key is invalid`                  | Wrong key, or a key from a different Cloud project than the OAuth client                                             |
+| `403 ... has not been used in project <number>` | That API is not enabled on the project                                                                               |
+| `requests from referer ... are blocked`         | The key's website restrictions do not cover this URL                                                                 |
+| `API_KEY_SERVICE_BLOCKED`                       | The key's **API restrictions** exclude the call. Tick both APIs, or unrestrict to confirm                            |
+| `origin_mismatch`                               | The origin is missing from the OAuth client. You would have seen this before the folder window opened, not at Select |
+
+Nothing useful there? Set the key's API restrictions to "Don't restrict key",
+wait five minutes and retry. If Select then works, the restriction was it.
 
 A folder that later disappears is only recreated when it came from a **typed
 name** (`shouldRecreateFolder`). A picked folder is never recreated: its name is

--- a/src/lib/google-picker.test.ts
+++ b/src/lib/google-picker.test.ts
@@ -285,7 +285,9 @@ describe("pickDriveFolder", () => {
    * `loadScript` short-circuits on a matching `src`, which is the only way this
    * flow can run without the network.
    */
-  function stubGoogle(opts: { accountEmail?: string | null } = {}) {
+  function stubGoogle(
+    opts: { accountEmail?: string | null; popupError?: string; accountCheckFails?: boolean } = {},
+  ) {
     for (const src of [
       "https://accounts.google.com/gsi/client",
       "https://apis.google.com/js/api.js",
@@ -303,7 +305,12 @@ describe("pickDriveFolder", () => {
         oauth2: {
           initTokenClient: (config) => {
             Object.assign(tokenConfig, config);
-            return { requestAccessToken: () => config.callback({ access_token: "tok-1" }) };
+            return {
+              requestAccessToken: () =>
+                opts.popupError
+                  ? config.error_callback?.({ type: opts.popupError })
+                  : config.callback({ access_token: "tok-1" }),
+            };
           },
         },
       },
@@ -312,10 +319,12 @@ describe("pickDriveFolder", () => {
 
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({
-        ok: opts.accountEmail !== undefined,
-        json: async () => ({ user: { emailAddress: opts.accountEmail } }),
-      }),
+      opts.accountCheckFails
+        ? vi.fn().mockRejectedValue(new Error("network"))
+        : vi.fn().mockResolvedValue({
+            ok: opts.accountEmail !== undefined,
+            json: async () => ({ user: { emailAddress: opts.accountEmail } }),
+          }),
     );
 
     return { built, tokenConfig };
@@ -349,7 +358,47 @@ describe("pickDriveFolder", () => {
     built.respond({ action: "cancel" });
 
     await expect(pending).resolves.toBeNull();
-    expect(tokenConfig.hint).toBe("club@jitsu.au");
+    expect(tokenConfig.login_hint).toBe("club@jitsu.au");
+  });
+
+  it("fails loudly when the sign-in window is closed or blocked", async () => {
+    // `callback` never fires for either, so without `error_callback` the browse
+    // hangs on "Opening..." forever with nothing to press.
+    const closed = stubGoogle({ popupError: "popup_closed" });
+    await expect(
+      pickDriveFolder({
+        clientId: "123456789012-abc.apps.googleusercontent.com",
+        developerKey: "AIza-key",
+      }),
+    ).rejects.toThrow(/closed/i);
+    expect(closed.built.visible).toBe(false);
+
+    vi.unstubAllGlobals();
+    document.head.innerHTML = "";
+    const blocked = stubGoogle({ popupError: "popup_failed_to_open" });
+    await expect(
+      pickDriveFolder({
+        clientId: "123456789012-abc.apps.googleusercontent.com",
+        developerKey: "AIza-key",
+      }),
+    ).rejects.toThrow(/pop-ups/i);
+    expect(blocked.built.visible).toBe(false);
+  });
+
+  it("still opens the picker when the account check cannot run", async () => {
+    // The check is a courtesy: a mismatch it misses still surfaces from the
+    // server, but a failed check must never be what stops the manager.
+    const { built } = stubGoogle({ accountCheckFails: true });
+
+    const pending = pickDriveFolder({
+      clientId: "123456789012-abc.apps.googleusercontent.com",
+      developerKey: "AIza-key",
+      connectedEmail: "club@jitsu.au",
+    });
+    await vi.waitFor(() => expect(built.visible).toBe(true));
+    built.respond({ action: "picked", docs: [{ id: "folder-1", name: "Waivers" }] });
+
+    await expect(pending).resolves.toEqual({ id: "folder-1", name: "Waivers" });
   });
 
   it("refuses to open when Google signed the manager in as another account", async () => {

--- a/src/lib/google-picker.test.ts
+++ b/src/lib/google-picker.test.ts
@@ -219,9 +219,10 @@ describe("readPickerResponse", () => {
 
 describe("buildFolderPicker", () => {
   it("sets the developer key, token, app id and origin the pick depends on", () => {
-    // Google checks all four when the manager presses Select, and rejects them
-    // silently: a picker missing any of them browses fine and then swallows the
-    // pick, leaving a greyed-out button and no callback. That was the bug.
+    // Google checks these when the manager presses Select, and rejects them
+    // silently: nothing reaches the callback, so a picker missing any of them
+    // browses fine and then leaves a greyed-out button and no result. The
+    // developer key is the one that was missing when that was reported.
     const { picker, built } = fakePicker();
 
     buildFolderPicker(picker, {
@@ -361,9 +362,51 @@ describe("pickDriveFolder", () => {
     expect(tokenConfig.login_hint).toBe("club@jitsu.au");
   });
 
+  it("gives the caller a way to abandon the dialog once it is on screen", async () => {
+    // Google's dialog only talks back on a pick or a cancel. When it refuses
+    // the pick instead, this is the only thing that ends the browse.
+    const { built } = stubGoogle({ accountEmail: "club@jitsu.au" });
+    let abandon: (() => void) | undefined;
+
+    const pending = pickDriveFolder({
+      clientId: "123456789012-abc.apps.googleusercontent.com",
+      developerKey: "AIza-key",
+      connectedEmail: "club@jitsu.au",
+      onOpen: (close) => {
+        abandon = close;
+      },
+    });
+    await vi.waitFor(() => expect(abandon).toBeDefined());
+    abandon!();
+
+    await expect(pending).resolves.toBeNull();
+    expect(built.visible).toBe(false);
+  });
+
+  it("bounds the account check so a stalled request cannot hang the browse", async () => {
+    // The check sits between the token and the dialog. A request that stalls
+    // rather than fails is not caught by a try/catch, only by this signal.
+    const { built } = stubGoogle({ accountEmail: "club@jitsu.au" });
+
+    const pending = pickDriveFolder({
+      clientId: "123456789012-abc.apps.googleusercontent.com",
+      developerKey: "AIza-key",
+      connectedEmail: "club@jitsu.au",
+    });
+    await vi.waitFor(() => expect(built.visible).toBe(true));
+    built.respond({ action: "cancel" });
+    await pending;
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/drive/v3/about"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
   it("fails loudly when the sign-in window is closed or blocked", async () => {
-    // `callback` never fires for either, so without `error_callback` the browse
-    // hangs on "Opening..." forever with nothing to press.
+    // `callback` never fires for either, so without `error_callback` these
+    // promises never settle: the assertions below would not fail, the test
+    // would time out with nothing to say about which path broke.
     const closed = stubGoogle({ popupError: "popup_closed" });
     await expect(
       pickDriveFolder({

--- a/src/lib/google-picker.test.ts
+++ b/src/lib/google-picker.test.ts
@@ -1,23 +1,44 @@
-// The picker's *view configuration* is the whole product behaviour here: get
-// it wrong and the manager is asked to select a file, or can only see the
-// folders in their own My Drive. `pickDriveFolder` itself is a thin wrapper
-// around Google's globals (script loading, OAuth popup) that can't run under
-// the test runner, so the parts worth pinning are extracted: which views the
-// picker opens with, and the app id derivation `drive.file` grants depend on.
-import { describe, expect, it } from "vitest";
+// The picker's *configuration* is the whole product behaviour here: get it
+// wrong and the manager is asked to select a file, can only see the folders in
+// their own My Drive, or (the bug this file grew for) presses Select and
+// watches nothing happen. Everything Google enforces on the pick is enforced
+// silently, so each piece of it is pinned here: the views the picker opens
+// with, the key/app id/token the response path depends on, and the account
+// check that stops a pick the server would never be able to read.
+// `pickDriveFolder` runs against stand-ins for Google's globals.
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { FOLDER_MIME_TYPE } from "./google-drive.constants";
 import {
+  accountMismatchMessage,
   appIdFromClientId,
+  buildFolderPicker,
   buildFolderViews,
+  type GooglePickerBuilder,
   type GooglePickerNamespace,
   type GooglePickerView,
+  type PickerResponse,
+  pickDriveFolder,
   readPickerResponse,
 } from "./google-picker";
 
 type Recorded = Record<string, unknown>;
 
-function fakePicker(): { picker: GooglePickerNamespace; views: Recorded[] } {
+/** What the fake builder recorded, so a test can inspect the picker we built. */
+interface BuiltPicker {
+  calls: Recorded;
+  addedViews: number;
+  visible: boolean;
+  respond: (data: PickerResponse) => void;
+}
+
+function fakePicker(): { picker: GooglePickerNamespace; views: Recorded[]; built: BuiltPicker } {
   const views: Recorded[] = [];
+  const built: BuiltPicker = {
+    calls: {},
+    addedViews: 0,
+    visible: false,
+    respond: () => {},
+  };
 
   class FakeDocsView implements GooglePickerView {
     private readonly calls: Recorded;
@@ -55,13 +76,52 @@ function fakePicker(): { picker: GooglePickerNamespace; views: Recorded[] } {
     }
   }
 
+  class FakePickerBuilder implements GooglePickerBuilder {
+    private set(key: string, value: unknown) {
+      built.calls[key] = value;
+      return this;
+    }
+    addView(view: GooglePickerView) {
+      built.addedViews += 1;
+      void view;
+      return this;
+    }
+    setOAuthToken(v: string) {
+      return this.set("oauthToken", v);
+    }
+    setDeveloperKey(v: string) {
+      return this.set("developerKey", v);
+    }
+    setOrigin(v: string) {
+      return this.set("origin", v);
+    }
+    setTitle(v: string) {
+      return this.set("title", v);
+    }
+    setAppId(v: string) {
+      return this.set("appId", v);
+    }
+    setCallback(cb: (data: PickerResponse) => void) {
+      built.respond = cb;
+      return this;
+    }
+    build() {
+      return {
+        setVisible: (visible: boolean) => {
+          built.visible = visible;
+        },
+      };
+    }
+  }
+
   return {
     views,
+    built,
     picker: {
       ViewId: { FOLDERS: "folders" },
       DocsViewMode: { LIST: "list", GRID: "grid" },
       DocsView: FakeDocsView,
-      PickerBuilder: class {} as unknown as GooglePickerNamespace["PickerBuilder"],
+      PickerBuilder: FakePickerBuilder,
       Action: { PICKED: "picked", CANCEL: "cancel" },
       Response: { ACTION: "action", DOCUMENTS: "docs" },
       Document: { ID: "id", NAME: "name" },
@@ -154,6 +214,155 @@ describe("readPickerResponse", () => {
       status: "picked",
       folder: null,
     });
+  });
+});
+
+describe("buildFolderPicker", () => {
+  it("sets the developer key, token, app id and origin the pick depends on", () => {
+    // Google checks all four when the manager presses Select, and rejects them
+    // silently: a picker missing any of them browses fine and then swallows the
+    // pick, leaving a greyed-out button and no callback. That was the bug.
+    const { picker, built } = fakePicker();
+
+    buildFolderPicker(picker, {
+      token: "tok-1",
+      developerKey: "AIza-key",
+      appId: "123456789012",
+      origin: "https://jitsu.au",
+      onResponse: () => {},
+    });
+
+    expect(built.calls.developerKey).toBe("AIza-key");
+    expect(built.calls.oauthToken).toBe("tok-1");
+    expect(built.calls.appId).toBe("123456789012");
+    expect(built.calls.origin).toBe("https://jitsu.au");
+    expect(built.addedViews).toBe(3);
+  });
+
+  it("still builds when the client id yielded no app id", () => {
+    const { picker, built } = fakePicker();
+
+    buildFolderPicker(picker, {
+      token: "tok-1",
+      developerKey: "AIza-key",
+      appId: null,
+      origin: "https://jitsu.au",
+      onResponse: () => {},
+    });
+
+    expect(built.calls.appId).toBeUndefined();
+  });
+});
+
+describe("accountMismatchMessage", () => {
+  it("names both accounts when the picker signed in as someone else", () => {
+    const message = accountMismatchMessage("personal@gmail.com", "club@jitsu.au");
+    expect(message).toContain("personal@gmail.com");
+    expect(message).toContain("club@jitsu.au");
+  });
+
+  it("says nothing when the accounts match, whatever the casing", () => {
+    expect(accountMismatchMessage("Club@Jitsu.au", "club@jitsu.au ")).toBeNull();
+  });
+
+  it("says nothing when either account is unknown", () => {
+    // Drive not answering `about.get` is not a reason to block the manager.
+    expect(accountMismatchMessage(null, "club@jitsu.au")).toBeNull();
+    expect(accountMismatchMessage("club@jitsu.au", null)).toBeNull();
+  });
+});
+
+describe("pickDriveFolder", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.head.innerHTML = "";
+    delete window.google;
+    delete window.gapi;
+  });
+
+  /**
+   * Stands in for Google's globals. The script tags are pre-inserted because
+   * `loadScript` short-circuits on a matching `src`, which is the only way this
+   * flow can run without the network.
+   */
+  function stubGoogle(opts: { accountEmail?: string | null } = {}) {
+    for (const src of [
+      "https://accounts.google.com/gsi/client",
+      "https://apis.google.com/js/api.js",
+    ]) {
+      const script = document.createElement("script");
+      script.src = src;
+      document.head.appendChild(script);
+    }
+
+    const { picker, built } = fakePicker();
+    const tokenConfig: Recorded = {};
+    window.gapi = { load: (_api: string, cb: () => void) => cb() };
+    window.google = {
+      accounts: {
+        oauth2: {
+          initTokenClient: (config) => {
+            Object.assign(tokenConfig, config);
+            return { requestAccessToken: () => config.callback({ access_token: "tok-1" }) };
+          },
+        },
+      },
+      picker,
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: opts.accountEmail !== undefined,
+        json: async () => ({ user: { emailAddress: opts.accountEmail } }),
+      }),
+    );
+
+    return { built, tokenConfig };
+  }
+
+  it("hands back the folder the manager picked", async () => {
+    const { built } = stubGoogle({ accountEmail: "club@jitsu.au" });
+
+    const pending = pickDriveFolder({
+      clientId: "123456789012-abc.apps.googleusercontent.com",
+      developerKey: "AIza-key",
+      connectedEmail: "club@jitsu.au",
+    });
+    await vi.waitFor(() => expect(built.visible).toBe(true));
+    built.respond({ action: "picked", docs: [{ id: "folder-1", name: "Waivers" }] });
+
+    await expect(pending).resolves.toEqual({ id: "folder-1", name: "Waivers" });
+  });
+
+  it("asks Google for the account the site is connected as", async () => {
+    // Without the hint the popup silently uses the browser's default account,
+    // and a pick made as the wrong one only fails later, server-side.
+    const { built, tokenConfig } = stubGoogle({ accountEmail: "club@jitsu.au" });
+
+    const pending = pickDriveFolder({
+      clientId: "123456789012-abc.apps.googleusercontent.com",
+      developerKey: "AIza-key",
+      connectedEmail: "club@jitsu.au",
+    });
+    await vi.waitFor(() => expect(built.visible).toBe(true));
+    built.respond({ action: "cancel" });
+
+    await expect(pending).resolves.toBeNull();
+    expect(tokenConfig.hint).toBe("club@jitsu.au");
+  });
+
+  it("refuses to open when Google signed the manager in as another account", async () => {
+    const { built } = stubGoogle({ accountEmail: "personal@gmail.com" });
+
+    await expect(
+      pickDriveFolder({
+        clientId: "123456789012-abc.apps.googleusercontent.com",
+        developerKey: "AIza-key",
+        connectedEmail: "club@jitsu.au",
+      }),
+    ).rejects.toThrow(/personal@gmail\.com/);
+    expect(built.visible).toBe(false);
   });
 });
 

--- a/src/lib/google-picker.ts
+++ b/src/lib/google-picker.ts
@@ -105,6 +105,39 @@ async function loadPickerLibrary(): Promise<void> {
 }
 
 /**
+ * Fetches Google's two scripts ahead of the manager pressing Browse.
+ *
+ * The sign-in popup has to open inside the click that asked for it, or the
+ * browser treats it as unsolicited and blocks it. Awaiting a script download
+ * first spends the click's transient activation, so the download happens when
+ * the card mounts instead. Failures are ignored on purpose: this is a warm-up,
+ * and `pickDriveFolder` reports for real if the scripts are genuinely missing.
+ */
+export function preloadGooglePicker(): void {
+  void loadScript(GIS_SRC).catch(() => {});
+  void loadPickerLibrary().catch(() => {});
+}
+
+/**
+ * Google's sign-in failures arrive as bare codes (`access_denied`,
+ * `popup_closed`). They now land in an alert that stays on screen, so they have
+ * to be sentences a manager can act on rather than something to paste into a
+ * search box.
+ */
+export function signInErrorMessage(code: string | undefined): string {
+  switch (code) {
+    case "popup_failed_to_open":
+      return "Google's sign-in window could not open. Allow pop-ups for this site and try again.";
+    case "popup_closed":
+      return "Google sign-in was closed before it finished.";
+    case "access_denied":
+      return "Google would not give this site access. Try again and allow it to see the folder you choose.";
+    default:
+      return "Google sign-in did not finish. Try again.";
+  }
+}
+
+/**
  * `login_hint` is the connected Google account's address. Without it the token
  * popup silently uses whichever account the browser happens to have as its
  * default, and a manager signed into two accounts then picks a folder their
@@ -128,20 +161,12 @@ async function requestAccessToken(clientId: string, loginHint?: string): Promise
       ...(loginHint ? { login_hint: loginHint } : {}),
       callback: (resp) => {
         if (resp.error || !resp.access_token) {
-          reject(new Error(resp.error ?? "Google sign-in was cancelled"));
+          reject(new Error(signInErrorMessage(resp.error)));
           return;
         }
         resolve(resp.access_token);
       },
-      error_callback: (err) => {
-        reject(
-          new Error(
-            err?.type === "popup_failed_to_open"
-              ? "Google's sign-in window could not open. Allow pop-ups for this site and try again."
-              : "Google sign-in was closed before it finished.",
-          ),
-        );
-      },
+      error_callback: (err) => reject(new Error(signInErrorMessage(err?.type))),
     });
     client.requestAccessToken();
   });
@@ -278,13 +303,13 @@ export function readPickerResponse(
  * be pinned by a test: everything Google enforces when the manager presses
  * Select lives here, and getting any of it wrong fails the same silent way.
  *
- * `setDeveloperKey` is not optional decoration. Google enforces the API key
- * together with the app id on the response path, so a picker built without one
- * browses perfectly and then swallows the Select: the button greys out, no
- * callback ever fires, and the dialog just sits there. The key must come from
- * the same Cloud project as the OAuth client, with the Picker API enabled on
- * it (the Picker API is separate from the Drive API, and a disabled one fails
- * identically).
+ * `setDeveloperKey` is the one this file was missing. Google documents the
+ * builder as taking a view, an OAuth token, a developer key and a callback,
+ * and a picker without the key is the leading explanation for browsing working
+ * and then Select doing nothing at all. It is not the only candidate: the
+ * Picker API being disabled on the project, or the key's own restrictions
+ * refusing the call, look identical from here, because none of them reach the
+ * callback. The key must come from the same Cloud project as the OAuth client.
  */
 export function buildFolderPicker(
   picker: GooglePickerNamespace,
@@ -317,6 +342,15 @@ export interface PickDriveFolderOptions {
   developerKey: string;
   /** The Google account this site's Drive is connected as, when we know it. */
   connectedEmail?: string | null;
+  /**
+   * Called once the dialog is on screen, with a way to give up on it.
+   *
+   * Everything inside that dialog is Google's, and it only talks back on a pick
+   * or a cancel. If it refuses the pick, or shows an error of its own and the
+   * manager dismisses it, nothing reaches us and the browse would wait forever.
+   * The caller uses this to put a way out on our own page.
+   */
+  onOpen?: (close: () => void) => void;
 }
 
 /**
@@ -355,6 +389,10 @@ export async function pickDriveFolder(
         },
       });
       picker.setVisible(true);
+      opts.onOpen?.(() => {
+        picker.setVisible(false);
+        resolve(null);
+      });
     } catch (e) {
       reject(e instanceof Error ? e : new Error("Failed to open Google Picker"));
     }

--- a/src/lib/google-picker.ts
+++ b/src/lib/google-picker.ts
@@ -65,8 +65,9 @@ declare global {
           initTokenClient(config: {
             client_id: string;
             scope: string;
-            hint?: string;
+            login_hint?: string;
             callback: (resp: { access_token?: string; error?: string }) => void;
+            error_callback?: (err?: { type?: string; message?: string }) => void;
           }): { requestAccessToken: (opts?: { prompt?: string }) => void };
         };
       };
@@ -104,11 +105,17 @@ async function loadPickerLibrary(): Promise<void> {
 }
 
 /**
- * `hint` is the connected Google account's address. Without it the token popup
- * silently uses whichever account the browser happens to have as its default,
- * and a manager signed into two accounts then picks a folder their *connection*
- * cannot see: `drive.file` access is recorded against (Google account, OAuth
- * client, file), so the pick looks fine and the server's read-back 404s.
+ * `login_hint` is the connected Google account's address. Without it the token
+ * popup silently uses whichever account the browser happens to have as its
+ * default, and a manager signed into two accounts then picks a folder their
+ * *connection* cannot see: `drive.file` access is recorded against (Google
+ * account, OAuth client, file), so the pick looks fine and the server's
+ * read-back 404s.
+ *
+ * `error_callback` is the other half of settling this promise. `callback` only
+ * fires on a token response, so without it a closed or blocked popup leaves
+ * every await below hanging: the button would sit on "Opening..." with nothing
+ * to press, which is the failure this whole file exists to stop.
  */
 async function requestAccessToken(clientId: string, loginHint?: string): Promise<string> {
   await loadScript(GIS_SRC);
@@ -118,7 +125,7 @@ async function requestAccessToken(clientId: string, loginHint?: string): Promise
     const client = google.accounts.oauth2.initTokenClient({
       client_id: clientId,
       scope: DRIVE_FILE_SCOPE,
-      ...(loginHint ? { hint: loginHint } : {}),
+      ...(loginHint ? { login_hint: loginHint } : {}),
       callback: (resp) => {
         if (resp.error || !resp.access_token) {
           reject(new Error(resp.error ?? "Google sign-in was cancelled"));
@@ -126,27 +133,46 @@ async function requestAccessToken(clientId: string, loginHint?: string): Promise
         }
         resolve(resp.access_token);
       },
+      error_callback: (err) => {
+        reject(
+          new Error(
+            err?.type === "popup_failed_to_open"
+              ? "Google's sign-in window could not open. Allow pop-ups for this site and try again."
+              : "Google sign-in was closed before it finished.",
+          ),
+        );
+      },
     });
     client.requestAccessToken();
   });
 }
+
+/** Long enough for a slow phone, short enough that nobody watches a dead button. */
+const ACCOUNT_CHECK_TIMEOUT_MS = 8000;
 
 /**
  * The account the picker token belongs to, or null if Drive would not say.
  * `about.get` is readable under `drive.file`, and it is the only way to learn
  * which account the popup actually signed in as: the token itself carries no
  * address, and the `userinfo` endpoints need scopes this token does not have.
+ *
+ * This sits between the token and the picker opening, so it is bounded: a
+ * request that stalls rather than fails (captive portal, extension, proxy)
+ * would otherwise hang the browse for good.
  */
 async function tokenAccountEmail(token: string): Promise<string | null> {
   try {
     const res = await fetch("https://www.googleapis.com/drive/v3/about?fields=user(emailAddress)", {
       headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(ACCOUNT_CHECK_TIMEOUT_MS),
     });
     if (!res.ok) return null;
     const body = (await res.json()) as { user?: { emailAddress?: string } };
     return body.user?.emailAddress ?? null;
   } catch {
-    // A blocked or flaky request is not a reason to stop the manager picking.
+    // A slow or blocked request is not a reason to stop the manager picking:
+    // a mismatch they were not warned about still fails with a readable
+    // message, one step later, from the server.
     return null;
   }
 }

--- a/src/lib/google-picker.ts
+++ b/src/lib/google-picker.ts
@@ -5,6 +5,15 @@
  * server-side Drive connector uses: `drive.file` grants are recorded per
  * (user, OAuth client, file), not per token, so whatever they pick here
  * becomes reachable by the server-side upload too.
+ *
+ * That "per (user, OAuth client, file)" is the whole reason this file is
+ * fussy about identity. Everything Google checks when the manager presses
+ * Select is checked silently: a missing API key, an app id from another
+ * project, or a browser signed into a different Google account all end the
+ * same way, with a greyed-out Select button and no callback. So the picker is
+ * only offered when both halves of the project are configured
+ * (`VITE_GOOGLE_OAUTH_CLIENT_ID` and `VITE_GOOGLE_PICKER_API_KEY`, with the
+ * Picker API enabled on that project), and the account is checked up front.
  */
 
 import { FOLDER_MIME_TYPE } from "./google-drive.constants";
@@ -27,9 +36,10 @@ export interface GooglePickerView {
   setLabel: (label: string) => GooglePickerView;
 }
 
-interface GooglePickerBuilder {
+export interface GooglePickerBuilder {
   addView: (view: GooglePickerView) => GooglePickerBuilder;
   setOAuthToken: (token: string) => GooglePickerBuilder;
+  setDeveloperKey: (key: string) => GooglePickerBuilder;
   setOrigin: (origin: string) => GooglePickerBuilder;
   setTitle: (title: string) => GooglePickerBuilder;
   setAppId: (appId: string) => GooglePickerBuilder;
@@ -55,9 +65,9 @@ declare global {
           initTokenClient(config: {
             client_id: string;
             scope: string;
+            hint?: string;
             callback: (resp: { access_token?: string; error?: string }) => void;
           }): { requestAccessToken: (opts?: { prompt?: string }) => void };
-          revoke(token: string, done: () => void): void;
         };
       };
       picker: GooglePickerNamespace;
@@ -93,7 +103,14 @@ async function loadPickerLibrary(): Promise<void> {
   await new Promise<void>((resolve) => window.gapi!.load("picker", () => resolve()));
 }
 
-async function requestAccessToken(clientId: string): Promise<string> {
+/**
+ * `hint` is the connected Google account's address. Without it the token popup
+ * silently uses whichever account the browser happens to have as its default,
+ * and a manager signed into two accounts then picks a folder their *connection*
+ * cannot see: `drive.file` access is recorded against (Google account, OAuth
+ * client, file), so the pick looks fine and the server's read-back 404s.
+ */
+async function requestAccessToken(clientId: string, loginHint?: string): Promise<string> {
   await loadScript(GIS_SRC);
   if (!window.google) throw new Error("Google Identity Services did not load");
   const google = window.google;
@@ -101,6 +118,7 @@ async function requestAccessToken(clientId: string): Promise<string> {
     const client = google.accounts.oauth2.initTokenClient({
       client_id: clientId,
       scope: DRIVE_FILE_SCOPE,
+      ...(loginHint ? { hint: loginHint } : {}),
       callback: (resp) => {
         if (resp.error || !resp.access_token) {
           reject(new Error(resp.error ?? "Google sign-in was cancelled"));
@@ -111,6 +129,41 @@ async function requestAccessToken(clientId: string): Promise<string> {
     });
     client.requestAccessToken();
   });
+}
+
+/**
+ * The account the picker token belongs to, or null if Drive would not say.
+ * `about.get` is readable under `drive.file`, and it is the only way to learn
+ * which account the popup actually signed in as: the token itself carries no
+ * address, and the `userinfo` endpoints need scopes this token does not have.
+ */
+async function tokenAccountEmail(token: string): Promise<string | null> {
+  try {
+    const res = await fetch("https://www.googleapis.com/drive/v3/about?fields=user(emailAddress)", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { user?: { emailAddress?: string } };
+    return body.user?.emailAddress ?? null;
+  } catch {
+    // A blocked or flaky request is not a reason to stop the manager picking.
+    return null;
+  }
+}
+
+/**
+ * The message for "you are picking as the wrong Google account", or null when
+ * there is nothing to complain about. A pick made under the wrong account fails
+ * later, on the server, as an unreadable folder id, so it is worth catching
+ * here where we can still name both accounts.
+ */
+export function accountMismatchMessage(
+  pickerEmail: string | null,
+  connectedEmail: string | null | undefined,
+): string | null {
+  if (!pickerEmail || !connectedEmail) return null;
+  if (pickerEmail.trim().toLowerCase() === connectedEmail.trim().toLowerCase()) return null;
+  return `Google signed you in as ${pickerEmail}, but this site's Drive is connected as ${connectedEmail}. Sign in as ${connectedEmail} and try again, or reconnect Google Drive with ${pickerEmail}.`;
 }
 
 /**
@@ -195,44 +248,86 @@ export function readPickerResponse(
 }
 
 /**
+ * Assembles the picker. Split from `pickDriveFolder` so the builder wiring can
+ * be pinned by a test: everything Google enforces when the manager presses
+ * Select lives here, and getting any of it wrong fails the same silent way.
+ *
+ * `setDeveloperKey` is not optional decoration. Google enforces the API key
+ * together with the app id on the response path, so a picker built without one
+ * browses perfectly and then swallows the Select: the button greys out, no
+ * callback ever fires, and the dialog just sits there. The key must come from
+ * the same Cloud project as the OAuth client, with the Picker API enabled on
+ * it (the Picker API is separate from the Drive API, and a disabled one fails
+ * identically).
+ */
+export function buildFolderPicker(
+  picker: GooglePickerNamespace,
+  opts: {
+    token: string;
+    developerKey: string;
+    appId: string | null;
+    origin: string;
+    onResponse: (data: PickerResponse) => void;
+  },
+): { setVisible: (visible: boolean) => void } {
+  const builder = new picker.PickerBuilder()
+    .setOAuthToken(opts.token)
+    .setDeveloperKey(opts.developerKey)
+    // Restricts the picker's postMessage response channel to this page's
+    // own origin, per Google's Picker integration guidance.
+    .setOrigin(opts.origin)
+    .setTitle("Choose a folder for signed waivers");
+
+  if (opts.appId) builder.setAppId(opts.appId);
+  for (const view of buildFolderViews(picker)) builder.addView(view);
+
+  return builder.setCallback(opts.onResponse).build();
+}
+
+export interface PickDriveFolderOptions {
+  /** OAuth client id, which must be the one the server-side connector runs on. */
+  clientId: string;
+  /** Browser API key from the same Cloud project, with the Picker API enabled. */
+  developerKey: string;
+  /** The Google account this site's Drive is connected as, when we know it. */
+  connectedEmail?: string | null;
+}
+
+/**
  * Opens Google Picker restricted to folder selection. Resolves with the
  * picked folder, or null if the manager closed the picker without choosing one.
  */
-export async function pickDriveFolder(clientId: string): Promise<PickedDriveFolder | null> {
-  const [, token] = await Promise.all([loadPickerLibrary(), requestAccessToken(clientId)]);
+export async function pickDriveFolder(
+  opts: PickDriveFolderOptions,
+): Promise<PickedDriveFolder | null> {
+  const [, token] = await Promise.all([
+    loadPickerLibrary(),
+    requestAccessToken(opts.clientId, opts.connectedEmail ?? undefined),
+  ]);
   const google = window.google;
   if (!google) throw new Error("Google Identity Services did not load");
 
+  const mismatch = accountMismatchMessage(await tokenAccountEmail(token), opts.connectedEmail);
+  if (mismatch) throw new Error(mismatch);
+
   return new Promise((resolve, reject) => {
     try {
-      // The token is scoped to this one picker session and used nowhere else,
-      // so once the manager has picked (or cancelled) there's no reason for it
-      // to remain valid — revoke it rather than leave it live until Google's
-      // own expiry.
-      const finish = (result: PickedDriveFolder | null) => {
-        google.accounts.oauth2.revoke(token, () => {});
-        resolve(result);
-      };
-
-      const builder = new google.picker.PickerBuilder()
-        .setOAuthToken(token)
-        // Restricts the picker's postMessage response channel to this page's
-        // own origin, per Google's Picker integration guidance.
-        .setOrigin(window.location.origin)
-        .setTitle("Choose a folder for signed waivers");
-
-      const appId = appIdFromClientId(clientId);
-      if (appId) builder.setAppId(appId);
-
-      for (const view of buildFolderViews(google.picker)) builder.addView(view);
-
-      const picker = builder
-        .setCallback((data: PickerResponse) => {
+      // Deliberately no `oauth2.revoke` when we're done. Revoking an access
+      // token revokes the whole grant for this (account, OAuth client) pair:
+      // it would tear up the per-file access the pick just recorded, and the
+      // connector's own refresh token with it, disconnecting Drive entirely.
+      // The token is short-lived and Google expires it on its own.
+      const picker = buildFolderPicker(google.picker, {
+        token,
+        developerKey: opts.developerKey,
+        appId: appIdFromClientId(opts.clientId),
+        origin: window.location.origin,
+        onResponse: (data) => {
           const result = readPickerResponse(google.picker, data);
-          if (result.status === "picked") finish(result.folder);
-          else if (result.status === "cancelled") finish(null);
-        })
-        .build();
+          if (result.status === "picked") resolve(result.folder);
+          else if (result.status === "cancelled") resolve(null);
+        },
+      });
       picker.setVisible(true);
     } catch (e) {
       reject(e instanceof Error ? e : new Error("Failed to open Google Picker"));

--- a/src/routes/_authenticated/account.test.tsx
+++ b/src/routes/_authenticated/account.test.tsx
@@ -5,7 +5,7 @@
 // rejects), and an unset size must go out as `null` rather than "".
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 
 const updateMyProfile = vi.fn().mockResolvedValue({ ok: true, fields: [] });
@@ -80,13 +80,21 @@ vi.mock("sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
 }));
 
+// Mutable so the manager-only cards (Google Drive) can be rendered by the few
+// tests that need them, without a second copy of this whole mock setup.
+const mockRoles = { isManager: false };
+
 vi.mock("@/hooks/useAuth", () => ({
   useAuth: () => ({
     user: { id: "u1", email: "ada@example.com", email_confirmed_at: "2026-01-01T00:00:00Z" },
     session: null,
     loading: false,
   }),
-  useRoles: () => ({ roles: ["member"], loading: false, isManager: false }),
+  useRoles: () => ({
+    roles: mockRoles.isManager ? ["manager"] : ["member"],
+    loading: false,
+    isManager: mockRoles.isManager,
+  }),
 }));
 
 const { Route } = await import("./account");
@@ -356,5 +364,56 @@ describe("/account", () => {
     expect(consentCard.queryByRole("button", { name: "Revert" })).toBeNull();
     expect(consentCard.getByRole("button", { name: "Save" })).toBeDisabled();
     expect(updateMyProfile).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Browsing needs an OAuth client id AND a Picker API key from the same Cloud
+   * project. Offered without the key, the Google window opens, browses, and
+   * then silently refuses to hand the folder back, so the manager is better
+   * off being pointed at the name field than at that dead end.
+   */
+  describe("the Google Drive card", () => {
+    async function renderConnected() {
+      mockRoles.isManager = true;
+      const { getGoogleDriveStatus } = await import("@/lib/google-drive.functions");
+      vi.mocked(getGoogleDriveStatus).mockResolvedValue({
+        connected: true,
+        email: "club@jitsu.au",
+        folderId: null,
+        folderName: null,
+      } as never);
+      await renderLoaded();
+      await screen.findByLabelText("Drive folder");
+      return within(card("Google Drive"));
+    }
+
+    afterEach(async () => {
+      mockRoles.isManager = false;
+      const { getGoogleDriveStatus } = await import("@/lib/google-drive.functions");
+      vi.mocked(getGoogleDriveStatus).mockResolvedValue({ connected: false } as never);
+      vi.unstubAllEnvs();
+    });
+
+    it("offers browsing, and says how to select a folder, once the picker is configured", async () => {
+      vi.stubEnv("VITE_GOOGLE_OAUTH_CLIENT_ID", "123456789012-abc.apps.googleusercontent.com");
+      vi.stubEnv("VITE_GOOGLE_PICKER_API_KEY", "AIza-key");
+
+      const driveCard = await renderConnected();
+
+      expect(driveCard.getByRole("button", { name: "Browse in Drive" })).toBeInTheDocument();
+      // Picker has no "choose the folder I'm in": opening a folder leaves
+      // Select greyed out, which is what sent the manager round in circles.
+      expect(driveCard.getByText(/click a folder once/i)).toBeInTheDocument();
+    });
+
+    it("hides browsing and points at the name field when the Picker key is missing", async () => {
+      vi.stubEnv("VITE_GOOGLE_OAUTH_CLIENT_ID", "123456789012-abc.apps.googleusercontent.com");
+      vi.stubEnv("VITE_GOOGLE_PICKER_API_KEY", "");
+
+      const driveCard = await renderConnected();
+
+      expect(driveCard.queryByRole("button", { name: "Browse in Drive" })).toBeNull();
+      expect(driveCard.getByText(/not set up on this site yet/i)).toBeInTheDocument();
+    });
   });
 });

--- a/src/routes/_authenticated/account.test.tsx
+++ b/src/routes/_authenticated/account.test.tsx
@@ -72,6 +72,13 @@ vi.mock("@/lib/google-drive.functions", () => ({
   setGoogleDriveFolderFromPicker: vi.fn(),
 }));
 
+// The picker itself is Google's; what this file pins is the wiring into it.
+const mockPickDriveFolder = vi.fn();
+vi.mock("@/lib/google-picker", () => ({
+  pickDriveFolder: (...args: unknown[]) => mockPickDriveFolder(...args),
+  preloadGooglePicker: vi.fn(),
+}));
+
 vi.mock("@/integrations/supabase/client", () => ({
   supabase: { auth: { updateUser: vi.fn() } },
 }));
@@ -387,33 +394,98 @@ describe("/account", () => {
       return within(card("Google Drive"));
     }
 
+    function configurePicker() {
+      vi.stubEnv("VITE_GOOGLE_OAUTH_CLIENT_ID", "123456789012-abc.apps.googleusercontent.com");
+      vi.stubEnv("VITE_GOOGLE_PICKER_API_KEY", "AIza-key");
+    }
+
     afterEach(async () => {
       mockRoles.isManager = false;
       const { getGoogleDriveStatus } = await import("@/lib/google-drive.functions");
       vi.mocked(getGoogleDriveStatus).mockResolvedValue({ connected: false } as never);
+      mockPickDriveFolder.mockReset();
       vi.unstubAllEnvs();
     });
 
     it("offers browsing, and says how to select a folder, once the picker is configured", async () => {
-      vi.stubEnv("VITE_GOOGLE_OAUTH_CLIENT_ID", "123456789012-abc.apps.googleusercontent.com");
-      vi.stubEnv("VITE_GOOGLE_PICKER_API_KEY", "AIza-key");
+      configurePicker();
 
       const driveCard = await renderConnected();
 
-      expect(driveCard.getByRole("button", { name: "Browse in Drive" })).toBeInTheDocument();
+      expect(driveCard.getByRole("button", { name: "Browse in Drive" })).toBeEnabled();
       // Picker has no "choose the folder I'm in": opening a folder leaves
       // Select greyed out, which is what sent the manager round in circles.
       expect(driveCard.getByText(/click a folder once/i)).toBeInTheDocument();
     });
 
-    it("hides browsing and points at the name field when the Picker key is missing", async () => {
+    it("disables browsing and points at the name field when the Picker key is missing", async () => {
       vi.stubEnv("VITE_GOOGLE_OAUTH_CLIENT_ID", "123456789012-abc.apps.googleusercontent.com");
       vi.stubEnv("VITE_GOOGLE_PICKER_API_KEY", "");
 
       const driveCard = await renderConnected();
 
-      expect(driveCard.queryByRole("button", { name: "Browse in Drive" })).toBeNull();
-      expect(driveCard.getByText(/not set up on this site yet/i)).toBeInTheDocument();
+      // Disabled rather than absent: the manager is the person who can fix
+      // this, and a button that vanished tells them nothing to fix.
+      expect(driveCard.getByRole("button", { name: "Browse in Drive" })).toBeDisabled();
+      expect(driveCard.getByText(/until this site has its google picker key/i)).toBeInTheDocument();
+    });
+
+    it("picks with the site's key, as the account the connection is on", async () => {
+      // Drop `connectedEmail` and the login hint plus the whole wrong-account
+      // check go quietly dead, with every picker test still green.
+      configurePicker();
+      mockPickDriveFolder.mockResolvedValue(null);
+      const user = userEvent.setup();
+
+      const driveCard = await renderConnected();
+      await user.click(driveCard.getByRole("button", { name: "Browse in Drive" }));
+
+      await waitFor(() => expect(mockPickDriveFolder).toHaveBeenCalledTimes(1));
+      expect(mockPickDriveFolder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clientId: "123456789012-abc.apps.googleusercontent.com",
+          developerKey: "AIza-key",
+          connectedEmail: "club@jitsu.au",
+        }),
+      );
+    });
+
+    it("gives the manager a way out while Google's window is open", async () => {
+      // Google's dialog only talks back on a pick or a cancel. If it refuses
+      // the pick, nothing reaches us, and without this the button would sit on
+      // "Opening..." until the page was reloaded. That was the reported bug.
+      configurePicker();
+      mockPickDriveFolder.mockImplementation(
+        (opts: { onOpen?: (close: () => void) => void }) =>
+          new Promise((resolve) => opts.onOpen?.(() => resolve(null))),
+      );
+      const user = userEvent.setup();
+
+      const driveCard = await renderConnected();
+      await user.click(driveCard.getByRole("button", { name: "Browse in Drive" }));
+
+      const cancel = await screen.findByRole("button", { name: "Cancel" });
+      await user.click(cancel);
+
+      await waitFor(() =>
+        expect(driveCard.getByRole("button", { name: "Browse in Drive" })).toBeEnabled(),
+      );
+      expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+    });
+
+    it("keeps a failed pick on screen, where it can be read and retried", async () => {
+      configurePicker();
+      mockPickDriveFolder.mockRejectedValue(new Error("Google sign-in did not finish. Try again."));
+      const { toast } = await import("sonner");
+      vi.mocked(toast.error).mockClear();
+      const user = userEvent.setup();
+
+      const driveCard = await renderConnected();
+      await user.click(driveCard.getByRole("button", { name: "Browse in Drive" }));
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(/google sign-in did not finish/i);
+      // A toast would take the one instruction away after a few seconds.
+      expect(toast.error).not.toHaveBeenCalled();
     });
   });
 

--- a/src/routes/_authenticated/account.tsx
+++ b/src/routes/_authenticated/account.tsx
@@ -914,6 +914,18 @@ function CodeOfConductCard() {
   );
 }
 
+/**
+ * The two build-time values Google Picker needs, or null when either is
+ * missing. Read here rather than inside `@/lib/google-picker` so the picker
+ * module (and Google's scripts with it) stay lazily loaded until the manager
+ * actually browses.
+ */
+function googlePickerConfig(): { clientId: string; developerKey: string } | null {
+  const clientId = import.meta.env.VITE_GOOGLE_OAUTH_CLIENT_ID as string | undefined;
+  const developerKey = import.meta.env.VITE_GOOGLE_PICKER_API_KEY as string | undefined;
+  return clientId && developerKey ? { clientId, developerKey } : null;
+}
+
 function GoogleDriveCard() {
   const status = useServerFn(getGoogleDriveStatus);
   const start = useServerFn(startGoogleDriveConnect);
@@ -930,6 +942,13 @@ function GoogleDriveCard() {
   const [folderNameInput, setFolderNameInput] = useState("");
   const [folderBusy, setFolderBusy] = useState(false);
   const [pickerBusy, setPickerBusy] = useState(false);
+  const [folderError, setFolderError] = useState<string | null>(null);
+
+  // Google Picker needs both halves of the same Cloud project: the OAuth client
+  // the connector runs on, and a browser API key with the Picker API enabled.
+  // With the key missing the picker opens, browses, and then silently refuses
+  // to hand a folder back, so offer typing a name rather than that dead end.
+  const picker = googlePickerConfig();
 
   const refresh = () =>
     status()
@@ -996,34 +1015,32 @@ function GoogleDriveCard() {
     const folderName = folderNameInput.trim();
     if (!folderName) return;
     setFolderBusy(true);
+    setFolderError(null);
     try {
       const result = await setFolder({ data: { folderName } });
       setSavedFolderName(result.folderName);
       toast.success(`Waivers will save to "${result.folderName}"`);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to set the Drive folder");
+      setFolderError(e instanceof Error ? e.message : "Failed to set the Drive folder");
     } finally {
       setFolderBusy(false);
     }
   }
 
   async function onBrowseFolder() {
-    const clientId = import.meta.env.VITE_GOOGLE_OAUTH_CLIENT_ID as string | undefined;
-    if (!clientId) {
-      toast.error("Browsing isn't set up yet. Type the folder name instead.");
-      return;
-    }
+    if (!picker) return;
     setPickerBusy(true);
+    setFolderError(null);
     try {
       const { pickDriveFolder } = await import("@/lib/google-picker");
-      const picked = await pickDriveFolder(clientId);
+      const picked = await pickDriveFolder({ ...picker, connectedEmail: email });
       if (!picked) return;
       const result = await saveFolderFromPicker({ data: { folderId: picked.id } });
       setSavedFolderName(result.folderName);
       setFolderNameInput(result.folderName);
       toast.success(`Waivers will save to "${result.folderName}"`);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to pick a folder");
+      setFolderError(e instanceof Error ? e.message : "Failed to pick a folder");
     } finally {
       setPickerBusy(false);
     }
@@ -1071,20 +1088,33 @@ function GoogleDriveCard() {
                 <Button type="submit" variant="outline" size="sm" disabled={folderBusy}>
                   {folderBusy ? "Saving..." : savedFolderName ? "Update folder" : "Save folder"}
                 </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={onBrowseFolder}
-                  disabled={pickerBusy}
-                >
-                  {pickerBusy ? "Opening..." : "Browse in Drive"}
-                </Button>
+                {picker ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={onBrowseFolder}
+                    disabled={pickerBusy}
+                  >
+                    {pickerBusy ? "Opening..." : "Browse in Drive"}
+                  </Button>
+                ) : null}
               </div>
+              {folderError ? (
+                <p role="alert" className="text-sm text-destructive">
+                  {folderError}
+                </p>
+              ) : null}
               <p className="text-xs text-muted-foreground">
                 {savedFolderName
-                  ? `Waivers save to "${savedFolderName}". Browsing lets you pick any folder you have access to, including one in a shared drive; typing a name will only find one this app made before (a folder you made yourself in Drive with the same name won't be found).`
-                  : "Browse to pick any folder you have access to, including one in a shared drive, or type a name and we'll create it in your own Drive (a folder you made yourself with the same name won't be found by typing)."}
+                  ? `Waivers save to "${savedFolderName}". `
+                  : "Waivers do not save to Drive until you set a folder. "}
+                {picker
+                  ? "Browsing lets you pick any folder you have access to, including one in a shared drive. In the Google window, click a folder once to highlight it and then press Select: opening a folder does not choose it. "
+                  : "Folder browsing is not set up on this site yet, so type a name for now. "}
+                {savedFolderName
+                  ? "Typing a name only finds a folder this app made before, so a folder you made yourself in Drive with the same name will not be found."
+                  : "Typing a name creates that folder in your own Drive, and only finds an existing one this app made before."}
               </p>
             </form>
           </div>

--- a/src/routes/_authenticated/account.tsx
+++ b/src/routes/_authenticated/account.tsx
@@ -954,12 +954,16 @@ function GoogleDriveCard() {
   const [folderBusy, setFolderBusy] = useState(false);
   const [pickerBusy, setPickerBusy] = useState(false);
   const [folderError, setFolderError] = useState<string | null>(null);
+  // Set while Google's dialog is on screen. Everything in that dialog is
+  // Google's and it only talks back on a pick or a cancel, so this is the
+  // manager's own way out if it refuses the pick or shows its own error.
+  const [abandonPicker, setAbandonPicker] = useState<(() => void) | null>(null);
 
   // Google Picker needs both halves of the same Cloud project: the OAuth client
   // the connector runs on, and a browser API key with the Picker API enabled.
-  // With the key missing the picker opens, browses, and then silently refuses
-  // to hand a folder back, so offer typing a name rather than that dead end.
-  const picker = googlePickerConfig();
+  // Without the key the picker is expected to browse and then refuse to hand a
+  // folder back, so the button is disabled rather than left as a dead end.
+  const picker = useMemo(googlePickerConfig, []);
 
   const refresh = () =>
     status()
@@ -981,6 +985,14 @@ function GoogleDriveCard() {
     refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Fetch Google's scripts now, while nobody is waiting. Downloading them
+  // inside the Browse click spends its transient activation, and the browser
+  // then blocks the sign-in popup as unsolicited.
+  useEffect(() => {
+    if (!picker || !connected) return;
+    void import("@/lib/google-picker").then((m) => m.preloadGooglePicker()).catch(() => {});
+  }, [picker, connected]);
 
   async function onConnect() {
     setBusy(true);
@@ -1044,7 +1056,11 @@ function GoogleDriveCard() {
     setFolderError(null);
     try {
       const { pickDriveFolder } = await import("@/lib/google-picker");
-      const picked = await pickDriveFolder({ ...picker, connectedEmail: email });
+      const picked = await pickDriveFolder({
+        ...picker,
+        connectedEmail: email,
+        onOpen: (close) => setAbandonPicker(() => close),
+      });
       if (!picked) return;
       const result = await saveFolderFromPicker({ data: { folderId: picked.id } });
       setSavedFolderName(result.folderName);
@@ -1054,6 +1070,7 @@ function GoogleDriveCard() {
       setFolderError(e instanceof Error ? e.message : "Failed to pick a folder");
     } finally {
       setPickerBusy(false);
+      setAbandonPicker(null);
     }
   }
 
@@ -1099,15 +1116,18 @@ function GoogleDriveCard() {
                 <Button type="submit" variant="outline" size="sm" disabled={folderBusy}>
                   {folderBusy ? "Saving..." : savedFolderName ? "Update folder" : "Save folder"}
                 </Button>
-                {picker ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={onBrowseFolder}
-                    disabled={pickerBusy}
-                  >
-                    {pickerBusy ? "Opening..." : "Browse in Drive"}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={onBrowseFolder}
+                  disabled={pickerBusy || !picker}
+                >
+                  {pickerBusy ? "Opening..." : "Browse in Drive"}
+                </Button>
+                {abandonPicker ? (
+                  <Button type="button" variant="ghost" size="sm" onClick={abandonPicker}>
+                    Cancel
                   </Button>
                 ) : null}
               </div>
@@ -1122,7 +1142,7 @@ function GoogleDriveCard() {
                   : "Waivers do not save to Drive until you set a folder. "}
                 {picker
                   ? "Browsing lets you pick any folder you have access to, including one in a shared drive. In the Google window, click a folder once to highlight it and then press Select: opening a folder does not choose it. "
-                  : "Folder browsing is not set up on this site yet, so type a name for now. "}
+                  : "Browsing is off until this site has its Google Picker key, so type a name for now. "}
                 {savedFolderName
                   ? "Typing a name only finds a folder this app made before, so a folder you made yourself in Drive with the same name will not be found."
                   : "Typing a name creates that folder in your own Drive, and only finds an existing one this app made before."}


### PR DESCRIPTION
## What was wrong

On `/account`, "Browse in Drive" opened Google's folder picker, browsed fine (shared drives included), and then did nothing: highlighting a folder and pressing **Select** greyed the button out and left the dialog sitting there. No folder was ever saved and nothing said why.

The picker was built without a **browser API key**. Google documents the builder as taking a view, an OAuth token, a developer key and a callback, and a missing key is the leading explanation for exactly this: browsing works on the token alone, and the pick is refused on a path that never reaches the callback.

Being straight about confidence: I could not verify that from Google's own docs (`developers.google.com` is unreachable from the sandbox this was written in), and two other misconfigurations fail identically because none of them reach the callback either: the **Picker API not being enabled**, and the **API key's own restrictions** refusing the call. Google reports which one it is in the browser console; `docs/google-drive.md` has the table.

The "Sign in to your Google Account" screen at the start is not a symptom: Google requires a signed-in session to use the picker with the `drive.file` scope.

## What you need to do in the Google Cloud console

Nothing in this PR works until this is done, in the project that owns the OAuth client. Full click-path in `docs/google-drive.md`; the short version:

1. **Enable the Google Picker API** and confirm the **Google Drive API** is on. They are separate, and a disabled Picker API fails exactly like a missing key.
2. **Create a browser API key.** Restrict it by website (`https://jitsu.au/*`, `https://*.jitsu.au/*`) and, under API restrictions, tick **both** Picker and Drive. Ticking Picker alone can starve the same call, with an identical symptom. To prove the key first, leave it unrestricted for one test and tighten after.
3. **Check the OAuth client** has `https://jitsu.au` under Authorised JavaScript origins. It already does if the picker has ever opened for you.
4. **Check the consent screen is published** (see the warning below).
5. **Add `VITE_GOOGLE_PICKER_API_KEY`** in Lovable project settings, then **rebuild and redeploy** — it is inlined at build time, so saving the setting alone changes nothing and the button stays greyed out.

> [!WARNING]
> **If the consent screen is still in Testing, publish it.** In Testing, every authorisation expires after 7 days, including the connector's stored refresh token. The club's Drive connection dies roughly weekly and waivers quietly stop arriving, with nothing on screen to say so. This is unrelated to the picker bug and worth checking regardless of this PR.

Two other things to know: OAuth JavaScript origins take no wildcards, so **browsing cannot work on a Lovable preview URL** — test on the live site. And a missing origin is not this bug: sign-in fails with `origin_mismatch` and the folder window never opens at all.

## What changes for the manager

- **Selecting a folder works**, once the key is in. Until then "Browse in Drive" is **disabled**, and the card says browsing is off until the site has its key and to type a folder name for now. Typing a name is unaffected.
- **Nobody gets stranded in Google's window.** It only talks back on a pick or a cancel, so if it refuses the pick there is now a **Cancel** button on our own page for as long as that dialog is up. Before, the button sat on "Opening..." until the page was reloaded, which is the reported symptom.
- **The card explains Google's picker**: click a folder once to highlight it, then press Select. Opening a folder leaves Select greyed out, because Picker has no "choose the folder I'm in". That was the second half of the confusion, and it is Picker behaviour we cannot change.
- **Picking as the wrong Google account is caught up front**, by name: "Google signed you in as X, but this site's Drive is connected as Y."
- **Folder errors stay on screen** as an alert next to the field instead of a toast, and Google's bare codes (`access_denied`, `popup_closed`) are turned into sentences with a next step.
- **The sign-in pop-up is less likely to be blocked**: Google's scripts are fetched when the card mounts, so the pop-up opens inside the click rather than a network round trip later.

## Also fixed on the way

- **The picker's token is no longer revoked** after a pick. Revoking an access token revokes the whole grant for that (account, OAuth client) pair, which would tear up the per-file access the pick just recorded and could take the connector's refresh token with it. Note this could not have caused the reported symptom (the revoke ran inside the callback that never fired) — but if any pick ever did complete under the old code, that manager's Drive connection may have been revoked underneath them and needs reconnecting.
- `initTokenClient` had no `error_callback`, so a closed or blocked sign-in window left the browse hanging. The account check is now bounded by an abort signal for the same reason.
- The login hint is sent as `login_hint`; `hint` is deprecated.

## Notes for review

- `drive.file` records access per (Google account, OAuth client, file), which is why identity is so fussy here and why the picker is the only way to reach a folder the site did not create itself. `docs/google-drive.md` is new and owns this flow.
- **One unverifiable assumption, now written down**: that `VITE_GOOGLE_OAUTH_CLIENT_ID` is the same Google client the Lovable connector runs on. Nothing in the repo can check it (the gateway is handed only the connector API key), and if the two diverge every pick fails server-side as an unreadable folder. That is the thing to watch for once Select starts working.
- Tests cover the builder wiring, the login hint, the account-mismatch refusal, both directions of the button-enabled rule, the card passing the key and connected account to the picker, the Cancel affordance, and the failed pick staying on screen. What they cannot cover is Google accepting the pick.
- Lint, typecheck, the full suite (1829 tests / 99 files) and the build are green. `bun.lock` untouched.
- `main` was merged in after the membership and password work landed; the only conflict was two unrelated `describe` blocks added at the same point in `account.test.tsx`, and both are kept.
