### PR TITLE
Drop Agent access button from Memberships, let the row wrap

### DIFF
--- a/src/routes/_authenticated/manager.memberships.tsx
+++ b/src/routes/_authenticated/manager.memberships.tsx
@@ -71,7 +71,7 @@ function ManagerMembershipsPage() {
               Activate paid memberships once payment lands, or reconcile a bank statement.
             </p>
           </div>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <Button asChild variant="outline">
               <Link to="/manager/users">Users</Link>
             </Button>
@@ -83,9 +83,6 @@ function ManagerMembershipsPage() {
             </Button>
             <Button asChild variant="outline">
               <Link to="/manager/settings">Settings</Link>
-            </Button>
-            <Button asChild variant="outline">
-              <Link to="/manager/api-tokens">Agent access</Link>
             </Button>
             <Button asChild variant="outline">
               <Link to="/account">Back to account</Link>


### PR DESCRIPTION
## What changes for the manager

On `/manager/memberships`, the row of navigation buttons at the top now wraps onto a second line instead of running off the side of the screen on a phone. The "Agent access" button is gone from that row; agent access is still one tap away from the member-area sidebar, where it already lives.

Nothing else on the page changes: the memberships table, activation and the reconciliation flow are untouched, and no member-facing screen is affected.

## What it looked like before

Six buttons (Users, Reconcile bank statement, Membership plans, Settings, Agent access, Back to account) sat in a single non-wrapping flex row, so at ~375px the last ones were pushed out of view.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (1594 passing) and `bun run build` all pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7DpNwvRbMnNS1YkByoBUG)_