### PR TITLE
Passwords: state the rules on screen, and make them rules worth stating

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,11 @@ exist` error is the more serious cousin: the migration never reached the live
 ## Auth & roles
 
 - Auth is Supabase email/password + magic link; the auth UI is `routes/auth.tsx`.
+- **Password rules live in `src/lib/password-policy.ts`, and only there.** They
+  follow NIST SP 800-63B-4: 15 characters minimum, no composition rules at all,
+  and a breached-password check (Have I Been Pwned as you type, Supabase's own
+  check server side). Every rule is stated on screen before anything is typed,
+  by `components/site/NewPasswordField`. Full spec: `docs/passwords.md`.
 - `_authenticated/route.tsx` gates the group: `ssr: false`, redirects to
   `/auth?redirect=...` when there is no user.
 - Roles come from the `user_roles` table and the `app_role` enum

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -60,8 +60,14 @@ who has met them. Neither asks for a kind of character, so neither is a
 composition rule.
 
 "Built out of" is the load-bearing phrase in the third one, and it is why the
-check is a **share** and not a substring match. A word has to account for at
-least a third of the password's letters and digits before it counts. Plain
+check is a **share** and not a substring match. Those words, taken together,
+have to account for at least a third of the password's letters and digits
+before it counts. Together, not one at a time: measured separately, "alexander"
+and "dominguez" are each only 9 of the 29 letters in "alexander dominguez
+kettle drill", so a password that is nothing but somebody's own name would pass
+a rule whose whole job is to stop it. Overlaps are counted once (an email local
+part contains the first name, "utsjitsu" contains "jitsu"), or the same letters
+would be counted three times and honest passphrases would start failing. Plain
 substring matching is too blunt to use on its own: "Hill", "Rose", "Dean" and
 "Bell" are surnames and also ordinary words, and flattening the punctuation out
 before comparing (which is necessary, or `J.i.t.s.u` walks straight through)
@@ -116,13 +122,22 @@ failed without telling you the rule. `describePasswordError()` rewrites it, and
 the two screens show it in an alert next to the rules rather than a toast.
 
 > [!IMPORTANT]
-> The 15-character minimum is currently enforced **in the browser only**. The
-> server-side floor is Supabase's `password_min_length`, which is project
-> configuration in the Supabase dashboard (Authentication → Sign In / Providers)
-> and cannot be set from this repo. To make the rule real rather than advertised,
-> set it to **15**, leave "leaked password protection" **on**, and leave the
-> required-characters setting **off**. Until then the client rules are a strong
-> default that a determined person could bypass with a direct API call.
+> **Only one of the four rules has real teeth.** The breach check is enforced by
+> Supabase and cannot be talked out of. The other three are browser-side, and a
+> `supabase.auth.updateUser()` call from the devtools console skips all of them.
+>
+> The length rule can be given teeth, and should be: Supabase's
+> `password_min_length` is project configuration in the dashboard
+> (Authentication → Sign In / Providers) and cannot be set from this repo. Set it
+> to **15**, leave "leaked password protection" **on**, and leave the
+> required-characters setting **off**.
+>
+> The variety and personal-word rules cannot. They are ours, Supabase has no
+> equivalent setting, and there is no server-side hook here to add one to, so
+> they are permanently advisory. That is an accepted trade rather than an
+> oversight: their job is to stop somebody talking themselves into a bad
+> password, not to stop somebody attacking their own account, and the person
+> bypassing them is the only person they protect.
 
 ## Where it appears
 

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -13,17 +13,25 @@ real standard without shutting anybody out.
 
 Stated in full, on screen, next to the field, before anything is typed:
 
-| Rule                                                     | Where it comes from                             |
-| -------------------------------------------------------- | ----------------------------------------------- |
-| At least **15 characters**                               | NIST SP 800-63B-4 §3.1.1.2, single factor       |
-| Not one character or short pattern repeated              | ours, see below                                 |
-| Nothing from your name, your email, or the club's name   | ours, see below                                 |
-| Not one of the passwords found in public data breaches   | NIST SP 800-63B-4, OWASP; via Have I Been Pwned |
-| No more than **72 characters** (a ceiling, not a demand) | bcrypt, via Supabase                            |
+| Rule                                                       | Where it comes from                             |
+| ---------------------------------------------------------- | ----------------------------------------------- |
+| At least **15 characters**                                 | NIST SP 800-63B-4 §3.1.1.2, single factor       |
+| Not one character or short pattern repeated                | ours, see below                                 |
+| Not built out of your name, your email, or the club's name | ours, see below                                 |
+| Not one of the passwords found in public data breaches     | NIST SP 800-63B-4, OWASP; via Have I Been Pwned |
+| No longer than **72 characters**                           | bcrypt, via Supabase                            |
 
 And, just as deliberately, what is **not** asked for: no uppercase, no digit, no
 symbol, no character classes of any kind. Every character is allowed, spaces and
 emoji included.
+
+The first four are on screen from the moment the field appears. The ceiling is
+the exception: it only joins the list once it has been broken, because it is a
+limit nobody approaches and a rule sitting green from the first keystroke to the
+last is noise in a list meant to be read. It has to appear then, though. A list
+showing all green next to a form that refuses to submit is the exact mismatch
+this change exists to remove, so **every rule that can stop the button is a rule
+on the list**.
 
 ## Why these and not "one number, one capital"
 
@@ -46,15 +54,30 @@ The two things that actually decide whether a password survives are:
    catches that, and a breach check catches nothing else.
 
 The two middle rules are ours, and each closes a way to satisfy rule 1 without
-gaining anything from it: `aaaaaaaaaaaaaaa` is fifteen characters of one
-guess, and a password containing the member's own surname or "jitsu" is
-guessable by anyone who has met them. Neither asks for a kind of character, so
-neither is a composition rule.
+gaining anything from it: `aaaaaaaaaaaaaaa` is fifteen characters of one guess,
+and a password that is mostly the member's own surname is guessable by anyone
+who has met them. Neither asks for a kind of character, so neither is a
+composition rule.
+
+"Built out of" is the load-bearing phrase in the third one, and it is why the
+check is a **share** and not a substring match. A word has to account for at
+least a third of the password's letters and digits before it counts. Plain
+substring matching is too blunt to use on its own: "Hill", "Rose", "Dean" and
+"Bell" are surnames and also ordinary words, and flattening the punctuation out
+before comparing (which is necessary, or `J.i.t.s.u` walks straight through)
+creates joins nobody typed, so "flash escape" contains "ashe". Rejecting a
+strong passphrase with "leave out your name" is how a rule set loses the person
+reading it. At fifteen characters minimum, a four or five letter surname cannot
+reach a third by accident, while a password that really is somebody's name with
+decoration on it is well past it.
 
 The 72 is not a policy at all. bcrypt, which Supabase hashes with, ignores
 everything past byte 72, so a longer passphrase would be silently truncated to
 something shorter than the person believes they set. It is counted in **bytes**,
-so accented or non-Latin characters use it up faster than ASCII.
+so accented or non-Latin characters use it up faster than ASCII. When the byte
+count and the character count disagree, the wording changes with it: telling
+somebody holding thirty Japanese characters that the limit is 72 characters
+reads as a broken form, so in that case the message says why instead.
 
 ## Where each half is enforced
 
@@ -63,17 +86,26 @@ variety, and the personal/club words. `passwordProblem()` is what a form calls
 before submitting, so somebody hears about a fixable problem without waiting for
 a round trip.
 
-**In the browser, advisory** (`src/lib/pwned-passwords.ts`): the breach lookup,
-run about half a second after typing stops, against Have I Been Pwned's range
-API. That API is a k-anonymity scheme: the password is SHA-1'd, only the first
-five hex characters of the hash are sent, and the several hundred matching
-suffixes are compared here on the device. The password never leaves the browser
-and neither does its full hash. The request carries `Add-Padding: true` so the
-response size does not leak which prefix was asked for.
+**In the browser** (`src/lib/pwned-passwords.ts`): the breach lookup, run about
+half a second after typing stops, against Have I Been Pwned's range API. That
+API is a k-anonymity scheme: the password is SHA-1'd, only the first five hex
+characters of the hash are sent, and the several hundred matching suffixes are
+compared here on the device. The password never leaves the browser and neither
+does its full hash. The request carries `Add-Padding: true` so the response size
+does not leak which prefix was asked for.
 
-Every failure of that lookup returns `unknown`, which reads as "carry on":
-`passwordProblem()` never consults it, and the rule shows as met. Nobody should
-be unable to set a password because a third party is down.
+That header is **best effort**. It is not CORS-safelisted, so sending it turns
+every lookup into a preflight, and a refused preflight fails the request rather
+than degrading. One failure and the header is dropped for the rest of the
+session and the plain request is used instead. Losing the padding costs a
+privacy property; losing the check would cost the check, silently, with the rule
+sitting green forever.
+
+A lookup that says **breached** does stop the form, because a red cross on
+screen has to mean the button will not work. Everything else lets it through:
+`checking`, and the `unknown` that every failure path produces. Nobody should be
+unable to set a password because a third party is down, and Supabase checks the
+same thing again anyway.
 
 **On the server** (Supabase Auth): the breach check again, and this one is the
 authority. Supabase's leaked-password protection queries the same corpus when
@@ -100,6 +132,13 @@ rules, and their live state:
 
 - `/update-password`, reached from the emailed reset link.
 - `/account`, the "Change password" card under Sign-in.
+
+Both feed the same things into the rules: the person's email and the name parts
+on their profile. `/update-password` has to fetch the profile to do it, because
+a recovery session carries only the address, and it does so in the background
+without holding up the form. If that fetch fails the check falls back to the
+email alone. The reason it bothers is that the field is showing a rule that
+mentions your name, and a screen should not list a rule it is not applying.
 
 `/auth` sign-in is deliberately untouched. It checks nothing: an existing member
 holding an older, shorter password keeps signing in with it, because these rules

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -1,0 +1,124 @@
+# Passwords
+
+What the club asks for when somebody sets a password, why those rules and not
+the usual ones, and where each half is enforced.
+
+Passwords are the secondary way into this site. The primary one is the emailed
+sign-in link on `/auth`, which needs no password at all, and there is no
+self-serve sign-up: an account exists because a manager approved a waiver. So a
+password here is a convenience for people who want one, and it can be held to a
+real standard without shutting anybody out.
+
+## The rules
+
+Stated in full, on screen, next to the field, before anything is typed:
+
+| Rule                                                     | Where it comes from                             |
+| -------------------------------------------------------- | ----------------------------------------------- |
+| At least **15 characters**                               | NIST SP 800-63B-4 §3.1.1.2, single factor       |
+| Not one character or short pattern repeated              | ours, see below                                 |
+| Nothing from your name, your email, or the club's name   | ours, see below                                 |
+| Not one of the passwords found in public data breaches   | NIST SP 800-63B-4, OWASP; via Have I Been Pwned |
+| No more than **72 characters** (a ceiling, not a demand) | bcrypt, via Supabase                            |
+
+And, just as deliberately, what is **not** asked for: no uppercase, no digit, no
+symbol, no character classes of any kind. Every character is allowed, spaces and
+emoji included.
+
+## Why these and not "one number, one capital"
+
+NIST SP 800-63B-4 (August 2025) and the OWASP Authentication Cheat Sheet both
+now say composition rules must not be imposed. They are not neutral-but-dated,
+they are actively harmful: told to add a capital, a digit and a symbol, people
+produce `Password1!`, `Summer2026!`, `Jitsu@123`. Those are not rare passwords,
+they are the most common shape in every credential-stuffing list, and an
+eight-character one with all four character classes has less guessing resistance
+than four ordinary words.
+
+The two things that actually decide whether a password survives are:
+
+1. **How long it is.** NIST requires 15 characters where the password is the
+   only factor. That is our case: this site has no second factor, and the
+   alternative to a password here is the emailed link, not an authenticator app.
+   Eight characters is only permitted when a second factor backs it up.
+2. **Whether it has already leaked.** Nearly every real account takeover starts
+   with a password lifted from someone else's breach. No composition rule
+   catches that, and a breach check catches nothing else.
+
+The two middle rules are ours, and each closes a way to satisfy rule 1 without
+gaining anything from it: `aaaaaaaaaaaaaaa` is fifteen characters of one
+guess, and a password containing the member's own surname or "jitsu" is
+guessable by anyone who has met them. Neither asks for a kind of character, so
+neither is a composition rule.
+
+The 72 is not a policy at all. bcrypt, which Supabase hashes with, ignores
+everything past byte 72, so a longer passphrase would be silently truncated to
+something shorter than the person believes they set. It is counted in **bytes**,
+so accented or non-Latin characters use it up faster than ASCII.
+
+## Where each half is enforced
+
+**In the browser** (`src/lib/password-policy.ts`, pure and unit tested): length,
+variety, and the personal/club words. `passwordProblem()` is what a form calls
+before submitting, so somebody hears about a fixable problem without waiting for
+a round trip.
+
+**In the browser, advisory** (`src/lib/pwned-passwords.ts`): the breach lookup,
+run about half a second after typing stops, against Have I Been Pwned's range
+API. That API is a k-anonymity scheme: the password is SHA-1'd, only the first
+five hex characters of the hash are sent, and the several hundred matching
+suffixes are compared here on the device. The password never leaves the browser
+and neither does its full hash. The request carries `Add-Padding: true` so the
+response size does not leak which prefix was asked for.
+
+Every failure of that lookup returns `unknown`, which reads as "carry on":
+`passwordProblem()` never consults it, and the rule shows as met. Nobody should
+be unable to set a password because a third party is down.
+
+**On the server** (Supabase Auth): the breach check again, and this one is the
+authority. Supabase's leaked-password protection queries the same corpus when
+the password is saved, and refuses with `weak_password`. Its message,
+`"Password is known to be weak and easy to guess, please choose a different
+one."`, is the one this whole module is a reaction to: it tells you that you
+failed without telling you the rule. `describePasswordError()` rewrites it, and
+the two screens show it in an alert next to the rules rather than a toast.
+
+> [!IMPORTANT]
+> The 15-character minimum is currently enforced **in the browser only**. The
+> server-side floor is Supabase's `password_min_length`, which is project
+> configuration in the Supabase dashboard (Authentication → Sign In / Providers)
+> and cannot be set from this repo. To make the rule real rather than advertised,
+> set it to **15**, leave "leaked password protection" **on**, and leave the
+> required-characters setting **off**. Until then the client rules are a strong
+> default that a determined person could bypass with a direct API call.
+
+## Where it appears
+
+Both screens that set a password use `NewPasswordField`
+(`src/components/site/NewPasswordField.tsx`), which renders the input, the
+rules, and their live state:
+
+- `/update-password`, reached from the emailed reset link.
+- `/account`, the "Change password" card under Sign-in.
+
+`/auth` sign-in is deliberately untouched. It checks nothing: an existing member
+holding an older, shorter password keeps signing in with it, because these rules
+apply when a password is **set**, never when one is used. Nobody is locked out
+by this change, and nobody is asked to rotate. (NIST also says not to force
+periodic rotation, and the club does not.)
+
+## Changing the rules
+
+`src/lib/password-policy.ts` is the only place the rules exist. The labels in
+that file are the copy shown on screen, so a rule cannot change without its
+wording changing with it, and `password-policy.test.ts` pins each one. If you
+add a rule, it needs a label a member can read and act on. A rule the form will
+not state is a rule the form should not have.
+
+## Sources
+
+- NIST SP 800-63B-4, _Digital Identity Guidelines: Authentication and
+  Authenticator Management_ (August 2025), §3.1.1
+- OWASP Cheat Sheet Series, _Authentication Cheat Sheet_, password length and
+  complexity
+- Have I Been Pwned, Pwned Passwords range API (k-anonymity, `Add-Padding`)

--- a/src/components/site/NewPasswordField.test.tsx
+++ b/src/components/site/NewPasswordField.test.tsx
@@ -4,12 +4,19 @@ import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { NewPasswordField } from "./NewPasswordField";
+import type { BreachStatus } from "@/lib/password-policy";
 
 const lookupBreachedPassword = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/pwned-passwords", () => ({ lookupBreachedPassword }));
 
 /** The field is controlled, so tests drive it through a small host. */
-function Host({ personal }: { personal?: (string | null | undefined)[] }) {
+function Host({
+  personal,
+  onBreachChange,
+}: {
+  personal?: (string | null | undefined)[];
+  onBreachChange?: (status: BreachStatus) => void;
+}) {
   const [value, setValue] = useState("");
   return (
     <NewPasswordField
@@ -18,6 +25,7 @@ function Host({ personal }: { personal?: (string | null | undefined)[] }) {
       value={value}
       onChange={setValue}
       personal={personal}
+      onBreachChange={onBreachChange}
     />
   );
 }
@@ -42,7 +50,7 @@ describe("NewPasswordField", () => {
     render(<Host />);
     expect(rule(/At least 15 characters/)).toBeInTheDocument();
     expect(rule(/Not one character or short pattern repeated/)).toBeInTheDocument();
-    expect(rule(/Nothing from your name, your email, or the club's name/)).toBeInTheDocument();
+    expect(rule(/Not built out of your name, your email, or the club's name/)).toBeInTheDocument();
     expect(rule(/public data breaches/)).toBeInTheDocument();
   });
 
@@ -78,7 +86,7 @@ describe("NewPasswordField", () => {
   it("marks a password built from the person's email unmet", async () => {
     render(<Host personal={["samrivers@example.com"]} />);
     await userEvent.type(screen.getByLabelText("New password"), "samrivers is my name");
-    expect(stateOf(/Nothing from your name/)).toContain("not met yet");
+    expect(stateOf(/Not built out of your name/)).toContain("not met yet");
   });
 
   it("does not spend a breach lookup on a password that fails the basics", async () => {
@@ -123,6 +131,25 @@ describe("NewPasswordField", () => {
     render(<Host />);
     await userEvent.type(screen.getByLabelText("New password"), "otter kettle marina");
     await waitFor(() => expect(stateOf(/public data breaches/)).toContain(", met"));
+  });
+
+  it("tells the form what the breach lookup found, so it can refuse to submit", async () => {
+    lookupBreachedPassword.mockResolvedValue("breached");
+    const seen: BreachStatus[] = [];
+    render(<Host onBreachChange={(status) => seen.push(status)} />);
+    await userEvent.type(screen.getByLabelText("New password"), "otter kettle marina");
+    await waitFor(() => expect(seen).toContain("breached"));
+  });
+
+  it("shows the length ceiling only once it has been broken", async () => {
+    render(<Host />);
+    expect(screen.queryByText(/No longer than 72 characters/)).not.toBeInTheDocument();
+    // Pasted rather than typed: nobody reaches 73 characters a keystroke at a
+    // time, and `userEvent.type` of that length is slow.
+    await userEvent.click(screen.getByLabelText("New password"));
+    await userEvent.paste("a b c d e f g h i j ".repeat(4));
+    expect(screen.getByText(/No longer than 72 characters/)).toBeInTheDocument();
+    expect(stateOf(/No longer than 72 characters/)).toContain("not met yet");
   });
 
   it("announces progress through the rules", async () => {

--- a/src/components/site/NewPasswordField.test.tsx
+++ b/src/components/site/NewPasswordField.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NewPasswordField } from "./NewPasswordField";
+
+const lookupBreachedPassword = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/pwned-passwords", () => ({ lookupBreachedPassword }));
+
+/** The field is controlled, so tests drive it through a small host. */
+function Host({ personal }: { personal?: (string | null | undefined)[] }) {
+  const [value, setValue] = useState("");
+  return (
+    <NewPasswordField
+      id="pw"
+      label="New password"
+      value={value}
+      onChange={setValue}
+      personal={personal}
+    />
+  );
+}
+
+function rule(text: RegExp) {
+  return screen.getByText(text);
+}
+
+/** The `, met` / `, not met yet` suffix the field adds for screen readers. */
+function stateOf(label: string | RegExp): string {
+  const item = screen.getByText(label).closest("li");
+  return item?.textContent ?? "";
+}
+
+beforeEach(() => {
+  lookupBreachedPassword.mockReset();
+  lookupBreachedPassword.mockResolvedValue("safe");
+});
+
+describe("NewPasswordField", () => {
+  it("states every rule before anything is typed", () => {
+    render(<Host />);
+    expect(rule(/At least 15 characters/)).toBeInTheDocument();
+    expect(rule(/Not one character or short pattern repeated/)).toBeInTheDocument();
+    expect(rule(/Nothing from your name, your email, or the club's name/)).toBeInTheDocument();
+    expect(rule(/public data breaches/)).toBeInTheDocument();
+  });
+
+  it("does not mark anything failed while the field is empty", () => {
+    render(<Host />);
+    expect(stateOf(/At least 15 characters/)).not.toContain("not met yet");
+  });
+
+  it("describes the field's rules to a screen reader", () => {
+    render(<Host />);
+    const field = screen.getByLabelText("New password");
+    expect(field.getAttribute("aria-describedby")).toContain("pw-rules");
+    expect(document.getElementById("pw-rules")).toBeInTheDocument();
+  });
+
+  it("asks the browser not to offer a saved password for a new one", () => {
+    render(<Host />);
+    expect(screen.getByLabelText("New password")).toHaveAttribute("autocomplete", "new-password");
+  });
+
+  it("marks the length rule unmet while the password is short", async () => {
+    render(<Host />);
+    await userEvent.type(screen.getByLabelText("New password"), "short");
+    expect(stateOf(/At least 15 characters/)).toContain("not met yet");
+  });
+
+  it("ticks the length rule off once it is long enough", async () => {
+    render(<Host />);
+    await userEvent.type(screen.getByLabelText("New password"), "otter kettle marina");
+    expect(stateOf(/At least 15 characters/)).toContain(", met");
+  });
+
+  it("marks a password built from the person's email unmet", async () => {
+    render(<Host personal={["samrivers@example.com"]} />);
+    await userEvent.type(screen.getByLabelText("New password"), "samrivers is my name");
+    expect(stateOf(/Nothing from your name/)).toContain("not met yet");
+  });
+
+  it("does not spend a breach lookup on a password that fails the basics", async () => {
+    render(<Host />);
+    await userEvent.type(screen.getByLabelText("New password"), "aaaaaaaaaaaaaaaaaa");
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    expect(lookupBreachedPassword).not.toHaveBeenCalled();
+  });
+
+  it("does not claim to be checking a password it has not asked about", async () => {
+    // The breach rule is unanswered either way, but only one of those two is
+    // work in progress. Saying "checking" about a password too short to have
+    // been sent anywhere is a spinner that never stops.
+    render(<Host />);
+    await userEvent.type(screen.getByLabelText("New password"), "short");
+    expect(stateOf(/public data breaches/)).not.toContain("checking");
+    expect(stateOf(/public data breaches/)).not.toContain("not met yet");
+  });
+
+  it("says it is checking while a lookup is actually in flight", async () => {
+    lookupBreachedPassword.mockReturnValue(new Promise(() => {}));
+    render(<Host />);
+    await userEvent.type(screen.getByLabelText("New password"), "otter kettle marina");
+    await waitFor(() => expect(stateOf(/public data breaches/)).toContain("checking"));
+  });
+
+  it("reports a leaked password as a failed rule", async () => {
+    lookupBreachedPassword.mockResolvedValue("breached");
+    render(<Host />);
+    await userEvent.type(screen.getByLabelText("New password"), "otter kettle marina");
+    await waitFor(() => expect(stateOf(/public data breaches/)).toContain("not met yet"));
+  });
+
+  it("ticks the breach rule off when the lookup comes back clear", async () => {
+    render(<Host />);
+    await userEvent.type(screen.getByLabelText("New password"), "otter kettle marina");
+    await waitFor(() => expect(stateOf(/public data breaches/)).toContain(", met"));
+  });
+
+  it("does not blame the person when the lookup cannot run", async () => {
+    lookupBreachedPassword.mockResolvedValue("unknown");
+    render(<Host />);
+    await userEvent.type(screen.getByLabelText("New password"), "otter kettle marina");
+    await waitFor(() => expect(stateOf(/public data breaches/)).toContain(", met"));
+  });
+
+  it("announces progress through the rules", async () => {
+    render(<Host />);
+    await userEvent.type(screen.getByLabelText("New password"), "otter kettle marina");
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent("4 of 4 password requirements met."),
+    );
+  });
+});

--- a/src/components/site/NewPasswordField.tsx
+++ b/src/components/site/NewPasswordField.tsx
@@ -1,5 +1,5 @@
 import { Check, Circle, Loader2, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { PasswordInput } from "@/components/site/PasswordInput";
 import { Label } from "@/components/ui/label";
@@ -27,6 +27,11 @@ type Props = {
    * The rules use it to refuse a password built out of it.
    */
   personal?: (string | null | undefined)[];
+  /**
+   * Told how the breach lookup is going, so the form can refuse to submit a
+   * password this field is showing a red cross against.
+   */
+  onBreachChange?: (status: BreachStatus) => void;
   autoFocus?: boolean;
   disabled?: boolean;
 };
@@ -49,10 +54,19 @@ export function NewPasswordField({
   value,
   onChange,
   personal,
+  onBreachChange,
   autoFocus,
   disabled,
 }: Props) {
   const [breach, setBreach] = useState<BreachStatus>("idle");
+
+  // Held in a ref so the report below fires when the STATUS changes and not
+  // whenever the parent happens to re-render with a fresh arrow function.
+  const report = useRef(onBreachChange);
+  report.current = onBreachChange;
+  useEffect(() => {
+    report.current?.(breach);
+  }, [breach]);
 
   // Only ask about a password that has already cleared the rules we can check
   // ourselves. A half-typed one is not worth a request, and its answer would be

--- a/src/components/site/NewPasswordField.tsx
+++ b/src/components/site/NewPasswordField.tsx
@@ -1,0 +1,168 @@
+import { Check, Circle, Loader2, X } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { PasswordInput } from "@/components/site/PasswordInput";
+import { Label } from "@/components/ui/label";
+import {
+  checkPassword,
+  hasVariety,
+  meetsLength,
+  PASSWORD_MIN_LENGTH,
+  type BreachStatus,
+  type PasswordRuleState,
+} from "@/lib/password-policy";
+import { lookupBreachedPassword } from "@/lib/pwned-passwords";
+import { cn } from "@/lib/utils";
+
+/** How long to sit still before asking HIBP, so a lookup is not fired per keystroke. */
+const LOOKUP_DELAY_MS = 500;
+
+type Props = {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  /**
+   * What the club knows about this person: their email address, their name.
+   * The rules use it to refuse a password built out of it.
+   */
+  personal?: (string | null | undefined)[];
+  autoFocus?: boolean;
+  disabled?: boolean;
+};
+
+/**
+ * The field for choosing a new password, with the rules on screen next to it.
+ *
+ * The rules are listed before anything is typed, not produced as a rejection
+ * afterwards, because being told "that one is weak" by a form that never said
+ * what it wanted is the whole problem this replaces. Each rule ticks off as it
+ * is met, including the breach check, which runs while you type rather than at
+ * submit.
+ *
+ * The rules themselves, and why they are these rules, live in
+ * `@/lib/password-policy`.
+ */
+export function NewPasswordField({
+  id,
+  label,
+  value,
+  onChange,
+  personal,
+  autoFocus,
+  disabled,
+}: Props) {
+  const [breach, setBreach] = useState<BreachStatus>("idle");
+
+  // Only ask about a password that has already cleared the rules we can check
+  // ourselves. A half-typed one is not worth a request, and its answer would be
+  // stale by the next keystroke anyway.
+  const worthChecking = meetsLength(value) && hasVariety(value);
+
+  useEffect(() => {
+    if (!worthChecking) {
+      setBreach("idle");
+      return;
+    }
+    setBreach("checking");
+    let cancelled = false;
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      lookupBreachedPassword(value, controller.signal).then((result) => {
+        if (!cancelled) setBreach(result);
+      });
+    }, LOOKUP_DELAY_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [value, worthChecking]);
+
+  const rules = checkPassword(value, { personal, breach });
+  const touched = value.length > 0;
+  const met = rules.filter((rule) => rule.state === "met").length;
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <PasswordInput
+        id={id}
+        required
+        autoFocus={autoFocus}
+        disabled={disabled}
+        autoComplete="new-password"
+        aria-describedby={`${id}-hint ${id}-rules`}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <p id={`${id}-hint`} className="text-sm text-muted-foreground">
+        Length is what makes a password hard to guess, not punctuation. Four unrelated words you can
+        picture are easier to type on a phone than a short one full of symbols, and far harder to
+        break.
+      </p>
+      <ul id={`${id}-rules`} className="space-y-1 text-sm">
+        {rules.map((rule) => {
+          const shown = displayState(rule.state, touched, breach);
+          return (
+            <li key={rule.id} className="flex items-start gap-2">
+              <RuleIcon state={shown} />
+              <span
+                className={cn(
+                  shown === "met" && "text-green-700",
+                  shown === "unmet" && "text-destructive",
+                  (shown === "idle" || shown === "pending") && "text-muted-foreground",
+                )}
+              >
+                {rule.label}
+                <span className="sr-only">{RULE_STATE_WORDING[shown]}</span>
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+      <p className="sr-only" role="status">
+        {touched ? `${met} of ${rules.length} password requirements met.` : ""}
+      </p>
+    </div>
+  );
+}
+
+/** A rule as the row shows it. `idle` is "nothing to say about this yet". */
+type ShownState = PasswordRuleState | "idle";
+
+const RULE_STATE_WORDING: Record<ShownState, string> = {
+  idle: "",
+  met: ", met",
+  pending: ", checking",
+  unmet: ", not met yet",
+};
+
+/**
+ * What a row shows, which is not quite the rule's own state.
+ *
+ * Two rules only, both about not accusing anybody of anything prematurely.
+ * Before a single character is typed, four red crosses read as a telling-off,
+ * so nothing has a verdict yet. And the breach rule sits at `pending` both
+ * while a lookup is in flight and before the password is even long enough to
+ * be worth one: a spinner is a promise that something is happening, so only
+ * the first of those gets one.
+ */
+function displayState(
+  state: PasswordRuleState,
+  touched: boolean,
+  breach: BreachStatus,
+): ShownState {
+  if (!touched) return "idle";
+  if (state === "pending") return breach === "checking" ? "pending" : "idle";
+  return state;
+}
+
+function RuleIcon({ state }: { state: ShownState }) {
+  const className = "mt-0.5 h-4 w-4 shrink-0";
+  if (state === "met") return <Check className={cn(className, "text-green-700")} aria-hidden />;
+  if (state === "unmet") return <X className={cn(className, "text-destructive")} aria-hidden />;
+  if (state === "pending")
+    return <Loader2 className={cn(className, "animate-spin text-muted-foreground")} aria-hidden />;
+  return <Circle className={cn(className, "text-muted-foreground/50")} aria-hidden />;
+}

--- a/src/components/site/NewPasswordField.tsx
+++ b/src/components/site/NewPasswordField.tsx
@@ -5,9 +5,7 @@ import { PasswordInput } from "@/components/site/PasswordInput";
 import { Label } from "@/components/ui/label";
 import {
   checkPassword,
-  hasVariety,
-  meetsLength,
-  PASSWORD_MIN_LENGTH,
+  passwordProblem,
   type BreachStatus,
   type PasswordRuleState,
 } from "@/lib/password-policy";
@@ -68,10 +66,11 @@ export function NewPasswordField({
     report.current?.(breach);
   }, [breach]);
 
-  // Only ask about a password that has already cleared the rules we can check
-  // ourselves. A half-typed one is not worth a request, and its answer would be
-  // stale by the next keystroke anyway.
-  const worthChecking = meetsLength(value) && hasVariety(value);
+  // Only ask about a password that has already cleared every rule we can check
+  // ourselves. A half-typed one is not worth a request, its answer would be
+  // stale by the next keystroke, and a password already failing on screen does
+  // not need a second reason.
+  const worthChecking = !passwordProblem(value, { personal });
 
   useEffect(() => {
     if (!worthChecking) {

--- a/src/lib/password-policy.test.ts
+++ b/src/lib/password-policy.test.ts
@@ -141,19 +141,53 @@ describe("passwordProblem", () => {
   });
 
   it("sees through punctuation and capitals used to dodge that", () => {
-    expect(passwordProblem("J.i.T.s.U-training-hall")).toMatch(/knows you could guess/i);
+    expect(passwordProblem("J.i.T.s.U-J.i.T.s.U-club")).toMatch(/knows you could guess/i);
+  });
+
+  it("leaves a passphrase alone when the name is only a small part of it", () => {
+    // "Hill" is a surname and also an ordinary word. Rejecting four unrelated
+    // words because one of them happens to be somebody's name is how a rule
+    // set loses the person reading it.
+    expect(passwordProblem("hill kettle marina drill", { personal: ["Hill"] })).toBeNull();
+  });
+
+  it("does not match across a join that flattening the punctuation invented", () => {
+    // "flash escape" only contains "ashe" once the space is stripped out.
+    expect(passwordProblem("flash escape marina drill", { personal: ["Ashe"] })).toBeNull();
+  });
+
+  it("still rejects a password that is mostly the person's surname", () => {
+    expect(passwordProblem("hillsboro hill road", { personal: ["Hill"] })).toMatch(
+      /knows you could guess/i,
+    );
   });
 
   it("rejects a password past bcrypt's ceiling", () => {
     expect(passwordProblem("a b c d e f g h i j ".repeat(4))).toMatch(/72 characters/);
   });
 
+  it("explains the ceiling differently when characters and bytes disagree", () => {
+    // 40 accented characters is 80 bytes. Telling somebody holding 40 of
+    // something that the limit is 72 reads as a broken form.
+    const message = passwordProblem("é".repeat(40)) ?? "";
+    expect(message).toMatch(/72 characters of plain text/);
+    expect(message).toMatch(/use up more than one/);
+  });
+
   it("reports the length problem before the personal one, so there is one thing to fix", () => {
     expect(passwordProblem("jitsu", { personal: [] })).toMatch(/more character/i);
   });
 
-  it("never consults the breach lookup, which may be unreachable", () => {
-    expect(passwordProblem(GOOD, { breach: "breached" })).toBeNull();
+  it("blocks a password the breach lookup has come back on", () => {
+    // A red cross on screen has to mean the button will not work.
+    expect(passwordProblem(GOOD, { breach: "breached" })).toMatch(/data breach/i);
+  });
+
+  it("lets the form through while the lookup is unfinished or unreachable", () => {
+    expect(passwordProblem(GOOD, { breach: "checking" })).toBeNull();
+    expect(passwordProblem(GOOD, { breach: "unknown" })).toBeNull();
+    expect(passwordProblem(GOOD, { breach: "idle" })).toBeNull();
+    expect(passwordProblem(GOOD)).toBeNull();
   });
 });
 
@@ -165,6 +199,26 @@ describe("checkPassword", () => {
       "notPersonal",
       "notBreached",
     ]);
+  });
+
+  it("keeps the ceiling out of the list until it is broken", () => {
+    // It is a limit nobody approaches, so it would sit green forever.
+    expect(checkPassword(GOOD).map((rule) => rule.id)).not.toContain("maxLength");
+  });
+
+  it("shows the ceiling as a failed rule once it is broken", () => {
+    // Otherwise the list reads 4 of 4 while the form refuses to submit, which
+    // is the exact mismatch this whole change is about.
+    const rules = checkPassword("a".repeat(80));
+    const ceiling = rules.find((rule) => rule.id === "maxLength");
+    expect(ceiling?.state).toBe("unmet");
+    expect(ceiling?.label).toContain("72");
+  });
+
+  it("does not put a character count on the ceiling when bytes are what ran out", () => {
+    const ceiling = checkPassword("é".repeat(40)).find((rule) => rule.id === "maxLength");
+    expect(ceiling?.label).not.toContain("72");
+    expect(ceiling?.label).toMatch(/store/i);
   });
 
   function breachState(breach: BreachStatus) {
@@ -229,11 +283,20 @@ describe("describePasswordError", () => {
     const messages = [
       describePasswordError("Password is known to be weak and easy to guess."),
       describePasswordError("Password should be at least 8 characters."),
+      describePasswordError("Password cannot be longer than 72 characters"),
       passwordProblem("short"),
       passwordProblem("aaaaaaaaaaaaaaaaaa"),
-      passwordProblem("jitsu is the best club"),
+      passwordProblem("utsjitsu training club"),
+      passwordProblem("a".repeat(80)),
+      passwordProblem("é".repeat(40)),
+      passwordProblem("otter kettle marina drill", { breach: "breached" }),
       ...checkPassword("").map((rule) => rule.label),
+      ...checkPassword("é".repeat(40)).map((rule) => rule.label),
     ];
+    // Every entry has to be a real message: a null here would silently pass.
+    expect(messages.every((message) => typeof message === "string" && message.length > 0)).toBe(
+      true,
+    );
     for (const message of messages) expect(message).not.toContain("—");
   });
 });

--- a/src/lib/password-policy.test.ts
+++ b/src/lib/password-policy.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  checkPassword,
+  describePasswordError,
+  hasVariety,
+  isTooLong,
+  meetsLength,
+  passwordByteLength,
+  passwordProblem,
+  personalTokens,
+  PASSWORD_MAX_BYTES,
+  PASSWORD_MIN_LENGTH,
+  type BreachStatus,
+} from "./password-policy";
+
+/** A password that passes everything, so each test can vary one thing about it. */
+const GOOD = "otter kettle marina drill";
+
+describe("password policy constants", () => {
+  it("requires 15 characters, the NIST single-factor minimum", () => {
+    expect(PASSWORD_MIN_LENGTH).toBe(15);
+  });
+
+  it("caps at bcrypt's 72 bytes", () => {
+    expect(PASSWORD_MAX_BYTES).toBe(72);
+  });
+});
+
+describe("meetsLength", () => {
+  it("rejects anything under the minimum", () => {
+    expect(meetsLength("a".repeat(PASSWORD_MIN_LENGTH - 1))).toBe(false);
+    expect(meetsLength("a".repeat(PASSWORD_MIN_LENGTH))).toBe(true);
+  });
+
+  it("counts code points, so an emoji counts once and not twice", () => {
+    // 13 letters plus one emoji is 14 characters, but JavaScript's `.length`
+    // counts the emoji twice and would wrongly wave it through at 15.
+    expect("abcdefghijklm🥋".length).toBe(15);
+    expect(meetsLength("abcdefghijklm🥋")).toBe(false);
+    expect(meetsLength("abcdefghijklmn🥋")).toBe(true);
+  });
+
+  it("counts a space as a character, because a passphrase is mostly spaces", () => {
+    expect(meetsLength("a b c d e f g h")).toBe(true);
+  });
+});
+
+describe("isTooLong", () => {
+  it("measures bytes rather than characters, the way bcrypt truncates", () => {
+    expect(passwordByteLength("é")).toBe(2);
+    // 72 accented characters look like 72 to a person but are 144 bytes, all
+    // but the first 72 of which bcrypt would silently discard.
+    expect(isTooLong("é".repeat(72))).toBe(true);
+    expect(isTooLong("é".repeat(36))).toBe(false);
+    expect(isTooLong("a".repeat(72))).toBe(false);
+    expect(isTooLong("a".repeat(73))).toBe(true);
+  });
+});
+
+describe("hasVariety", () => {
+  it("rejects one character held down", () => {
+    expect(hasVariety("aaaaaaaaaaaaaaaaaaaa")).toBe(false);
+  });
+
+  it("rejects a short unit typed over and over", () => {
+    expect(hasVariety("abcabcabcabcabcabc")).toBe(false);
+    expect(hasVariety("abcdeabcdeabcdeabcde")).toBe(false);
+    expect(hasVariety("ab ab ab ab ab ab ")).toBe(false);
+  });
+
+  it("accepts an ordinary passphrase", () => {
+    expect(hasVariety(GOOD)).toBe(true);
+  });
+
+  it("does not ask for any particular kind of character", () => {
+    // All lower case, no digits, no symbols. NIST 800-63B-4 forbids requiring
+    // those, so this has to pass.
+    expect(hasVariety("thequickbrownfoxjumps")).toBe(true);
+  });
+});
+
+describe("personalTokens", () => {
+  it("always includes the club's own names", () => {
+    expect(personalTokens()).toContain("jitsu");
+    expect(personalTokens()).toContain("utsjitsu");
+  });
+
+  it("takes an email's local part and drops the domain", () => {
+    const tokens = personalTokens(["sam.rivers@example.com"]);
+    expect(tokens).toContain("samrivers");
+    expect(tokens).toContain("rivers");
+    expect(tokens).not.toContain("example");
+  });
+
+  it("splits a hyphenated name into its parts as well as the whole", () => {
+    const tokens = personalTokens(["Mary-Jane"]);
+    expect(tokens).toEqual(expect.arrayContaining(["maryjane", "mary", "jane"]));
+  });
+
+  it("drops tokens under four characters, which match innocent words", () => {
+    // "uts" is inside "outstanding"; a rule that fires on it is a rule people
+    // learn to ignore.
+    expect(personalTokens(["UTS", "Bo"])).not.toContain("uts");
+    expect(personalTokens(["UTS"])).toEqual(personalTokens([]));
+  });
+
+  it("ignores blanks and nulls from an unloaded profile", () => {
+    expect(personalTokens([null, undefined, ""])).toEqual(personalTokens([]));
+  });
+});
+
+describe("passwordProblem", () => {
+  it("passes a long passphrase with nothing but lower case letters and spaces", () => {
+    expect(passwordProblem(GOOD)).toBeNull();
+  });
+
+  it("rejects the short-with-symbols password the old rule allowed", () => {
+    // The previous rule was minLength 8, so this used to be acceptable. It is
+    // the exact shape composition rules produce, and it is 10 characters.
+    expect(passwordProblem("Password1!")).toMatch(/at least|more character/i);
+  });
+
+  it("says how many more characters are needed", () => {
+    expect(passwordProblem("abcdefghijkl")).toContain("3 more characters");
+    expect(passwordProblem("abcdefghijklmn")).toContain("1 more character");
+  });
+
+  it("rejects a long password made of one repeated thing", () => {
+    expect(passwordProblem("abcabcabcabcabcabc")).toMatch(/repeated/i);
+  });
+
+  it("rejects a password built from the person's own email", () => {
+    expect(
+      passwordProblem("samrivers is my name", { personal: ["samrivers@example.com"] }),
+    ).toMatch(/knows you could guess/i);
+  });
+
+  it("rejects a password built from the club's name", () => {
+    expect(passwordProblem("utsjitsu training club")).toMatch(/knows you could guess/i);
+  });
+
+  it("sees through punctuation and capitals used to dodge that", () => {
+    expect(passwordProblem("J.i.T.s.U-training-hall")).toMatch(/knows you could guess/i);
+  });
+
+  it("rejects a password past bcrypt's ceiling", () => {
+    expect(passwordProblem("a b c d e f g h i j ".repeat(4))).toMatch(/72 characters/);
+  });
+
+  it("reports the length problem before the personal one, so there is one thing to fix", () => {
+    expect(passwordProblem("jitsu", { personal: [] })).toMatch(/more character/i);
+  });
+
+  it("never consults the breach lookup, which may be unreachable", () => {
+    expect(passwordProblem(GOOD, { breach: "breached" })).toBeNull();
+  });
+});
+
+describe("checkPassword", () => {
+  it("lists every rule, in a fixed order", () => {
+    expect(checkPassword("").map((rule) => rule.id)).toEqual([
+      "length",
+      "variety",
+      "notPersonal",
+      "notBreached",
+    ]);
+  });
+
+  function breachState(breach: BreachStatus) {
+    return checkPassword(GOOD, { breach }).find((rule) => rule.id === "notBreached")?.state;
+  }
+
+  it("holds the breach rule open until a lookup has answered", () => {
+    expect(breachState("idle")).toBe("pending");
+    expect(breachState("checking")).toBe("pending");
+  });
+
+  it("marks the breach rule met when the password is clear", () => {
+    expect(breachState("safe")).toBe("met");
+  });
+
+  it("marks the breach rule unmet when the password has leaked", () => {
+    expect(breachState("breached")).toBe("unmet");
+  });
+
+  it("does not hold an unreachable lookup against the person", () => {
+    // Supabase checks this again server side, so a third party being down must
+    // not read as a failed rule.
+    expect(breachState("unknown")).toBe("met");
+  });
+
+  it("states the minimum in the rule's own label", () => {
+    expect(checkPassword("").find((rule) => rule.id === "length")?.label).toContain("15");
+  });
+});
+
+describe("describePasswordError", () => {
+  it("turns Supabase's bare weak-password refusal into something actionable", () => {
+    const supabaseMessage =
+      "Password is known to be weak and easy to guess, please choose a different one.";
+    const rewritten = describePasswordError(supabaseMessage);
+    expect(rewritten).not.toBe(supabaseMessage);
+    expect(rewritten).toMatch(/data breach/i);
+    expect(rewritten).toMatch(/unrelated words/i);
+  });
+
+  it("restates the length rule with our minimum, not Supabase's", () => {
+    expect(describePasswordError("Password should be at least 8 characters.")).toContain("15");
+  });
+
+  it("explains the 72 character ceiling", () => {
+    expect(describePasswordError("Password cannot be longer than 72 characters")).toMatch(
+      /72 characters/,
+    );
+  });
+
+  it("answers a character-class complaint with length instead", () => {
+    const message =
+      "Password should contain at least one character of each: abcdefghijklmnopqrstuvwxyz, 0123456789.";
+    expect(describePasswordError(message)).toMatch(/length is what counts/i);
+  });
+
+  it("passes an unrecognised message through rather than swallowing it", () => {
+    expect(describePasswordError("Auth session missing!")).toBe("Auth session missing!");
+  });
+
+  it("contains no em dash, which the copy rules forbid", () => {
+    const messages = [
+      describePasswordError("Password is known to be weak and easy to guess."),
+      describePasswordError("Password should be at least 8 characters."),
+      passwordProblem("short"),
+      passwordProblem("aaaaaaaaaaaaaaaaaa"),
+      passwordProblem("jitsu is the best club"),
+      ...checkPassword("").map((rule) => rule.label),
+    ];
+    for (const message of messages) expect(message).not.toContain("—");
+  });
+});

--- a/src/lib/password-policy.test.ts
+++ b/src/lib/password-policy.test.ts
@@ -69,6 +69,22 @@ describe("hasVariety", () => {
     expect(hasVariety("ab ab ab ab ab ab ")).toBe(false);
   });
 
+  it("rejects a unit too long for the old seven character cap", () => {
+    // At a fifteen character minimum, one eight letter word typed twice is the
+    // obvious way to reach the length, and it used to pass.
+    expect(hasVariety("passwordpassword")).toBe(false);
+    expect(hasVariety("abcdefghabcdefgh")).toBe(false);
+    expect(hasVariety("correcthorsecorrecthorse")).toBe(false);
+  });
+
+  it("does not choke on a pasted novel", () => {
+    // There is no backtracking left to reason about: this was a backreference
+    // regex, and the field runs it on every keystroke.
+    const started = performance.now();
+    expect(hasVariety("otter kettle marina drill ".repeat(20_000))).toBe(false);
+    expect(performance.now() - started).toBeLessThan(2_000);
+  });
+
   it("accepts an ordinary passphrase", () => {
     expect(hasVariety(GOOD)).toBe(true);
   });
@@ -158,6 +174,35 @@ describe("passwordProblem", () => {
 
   it("still rejects a password that is mostly the person's surname", () => {
     expect(passwordProblem("hillsboro hill road", { personal: ["Hill"] })).toMatch(
+      /knows you could guess/i,
+    );
+  });
+
+  it("rejects a password that is the person's first and last name", () => {
+    // Measured one word at a time, neither half reaches a third (each is 9 of
+    // 29 letters), so this used to sail through the rule that exists to stop
+    // exactly it.
+    const personal = ["alex.dominguez@example.com", "Alexander", "Dominguez"];
+    expect(passwordProblem("alexander dominguez kettle drill", { personal })).toMatch(
+      /knows you could guess/i,
+    );
+  });
+
+  it("does not count overlapping words twice when adding them up", () => {
+    // The tokens overlap by construction: the email local part contains the
+    // first name, and "utsjitsu" contains "jitsu". Counting the same letters
+    // three times would start refusing honest passphrases.
+    const personal = ["rose.hill@example.com", "Rose", "Hill"];
+    expect(passwordProblem("rose kettle marina drill anvil", { personal })).toBeNull();
+  });
+
+  it("folds accents rather than deleting them", () => {
+    // "Müller" reduced to "mller" before this, which matches nothing anybody
+    // types, so the rule quietly did nothing for members with accented names.
+    expect(passwordProblem("müller müller kettle", { personal: ["Müller"] })).toMatch(
+      /knows you could guess/i,
+    );
+    expect(passwordProblem("muller muller kettle", { personal: ["Müller"] })).toMatch(
       /knows you could guess/i,
     );
   });

--- a/src/lib/password-policy.ts
+++ b/src/lib/password-policy.ts
@@ -82,9 +82,21 @@ export type PasswordContext = {
   breach?: BreachStatus;
 };
 
-/** Strip a string down to what a guesser would actually try: letters and digits. */
+/**
+ * Strip a string down to what a guesser would actually try: letters and digits.
+ *
+ * Accents are folded rather than deleted (NFD splits "ü" into "u" plus a
+ * combining mark, and only the mark is dropped). Without that step "Müller"
+ * would reduce to "mller", which matches nothing a person would type, and the
+ * rule would quietly stop working for exactly the members whose names carry
+ * diacritics. Both sides of every comparison go through here, so they agree.
+ */
 function normalise(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
 }
 
 export function passwordByteLength(password: string): number {
@@ -134,23 +146,30 @@ export function personalTokens(personal: (string | null | undefined)[] = []): st
  */
 const PERSONAL_SHARE = 1 / 3;
 
-/** The largest share of the password that any single one of these words covers. */
+/**
+ * The share of the password covered by these words TAKEN TOGETHER.
+ *
+ * Together, not the largest of them separately. Measuring one word at a time
+ * lets a full name through: in "alexander dominguez kettle drill" neither half
+ * reaches a third on its own (each is 9 of 29 letters), so a password that is
+ * nothing but the member's own first and last name passed a rule whose label
+ * promises otherwise.
+ *
+ * Marking positions rather than adding lengths is what makes "together" safe.
+ * The words overlap by construction (an email local part contains the first
+ * name; "utsjitsu" contains "jitsu"), and adding them up would count the same
+ * letters two and three times and start refusing honest passphrases.
+ */
 function personalShare(password: string, tokens: string[]): number {
   const flattened = normalise(password);
   if (!flattened) return 0;
-  let largest = 0;
+  const covered = new Array<boolean>(flattened.length).fill(false);
   for (const token of tokens) {
-    let covered = 0;
-    for (
-      let at = flattened.indexOf(token);
-      at !== -1;
-      at = flattened.indexOf(token, at + token.length)
-    ) {
-      covered += token.length;
+    for (let at = flattened.indexOf(token); at !== -1; at = flattened.indexOf(token, at + 1)) {
+      for (let i = at; i < at + token.length; i++) covered[i] = true;
     }
-    largest = Math.max(largest, covered / flattened.length);
   }
-  return largest;
+  return covered.filter(Boolean).length / flattened.length;
 }
 
 function isBuiltFromPersonal(password: string, tokens: string[]): boolean {
@@ -158,8 +177,34 @@ function isBuiltFromPersonal(password: string, tokens: string[]): boolean {
 }
 
 /**
+ * Whether the password is some unit typed over and over: "abcabcabcabcabc",
+ * "passwordpassword".
+ *
+ * Every unit length is tried, not the first few. This was a regex with the
+ * repeat capped at seven characters, and "passwordpassword" walked through it
+ * on a unit of eight, which is not an edge case: at a fifteen character
+ * minimum, an eight letter word typed twice is the obvious way to reach the
+ * length. A loop rather than a backreference also means no backtracking to
+ * reason about on a pasted megabyte, and it compares code points, so an emoji
+ * counts once here the same as it does everywhere else in this file.
+ */
+function isRepeatedUnit(password: string): boolean {
+  const chars = [...password];
+  const length = chars.length;
+  for (let unit = 1; unit <= length / 2; unit++) {
+    if (length % unit !== 0) continue;
+    let repeats = true;
+    for (let i = unit; i < length && repeats; i++) {
+      if (chars[i] !== chars[i - unit]) repeats = false;
+    }
+    if (repeats) return true;
+  }
+  return false;
+}
+
+/**
  * Reject the degenerate ways to reach the length without adding any guesswork:
- * one character held down, or a short unit typed over and over.
+ * one character held down, or a unit typed over and over.
  *
  * This is not a composition rule. It asks for no particular kind of character,
  * only that there be more than a handful of distinct ones, so "aaaaaaaaaaaaaaa"
@@ -167,7 +212,7 @@ function isBuiltFromPersonal(password: string, tokens: string[]): boolean {
  */
 export function hasVariety(password: string): boolean {
   if (new Set([...password]).size < 5) return false;
-  return !/^(.{1,7}?)\1+$/s.test(password);
+  return !isRepeatedUnit(password);
 }
 
 export function meetsLength(password: string): boolean {

--- a/src/lib/password-policy.ts
+++ b/src/lib/password-policy.ts
@@ -59,7 +59,7 @@ const CLUB_TERMS = ["jitsu", "jiujitsu", "utsjitsu", "jitsuau"];
 /** How the breach lookup is going. `unknown` means we could not find out. */
 export type BreachStatus = "idle" | "checking" | "safe" | "breached" | "unknown";
 
-export type PasswordRuleId = "length" | "variety" | "notPersonal" | "notBreached";
+export type PasswordRuleId = "length" | "variety" | "notPersonal" | "notBreached" | "maxLength";
 
 /** `pending` is "we cannot say yet", which is only ever the breach lookup. */
 export type PasswordRuleState = "met" | "unmet" | "pending";
@@ -117,10 +117,44 @@ export function personalTokens(personal: (string | null | undefined)[] = []): st
   return [...tokens];
 }
 
-function containsPersonal(password: string, tokens: string[]): boolean {
+/**
+ * How much of a password one of those words has to account for before it is
+ * the reason the password is guessable.
+ *
+ * Plain substring matching is too blunt to use on its own. "Hill", "Rose",
+ * "Dean" and "Bell" are surnames and also ordinary words, and flattening the
+ * punctuation out before matching creates joins nobody typed ("flash escape"
+ * contains "ashe"). Rejecting a strong passphrase with "leave out your name"
+ * is how a rule set loses the person reading it.
+ *
+ * A third is the line. At fifteen characters minimum, a four or five letter
+ * surname cannot reach it by accident, while the passwords this rule is
+ * actually for, the ones that ARE somebody's name with a bit of decoration,
+ * are well past it.
+ */
+const PERSONAL_SHARE = 1 / 3;
+
+/** The largest share of the password that any single one of these words covers. */
+function personalShare(password: string, tokens: string[]): number {
   const flattened = normalise(password);
-  if (!flattened) return false;
-  return tokens.some((token) => flattened.includes(token));
+  if (!flattened) return 0;
+  let largest = 0;
+  for (const token of tokens) {
+    let covered = 0;
+    for (
+      let at = flattened.indexOf(token);
+      at !== -1;
+      at = flattened.indexOf(token, at + token.length)
+    ) {
+      covered += token.length;
+    }
+    largest = Math.max(largest, covered / flattened.length);
+  }
+  return largest;
+}
+
+function isBuiltFromPersonal(password: string, tokens: string[]): boolean {
+  return personalShare(password, tokens) >= PERSONAL_SHARE;
 }
 
 /**
@@ -147,10 +181,41 @@ export function isTooLong(password: string): boolean {
 }
 
 /**
+ * The ceiling stated to someone who has hit it.
+ *
+ * "72 characters" is only true of plain text. Told that while holding a
+ * thirty-character Japanese passphrase, a person would reasonably conclude the
+ * form is broken, so when the two counts disagree the reason comes with the
+ * number.
+ */
+function ceilingWording(password: string): { label: string; message: string } {
+  if (passwordByteLength(password) === [...password].length) {
+    return {
+      label: `No longer than ${PASSWORD_MAX_BYTES} characters`,
+      message: `That is longer than we can store. Passwords go up to ${PASSWORD_MAX_BYTES} characters.`,
+    };
+  }
+  return {
+    label: "Short enough for us to store",
+    message: `That is longer than we can store. The limit is ${PASSWORD_MAX_BYTES} characters of plain text, and accented, emoji and non-Latin characters each use up more than one.`,
+  };
+}
+
+/** The copy for a password found in breach data, shared by the live check and Supabase's refusal. */
+const BREACHED_MESSAGE =
+  "That password has turned up in a public data breach, which puts it on the lists attackers try first. It has to be a different one. Three or four unrelated words is the easiest way to get there.";
+
+/**
  * Every rule and where this password stands against it, in the order the field
  * lists them. The breach rule is `pending` until a lookup has answered, and
  * counts as met when the lookup could not run at all: the server checks it
  * again anyway, and a third party being unreachable is not the person's fault.
+ *
+ * The ceiling is the odd one out: it appears only once it has been broken. It
+ * is a limit nobody approaches, and a rule sitting green from the first
+ * keystroke to the last is noise in a list that is meant to be read. It has to
+ * appear then, though, because it does stop the form, and a list showing all
+ * green next to a refusal is the thing this whole change is fixing.
  */
 export function checkPassword(password: string, context: PasswordContext = {}): PasswordRule[] {
   const breach = context.breach ?? "idle";
@@ -158,7 +223,7 @@ export function checkPassword(password: string, context: PasswordContext = {}): 
   const breachState: PasswordRuleState =
     breach === "breached" ? "unmet" : breach === "safe" || breach === "unknown" ? "met" : "pending";
 
-  return [
+  const rules: PasswordRule[] = [
     {
       id: "length",
       label: `At least ${PASSWORD_MIN_LENGTH} characters`,
@@ -171,8 +236,8 @@ export function checkPassword(password: string, context: PasswordContext = {}): 
     },
     {
       id: "notPersonal",
-      label: "Nothing from your name, your email, or the club's name",
-      state: containsPersonal(password, tokens) ? "unmet" : "met",
+      label: "Not built out of your name, your email, or the club's name",
+      state: isBuiltFromPersonal(password, tokens) ? "unmet" : "met",
     },
     {
       id: "notBreached",
@@ -180,6 +245,11 @@ export function checkPassword(password: string, context: PasswordContext = {}): 
       state: breachState,
     },
   ];
+
+  if (isTooLong(password)) {
+    rules.push({ id: "maxLength", label: ceilingWording(password).label, state: "unmet" });
+  }
+  return rules;
 }
 
 /**
@@ -187,16 +257,15 @@ export function checkPassword(password: string, context: PasswordContext = {}): 
  * null when there is nothing to fix. Forms call this to decide whether to
  * submit.
  *
- * The breach lookup is deliberately not consulted here. It is a call to a
- * third party that can be slow or down, and a member should never be unable to
- * set a password because someone else's API is having an afternoon. Supabase
- * enforces that half server side regardless, and `describePasswordError` turns
- * its refusal into something worth reading.
+ * The breach lookup only blocks when it has actually come back saying the
+ * password has leaked. "Checking" and "unknown" both let the form through: it
+ * is a call to a third party that can be slow or down, and nobody should be
+ * unable to set a password because someone else's API is having an afternoon.
+ * Supabase checks the same thing server side regardless, and
+ * `describePasswordError` turns its refusal into something worth reading.
  */
 export function passwordProblem(password: string, context: PasswordContext = {}): string | null {
-  if (isTooLong(password)) {
-    return `That is longer than we can store. Passwords go up to ${PASSWORD_MAX_BYTES} characters.`;
-  }
+  if (isTooLong(password)) return ceilingWording(password).message;
   if (!meetsLength(password)) {
     const short = PASSWORD_MIN_LENGTH - [...password].length;
     return `A bit short. Add ${short} more character${short === 1 ? "" : "s"} to reach ${PASSWORD_MIN_LENGTH}.`;
@@ -204,9 +273,12 @@ export function passwordProblem(password: string, context: PasswordContext = {})
   if (!hasVariety(password)) {
     return "That is the same thing repeated, so it is as short as its shortest part. Try a few unrelated words instead.";
   }
-  if (containsPersonal(password, personalTokens(context.personal))) {
+  if (isBuiltFromPersonal(password, personalTokens(context.personal))) {
     return "Anyone who knows you could guess that. Leave out your name, your email and the club's name.";
   }
+  // Last, and only on a definite answer: a red cross on screen has to mean the
+  // button will not work, or the list is decoration.
+  if (context.breach === "breached") return BREACHED_MESSAGE;
   return null;
 }
 
@@ -221,9 +293,7 @@ export function passwordProblem(password: string, context: PasswordContext = {})
  */
 export function describePasswordError(message: string): string {
   const text = message.toLowerCase();
-  if (text.includes("known to be weak")) {
-    return "That password has turned up in a public data breach, which puts it on the lists attackers try first. It has to be a different one. Three or four unrelated words is the easiest way to get there.";
-  }
+  if (text.includes("known to be weak")) return BREACHED_MESSAGE;
   if (text.includes("should be at least")) {
     return `A bit short. Use at least ${PASSWORD_MIN_LENGTH} characters.`;
   }

--- a/src/lib/password-policy.ts
+++ b/src/lib/password-policy.ts
@@ -1,0 +1,240 @@
+// The club's password rules, written down once, in a form a person can read.
+//
+// The rules follow NIST SP 800-63B-4 (Digital Identity Guidelines, August 2025)
+// and the OWASP Authentication Cheat Sheet, not the older "one capital, one
+// number, one symbol" habit. That habit is worse than nothing: it is what
+// produces `Password1!` and its cousins, which is precisely the shape of every
+// credential-stuffing list. Both documents now say the same two things instead,
+// and they are what this module enforces:
+//
+//   * LENGTH is the control that matters. NIST requires 15 characters when the
+//     password is the only factor, which is our case (this site has no second
+//     factor; the alternative here is the emailed sign-in link, not an app
+//     code). Eight is only permitted when a second factor backs it up.
+//   * NOT HAVING LEAKED is the other one. Almost every real account takeover
+//     starts with a password already published in a breach, so a password gets
+//     checked against that corpus rather than against a character-class rule.
+//
+// And the thing we deliberately do NOT do: NIST 800-63B-4 says verifiers SHALL
+// NOT impose composition rules. Every character is allowed here, spaces and
+// emoji included, and nothing is required to appear.
+//
+// Two of the numbers are not ours to pick:
+//
+//   * 72 is a hard ceiling from bcrypt, which is what Supabase hashes with.
+//     bcrypt ignores everything past byte 72, so a longer passphrase would be
+//     silently truncated to something shorter than the person thinks they set.
+//     Supabase rejects it outright, and so do we, with an explanation.
+//   * The breach check itself already runs server side: Supabase's leaked
+//     password protection queries Have I Been Pwned, and its rejection is the
+//     bare "Password is known to be weak and easy to guess, please choose a
+//     different one." that sent nobody anywhere useful. That check stays (it is
+//     the authority), but the same lookup now runs as you type, so the answer
+//     arrives before you commit to a password rather than after.
+//
+// Pure and side-effect free, like `validation.ts` next to it: the network half
+// of the breach check lives in `pwned-passwords.ts` so these rules stay
+// unit-testable on their own.
+
+/**
+ * Minimum length. NIST SP 800-63B-4 section 3.1.1.2: 15 characters for a
+ * password used as a single factor.
+ *
+ * Raising this does not lock anybody out. It is checked when a password is
+ * SET, never when one is used to sign in, so members holding an older, shorter
+ * password keep signing in with it until they change it.
+ */
+export const PASSWORD_MIN_LENGTH = 15;
+
+/**
+ * Maximum length, in BYTES rather than characters, because that is how bcrypt
+ * counts: a passphrase of accented or non-Latin characters runs out sooner
+ * than a plain ASCII one of the same visible length.
+ */
+export const PASSWORD_MAX_BYTES = 72;
+
+/** Names the club answers to. A password should not be guessable from the sign. */
+const CLUB_TERMS = ["jitsu", "jiujitsu", "utsjitsu", "jitsuau"];
+
+/** How the breach lookup is going. `unknown` means we could not find out. */
+export type BreachStatus = "idle" | "checking" | "safe" | "breached" | "unknown";
+
+export type PasswordRuleId = "length" | "variety" | "notPersonal" | "notBreached";
+
+/** `pending` is "we cannot say yet", which is only ever the breach lookup. */
+export type PasswordRuleState = "met" | "unmet" | "pending";
+
+export type PasswordRule = {
+  id: PasswordRuleId;
+  /** Shown to the person, so it is the rule itself and not a description of it. */
+  label: string;
+  state: PasswordRuleState;
+};
+
+export type PasswordContext = {
+  /**
+   * Things this person is publicly associated with: their email address, the
+   * parts of their name. A password built out of these is guessable by anyone
+   * who has met them.
+   */
+  personal?: (string | null | undefined)[];
+  /** Result of the Have I Been Pwned lookup, if one has run. */
+  breach?: BreachStatus;
+};
+
+/** Strip a string down to what a guesser would actually try: letters and digits. */
+function normalise(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+export function passwordByteLength(password: string): number {
+  return new TextEncoder().encode(password).length;
+}
+
+/**
+ * The words a password must not be built from, drawn from whatever the caller
+ * knows about the person plus the club's own names.
+ *
+ * Tokens shorter than four characters are dropped rather than matched. "uts"
+ * is a substring of "outstanding", and a rule that rejects an honest
+ * passphrase for containing three incidental letters teaches people to stop
+ * reading the rules.
+ */
+export function personalTokens(personal: (string | null | undefined)[] = []): string[] {
+  const tokens = new Set<string>(CLUB_TERMS);
+  for (const raw of personal) {
+    if (!raw) continue;
+    // An email is only guessable up to the "@": the domain is shared by
+    // thousands of people and rejecting "gmail" would be noise.
+    const value = raw.includes("@") ? raw.slice(0, raw.indexOf("@")) : raw;
+    // Split as well as taking the whole, so "mary-jane" contributes all three
+    // of "maryjane", "mary" and "jane".
+    for (const piece of [value, ...value.split(/[^A-Za-z0-9]+/)]) {
+      const token = normalise(piece);
+      if (token.length >= 4) tokens.add(token);
+    }
+  }
+  return [...tokens];
+}
+
+function containsPersonal(password: string, tokens: string[]): boolean {
+  const flattened = normalise(password);
+  if (!flattened) return false;
+  return tokens.some((token) => flattened.includes(token));
+}
+
+/**
+ * Reject the degenerate ways to reach the length without adding any guesswork:
+ * one character held down, or a short unit typed over and over.
+ *
+ * This is not a composition rule. It asks for no particular kind of character,
+ * only that there be more than a handful of distinct ones, so "aaaaaaaaaaaaaaa"
+ * and "abcabcabcabcabc" do not pass as fifteen characters of anything.
+ */
+export function hasVariety(password: string): boolean {
+  if (new Set([...password]).size < 5) return false;
+  return !/^(.{1,7}?)\1+$/s.test(password);
+}
+
+export function meetsLength(password: string): boolean {
+  // Count code points, not UTF-16 units, so an emoji counts once rather than
+  // twice and nobody reaches 15 with seven of them.
+  return [...password].length >= PASSWORD_MIN_LENGTH;
+}
+
+export function isTooLong(password: string): boolean {
+  return passwordByteLength(password) > PASSWORD_MAX_BYTES;
+}
+
+/**
+ * Every rule and where this password stands against it, in the order the field
+ * lists them. The breach rule is `pending` until a lookup has answered, and
+ * counts as met when the lookup could not run at all: the server checks it
+ * again anyway, and a third party being unreachable is not the person's fault.
+ */
+export function checkPassword(password: string, context: PasswordContext = {}): PasswordRule[] {
+  const breach = context.breach ?? "idle";
+  const tokens = personalTokens(context.personal);
+  const breachState: PasswordRuleState =
+    breach === "breached" ? "unmet" : breach === "safe" || breach === "unknown" ? "met" : "pending";
+
+  return [
+    {
+      id: "length",
+      label: `At least ${PASSWORD_MIN_LENGTH} characters`,
+      state: meetsLength(password) ? "met" : "unmet",
+    },
+    {
+      id: "variety",
+      label: "Not one character or short pattern repeated",
+      state: hasVariety(password) ? "met" : "unmet",
+    },
+    {
+      id: "notPersonal",
+      label: "Nothing from your name, your email, or the club's name",
+      state: containsPersonal(password, tokens) ? "unmet" : "met",
+    },
+    {
+      id: "notBreached",
+      label: "Not one of the passwords found in public data breaches",
+      state: breachState,
+    },
+  ];
+}
+
+/**
+ * The one thing wrong with this password, phrased as what to do about it, or
+ * null when there is nothing to fix. Forms call this to decide whether to
+ * submit.
+ *
+ * The breach lookup is deliberately not consulted here. It is a call to a
+ * third party that can be slow or down, and a member should never be unable to
+ * set a password because someone else's API is having an afternoon. Supabase
+ * enforces that half server side regardless, and `describePasswordError` turns
+ * its refusal into something worth reading.
+ */
+export function passwordProblem(password: string, context: PasswordContext = {}): string | null {
+  if (isTooLong(password)) {
+    return `That is longer than we can store. Passwords go up to ${PASSWORD_MAX_BYTES} characters.`;
+  }
+  if (!meetsLength(password)) {
+    const short = PASSWORD_MIN_LENGTH - [...password].length;
+    return `A bit short. Add ${short} more character${short === 1 ? "" : "s"} to reach ${PASSWORD_MIN_LENGTH}.`;
+  }
+  if (!hasVariety(password)) {
+    return "That is the same thing repeated, so it is as short as its shortest part. Try a few unrelated words instead.";
+  }
+  if (containsPersonal(password, personalTokens(context.personal))) {
+    return "Anyone who knows you could guess that. Leave out your name, your email and the club's name.";
+  }
+  return null;
+}
+
+/**
+ * Supabase's own password refusals, rewritten for the person reading them.
+ *
+ * The strings are matched loosely on purpose: they come from GoTrue, we do not
+ * own them, and an unrecognised one falls through unchanged rather than being
+ * swallowed. `weak_password` is the interesting case, and its bare wording
+ * ("known to be weak and easy to guess") is what this whole module is a
+ * reaction to: it tells you that you failed without telling you the rule.
+ */
+export function describePasswordError(message: string): string {
+  const text = message.toLowerCase();
+  if (text.includes("known to be weak")) {
+    return "That password has turned up in a public data breach, which puts it on the lists attackers try first. It has to be a different one. Three or four unrelated words is the easiest way to get there.";
+  }
+  if (text.includes("should be at least")) {
+    return `A bit short. Use at least ${PASSWORD_MIN_LENGTH} characters.`;
+  }
+  if (text.includes("longer than 72")) {
+    return `That is longer than we can store. Passwords go up to ${PASSWORD_MAX_BYTES} characters.`;
+  }
+  if (text.includes("at least one character of each")) {
+    return `Use at least ${PASSWORD_MIN_LENGTH} characters. Length is what counts, so a few unrelated words beats a short one with symbols in it.`;
+  }
+  if (text.includes("different from the old password")) {
+    return "That is the password you already have. Pick a new one.";
+  }
+  return message;
+}

--- a/src/lib/pwned-passwords.test.ts
+++ b/src/lib/pwned-passwords.test.ts
@@ -1,7 +1,10 @@
 import { createHash, webcrypto } from "node:crypto";
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { lookupBreachedPassword } from "./pwned-passwords";
+// Imported fresh per test rather than once at the top: the module remembers
+// across calls whether the padding header was accepted, and a test that makes
+// it give up must not decide the outcome of the next one.
+let lookupBreachedPassword: typeof import("./pwned-passwords").lookupBreachedPassword;
 
 /** The same hash the module computes, so a fake response can be built around it. */
 function sha1(value: string): string {
@@ -24,12 +27,14 @@ function respondWith(body: string, init: ResponseInit = {}) {
   return fetchMock;
 }
 
-beforeAll(() => {
+beforeEach(async () => {
   // jsdom's `crypto` has no `subtle`, so borrow Node's WebCrypto. The module
   // reads `crypto.subtle` at call time, which is what makes this substitutable.
   if (!globalThis.crypto?.subtle) {
     vi.stubGlobal("crypto", webcrypto);
   }
+  vi.resetModules();
+  ({ lookupBreachedPassword } = await import("./pwned-passwords"));
 });
 
 afterEach(() => {
@@ -96,6 +101,48 @@ describe("lookupBreachedPassword", () => {
       }),
     );
     await expect(lookupBreachedPassword(PASSWORD, controller.signal)).resolves.toBe("unknown");
+  });
+
+  it("still answers when the padding header is refused, and stops sending it", async () => {
+    // `Add-Padding` is not CORS-safelisted, so it forces a preflight. If that
+    // preflight is refused, dropping the header has to be what happens: the
+    // alternative is a lookup that returns "unknown" forever and a rule that
+    // sits green while checking nothing.
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.headers) throw new TypeError("Failed to fetch");
+      return new Response(rangeBody([[SUFFIX, 42]]), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(lookupBreachedPassword(PASSWORD)).resolves.toBe("breached");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // The refusal is remembered, so the next lookup costs one request.
+    fetchMock.mockClear();
+    await expect(lookupBreachedPassword(PASSWORD)).resolves.toBe("breached");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1]?.headers).toBeUndefined();
+  });
+
+  it("keeps sending the padding header while it is accepted", async () => {
+    const fetchMock = respondWith(rangeBody([[SUFFIX, 0]]));
+    await lookupBreachedPassword(PASSWORD);
+    await lookupBreachedPassword(PASSWORD);
+    for (const [, init] of fetchMock.mock.calls as unknown as [string, RequestInit][]) {
+      expect(init.headers).toMatchObject({ "Add-Padding": "true" });
+    }
+  });
+
+  it("does not read an abort as the padding header being refused", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn(async () => {
+      controller.abort();
+      throw new DOMException("Aborted", "AbortError");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(lookupBreachedPassword(PASSWORD, controller.signal)).resolves.toBe("unknown");
+    // One attempt, not a retry: an abort is us cancelling, not HIBP objecting.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("returns unknown without WebCrypto rather than throwing", async () => {

--- a/src/lib/pwned-passwords.test.ts
+++ b/src/lib/pwned-passwords.test.ts
@@ -1,0 +1,108 @@
+import { createHash, webcrypto } from "node:crypto";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { lookupBreachedPassword } from "./pwned-passwords";
+
+/** The same hash the module computes, so a fake response can be built around it. */
+function sha1(value: string): string {
+  return createHash("sha1").update(value).digest("hex").toUpperCase();
+}
+
+const PASSWORD = "otter kettle marina drill";
+const HASH = sha1(PASSWORD);
+const PREFIX = HASH.slice(0, 5);
+const SUFFIX = HASH.slice(5);
+
+/** A range response in HIBP's format: SUFFIX:COUNT lines, CRLF separated. */
+function rangeBody(entries: [string, number][]): string {
+  return entries.map(([suffix, count]) => `${suffix}:${count}`).join("\r\n");
+}
+
+function respondWith(body: string, init: ResponseInit = {}) {
+  const fetchMock = vi.fn(async () => new Response(body, { status: 200, ...init }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+beforeAll(() => {
+  // jsdom's `crypto` has no `subtle`, so borrow Node's WebCrypto. The module
+  // reads `crypto.subtle` at call time, which is what makes this substitutable.
+  if (!globalThis.crypto?.subtle) {
+    vi.stubGlobal("crypto", webcrypto);
+  }
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("lookupBreachedPassword", () => {
+  it("sends only the first five characters of the hash, never the password", async () => {
+    const fetchMock = respondWith(rangeBody([["0".repeat(35), 0]]));
+    await lookupBreachedPassword(PASSWORD);
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(`https://api.pwnedpasswords.com/range/${PREFIX}`);
+    expect(url).not.toContain(SUFFIX);
+    expect(url).not.toContain(PASSWORD);
+    // Without padding the size of the response is itself a hint about which
+    // prefix was asked for.
+    expect(init.headers).toMatchObject({ "Add-Padding": "true" });
+  });
+
+  it("reports a password that appears in the range with a real count", async () => {
+    respondWith(
+      rangeBody([
+        ["A".repeat(35), 3],
+        [SUFFIX, 1_284],
+      ]),
+    );
+    await expect(lookupBreachedPassword(PASSWORD)).resolves.toBe("breached");
+  });
+
+  it("treats a zero count as padding rather than a sighting", async () => {
+    // HIBP pads responses with decoy suffixes, and marks them with a 0 count.
+    respondWith(rangeBody([[SUFFIX, 0]]));
+    await expect(lookupBreachedPassword(PASSWORD)).resolves.toBe("safe");
+  });
+
+  it("reports safe when the suffix is absent from the range", async () => {
+    respondWith(rangeBody([["B".repeat(35), 9]]));
+    await expect(lookupBreachedPassword(PASSWORD)).resolves.toBe("safe");
+  });
+
+  it("returns unknown, never breached, when the service errors", async () => {
+    respondWith("", { status: 503 });
+    await expect(lookupBreachedPassword(PASSWORD)).resolves.toBe("unknown");
+  });
+
+  it("returns unknown when the request fails outright", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new TypeError("Failed to fetch");
+      }),
+    );
+    await expect(lookupBreachedPassword(PASSWORD)).resolves.toBe("unknown");
+  });
+
+  it("returns unknown when the request is aborted mid-flight", async () => {
+    const controller = new AbortController();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        controller.abort();
+        throw new DOMException("Aborted", "AbortError");
+      }),
+    );
+    await expect(lookupBreachedPassword(PASSWORD, controller.signal)).resolves.toBe("unknown");
+  });
+
+  it("returns unknown without WebCrypto rather than throwing", async () => {
+    // Plain http, or an old browser. The server side check still applies.
+    vi.stubGlobal("crypto", {});
+    const fetchMock = respondWith(rangeBody([[SUFFIX, 12]]));
+    await expect(lookupBreachedPassword(PASSWORD)).resolves.toBe("unknown");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/pwned-passwords.ts
+++ b/src/lib/pwned-passwords.ts
@@ -27,6 +27,31 @@ const RANGE_URL = "https://api.pwnedpasswords.com/range/";
 
 export type BreachLookup = "safe" | "breached" | "unknown";
 
+/**
+ * Whether to keep asking for padding. `Add-Padding` is not a CORS-safelisted
+ * request header, so sending it turns every lookup into a preflight, and a
+ * refused preflight fails the request outright rather than degrading. That
+ * would be the worst outcome available: the lookup would return "unknown"
+ * forever, the rule would sit permanently green, and nothing would say so.
+ *
+ * So the header is best effort. One failure and it is dropped for the rest of
+ * the session and the plain request is tried instead. Losing the padding costs
+ * a privacy property (the response size hints at how many suffixes share the
+ * prefix). Losing the check costs the check.
+ */
+let usePadding = true;
+
+function requestRange(prefix: string, signal?: AbortSignal): Promise<Response> {
+  const url = `${RANGE_URL}${prefix}`;
+  if (!usePadding) return fetch(url, { signal });
+  return fetch(url, { signal, headers: { "Add-Padding": "true" } }).catch((error) => {
+    // An abort is us, not the header. Do not read it as a verdict on padding.
+    if (signal?.aborted) throw error;
+    usePadding = false;
+    return fetch(url, { signal });
+  });
+}
+
 async function sha1Hex(value: string): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-1", new TextEncoder().encode(value));
   return [...new Uint8Array(digest)]
@@ -52,13 +77,9 @@ export async function lookupBreachedPassword(
 
   try {
     const hash = await sha1Hex(password);
-    const prefix = hash.slice(0, 5);
     const suffix = hash.slice(5);
 
-    const response = await fetch(`${RANGE_URL}${prefix}`, {
-      signal,
-      headers: { "Add-Padding": "true" },
-    });
+    const response = await requestRange(hash.slice(0, 5), signal);
     if (!response.ok) return "unknown";
 
     for (const line of (await response.text()).split("\n")) {

--- a/src/lib/pwned-passwords.ts
+++ b/src/lib/pwned-passwords.ts
@@ -1,0 +1,75 @@
+// "Has this password already leaked?", asked without telling anyone the password.
+//
+// Have I Been Pwned's range API is a k-anonymity scheme: we SHA-1 the password,
+// send the first five hex characters of the hash, and get back every suffix
+// that shares that prefix (a few hundred to a few thousand) along with how many
+// times each has been seen in a breach. The matching happens here, in the
+// browser. The password never leaves the device, and neither does its full
+// hash, so the service cannot tell which of the returned entries we were asking
+// about.
+//
+// The `Add-Padding` request header is part of that: without it the SIZE of the
+// response is itself a signal, because a prefix with few matches returns a
+// small body. With it every response is padded with decoy entries to a uniform
+// bulk, and the decoys carry a count of 0, which is why a match is only a match
+// when its count is above zero.
+//
+// SHA-1 here is not a security choice we are making. It is the index HIBP is
+// built on, it is used as a lookup key rather than to protect anything, and
+// nothing about the scheme relies on it being collision resistant.
+//
+// This is advisory. Supabase runs the same check server side when the password
+// is saved and that is what actually enforces it. Everything here exists so the
+// answer arrives while somebody is still typing, and every failure path returns
+// "unknown" rather than blocking them.
+
+const RANGE_URL = "https://api.pwnedpasswords.com/range/";
+
+export type BreachLookup = "safe" | "breached" | "unknown";
+
+async function sha1Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-1", new TextEncoder().encode(value));
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+    .toUpperCase();
+}
+
+/**
+ * Whether this password appears in Have I Been Pwned's breach corpus.
+ *
+ * Returns "unknown" for every failure, including an aborted request: no
+ * network, a blocked request, an old browser without WebCrypto, HIBP being
+ * down. A caller must treat "unknown" as "carry on", never as a rejection.
+ */
+export async function lookupBreachedPassword(
+  password: string,
+  signal?: AbortSignal,
+): Promise<BreachLookup> {
+  // Requires a secure context, so it is absent on plain http and in some test
+  // environments. Nothing to do about it beyond not crashing.
+  if (typeof crypto === "undefined" || !crypto.subtle) return "unknown";
+
+  try {
+    const hash = await sha1Hex(password);
+    const prefix = hash.slice(0, 5);
+    const suffix = hash.slice(5);
+
+    const response = await fetch(`${RANGE_URL}${prefix}`, {
+      signal,
+      headers: { "Add-Padding": "true" },
+    });
+    if (!response.ok) return "unknown";
+
+    for (const line of (await response.text()).split("\n")) {
+      const [candidate, count] = line.trim().split(":");
+      if (candidate !== suffix) continue;
+      // A count of 0 is padding, not a sighting.
+      return Number(count) > 0 ? "breached" : "safe";
+    }
+    // The prefix came back and our suffix was not in it, which is a real answer.
+    return "safe";
+  } catch {
+    return "unknown";
+  }
+}

--- a/src/routes/_authenticated/account.test.tsx
+++ b/src/routes/_authenticated/account.test.tsx
@@ -357,4 +357,72 @@ describe("/account", () => {
     expect(consentCard.getByRole("button", { name: "Save" })).toBeDisabled();
     expect(updateMyProfile).not.toHaveBeenCalled();
   });
+
+  // The password rules themselves are pinned in `lib/password-policy.test.ts`.
+  // What is pinned here is the wiring: that this card actually consults them,
+  // that Supabase's refusal reaches the screen in words, and that the refusal
+  // gets out of the way again.
+  describe("change password", () => {
+    const passwordCard = () => within(card("Change password"));
+
+    async function typePassword(user: ReturnType<typeof userEvent.setup>, value: string) {
+      await user.click(passwordCard().getByLabelText("New password"));
+      await user.paste(value);
+    }
+
+    it("refuses a password that breaks a rule without calling Supabase", async () => {
+      const { supabase } = await import("@/integrations/supabase/client");
+      const user = userEvent.setup();
+      await renderLoaded();
+
+      await typePassword(user, "Password1!");
+      await user.click(passwordCard().getByRole("button", { name: "Update password" }));
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(/5 more characters/);
+      expect(supabase.auth.updateUser).not.toHaveBeenCalled();
+    });
+
+    it("checks the password against the name on the profile, not just the email", async () => {
+      const user = userEvent.setup();
+      await renderLoaded();
+
+      // Ada Lovelace, per the profile fixture. Her own name is not a password.
+      await typePassword(user, "ada lovelace ada");
+      await user.click(passwordCard().getByRole("button", { name: "Update password" }));
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(/knows you could guess/i);
+    });
+
+    it("puts Supabase's refusal on screen in words a person can act on", async () => {
+      const { supabase } = await import("@/integrations/supabase/client");
+      vi.mocked(supabase.auth.updateUser).mockResolvedValueOnce({
+        data: { user: null },
+        error: {
+          message: "Password is known to be weak and easy to guess, please choose a different one.",
+        },
+      } as unknown as Awaited<ReturnType<typeof supabase.auth.updateUser>>);
+      const user = userEvent.setup();
+      await renderLoaded();
+
+      await typePassword(user, "otter kettle marina drill");
+      await user.click(passwordCard().getByRole("button", { name: "Update password" }));
+
+      const alert = await screen.findByRole("alert");
+      // Not the raw message, and not a toast: it stays on screen next to the rules.
+      expect(alert).toHaveTextContent(/data breach/i);
+      expect(alert).not.toHaveTextContent(/known to be weak/i);
+    });
+
+    it("clears the refusal as soon as they start fixing it", async () => {
+      const user = userEvent.setup();
+      await renderLoaded();
+
+      await typePassword(user, "short");
+      await user.click(passwordCard().getByRole("button", { name: "Update password" }));
+      expect(await screen.findByRole("alert")).toBeInTheDocument();
+
+      await user.type(passwordCard().getByLabelText("New password"), "er");
+      expect(screen.queryByRole("alert")).toBeNull();
+    });
+  });
 });

--- a/src/routes/_authenticated/account.tsx
+++ b/src/routes/_authenticated/account.tsx
@@ -8,7 +8,10 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Pill } from "@/components/site/StatusPill";
+import { NewPasswordField } from "@/components/site/NewPasswordField";
+import { describePasswordError, passwordProblem } from "@/lib/password-policy";
 import {
   BELT_SIZE_HINT,
   BeltSizeSelect,
@@ -232,7 +235,15 @@ function AccountPage() {
 
       <SectionHeading>Sign-in</SectionHeading>
 
-      <ChangePasswordCard />
+      <ChangePasswordCard
+        personal={[
+          user?.email,
+          profile?.first_name,
+          profile?.middle_name,
+          profile?.last_name,
+          profile?.preferred_name,
+        ]}
+      />
 
       {isManager && (
         <>
@@ -1103,16 +1114,23 @@ function GoogleDriveCard() {
   );
 }
 
-function ChangePasswordCard() {
+function ChangePasswordCard({ personal }: { personal: (string | null | undefined)[] }) {
   const [password, setPassword] = useState("");
+  const [problem, setProblem] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
+    // Say what is wrong here rather than spending a round trip to be told.
+    const local = passwordProblem(password, { personal });
+    if (local) return setProblem(local);
+    setProblem(null);
     setBusy(true);
     const { error } = await supabase.auth.updateUser({ password });
     setBusy(false);
-    if (error) return toast.error(error.message);
+    // Not a toast: this stops somebody, so it has to still be on screen while
+    // they fix it, next to the rules it is about.
+    if (error) return setProblem(describePasswordError(error.message));
     setPassword("");
     toast.success("Password updated");
   }
@@ -1123,18 +1141,20 @@ function ChangePasswordCard() {
         <CardTitle>Change password</CardTitle>
       </CardHeader>
       <CardContent>
-        <form onSubmit={onSubmit} className="space-y-3">
-          <div>
-            <Label htmlFor="cp">New password</Label>
-            <Input
-              id="cp"
-              type="password"
-              required
-              minLength={8}
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
-          </div>
+        <form onSubmit={onSubmit} className="space-y-4">
+          <NewPasswordField
+            id="cp"
+            label="New password"
+            disabled={busy}
+            value={password}
+            onChange={setPassword}
+            personal={personal}
+          />
+          {problem && (
+            <Alert variant="destructive">
+              <AlertDescription>{problem}</AlertDescription>
+            </Alert>
+          )}
           <Button type="submit" disabled={busy}>
             {busy ? "Saving..." : "Update password"}
           </Button>

--- a/src/routes/_authenticated/account.tsx
+++ b/src/routes/_authenticated/account.tsx
@@ -11,7 +11,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Pill } from "@/components/site/StatusPill";
 import { NewPasswordField } from "@/components/site/NewPasswordField";
-import { describePasswordError, passwordProblem } from "@/lib/password-policy";
+import { describePasswordError, passwordProblem, type BreachStatus } from "@/lib/password-policy";
 import {
   BELT_SIZE_HINT,
   BeltSizeSelect,
@@ -1116,13 +1116,14 @@ function GoogleDriveCard() {
 
 function ChangePasswordCard({ personal }: { personal: (string | null | undefined)[] }) {
   const [password, setPassword] = useState("");
+  const [breach, setBreach] = useState<BreachStatus>("idle");
   const [problem, setProblem] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     // Say what is wrong here rather than spending a round trip to be told.
-    const local = passwordProblem(password, { personal });
+    const local = passwordProblem(password, { personal, breach });
     if (local) return setProblem(local);
     setProblem(null);
     setBusy(true);
@@ -1147,7 +1148,14 @@ function ChangePasswordCard({ personal }: { personal: (string | null | undefined
             label="New password"
             disabled={busy}
             value={password}
-            onChange={setPassword}
+            // Clear the refusal as soon as they start fixing it. A red panel
+            // sitting under rules that have since gone green is worse than no
+            // panel.
+            onChange={(next) => {
+              setPassword(next);
+              setProblem(null);
+            }}
+            onBreachChange={setBreach}
             personal={personal}
           />
           {problem && (

--- a/src/routes/update-password.tsx
+++ b/src/routes/update-password.tsx
@@ -4,7 +4,8 @@ import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
 import { SiteLayout } from "@/components/site/SiteLayout";
 import { NewPasswordField } from "@/components/site/NewPasswordField";
-import { describePasswordError, passwordProblem } from "@/lib/password-policy";
+import { describePasswordError, passwordProblem, type BreachStatus } from "@/lib/password-policy";
+import { getMyProfile } from "@/lib/waiver.functions";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -19,26 +20,44 @@ export const Route = createFileRoute("/update-password")({
 function UpdatePasswordPage() {
   const navigate = useNavigate();
   const [ready, setReady] = useState(false);
-  const [email, setEmail] = useState<string | null>(null);
+  const [personal, setPersonal] = useState<(string | null | undefined)[]>([]);
   const [password, setPassword] = useState("");
+  const [breach, setBreach] = useState<BreachStatus>("idle");
   const [problem, setProblem] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
     // Supabase parses the recovery token from the URL hash automatically.
-    supabase.auth.getSession().then(({ data }) => {
+    supabase.auth.getSession().then(async ({ data }) => {
       if (!data.session) toast.error("Reset link is invalid or expired. Request a new one.");
-      // The recovery session tells us who this is, which is what lets the rules
-      // refuse a password built out of their own address.
-      setEmail(data.session?.user.email ?? null);
+      const email = data.session?.user.email ?? null;
+      setPersonal([email]);
       setReady(true);
+      if (!data.session) return;
+      // The field promises to refuse a password built out of the person's NAME
+      // as well as their address, and the recovery session only carries the
+      // address. Fetch the rest so this screen enforces the list it is showing,
+      // the same as /account does. Best effort and never blocking: the form is
+      // already usable, and a name arriving late only tightens the check.
+      try {
+        const profile = await getMyProfile();
+        setPersonal([
+          email,
+          profile?.first_name,
+          profile?.middle_name,
+          profile?.last_name,
+          profile?.preferred_name,
+        ]);
+      } catch {
+        // Leave the email-only check in place. Supabase still has the last word.
+      }
     });
   }, []);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     // Say what is wrong here rather than spending a round trip to be told.
-    const local = passwordProblem(password, { personal: [email] });
+    const local = passwordProblem(password, { personal, breach });
     if (local) return setProblem(local);
     setProblem(null);
     setBusy(true);
@@ -67,8 +86,15 @@ function UpdatePasswordPage() {
                   autoFocus
                   disabled={busy}
                   value={password}
-                  onChange={setPassword}
-                  personal={[email]}
+                  // Clear the refusal as soon as they start fixing it. A red
+                  // panel sitting under rules that have since gone green is
+                  // worse than no panel.
+                  onChange={(next) => {
+                    setPassword(next);
+                    setProblem(null);
+                  }}
+                  onBreachChange={setBreach}
+                  personal={personal}
                 />
                 {problem && (
                   <Alert variant="destructive">

--- a/src/routes/update-password.tsx
+++ b/src/routes/update-password.tsx
@@ -3,9 +3,10 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
 import { SiteLayout } from "@/components/site/SiteLayout";
-import { PasswordInput } from "@/components/site/PasswordInput";
+import { NewPasswordField } from "@/components/site/NewPasswordField";
+import { describePasswordError, passwordProblem } from "@/lib/password-policy";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export const Route = createFileRoute("/update-password")({
@@ -18,23 +19,34 @@ export const Route = createFileRoute("/update-password")({
 function UpdatePasswordPage() {
   const navigate = useNavigate();
   const [ready, setReady] = useState(false);
+  const [email, setEmail] = useState<string | null>(null);
   const [password, setPassword] = useState("");
+  const [problem, setProblem] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
     // Supabase parses the recovery token from the URL hash automatically.
     supabase.auth.getSession().then(({ data }) => {
       if (!data.session) toast.error("Reset link is invalid or expired. Request a new one.");
+      // The recovery session tells us who this is, which is what lets the rules
+      // refuse a password built out of their own address.
+      setEmail(data.session?.user.email ?? null);
       setReady(true);
     });
   }, []);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
+    // Say what is wrong here rather than spending a round trip to be told.
+    const local = passwordProblem(password, { personal: [email] });
+    if (local) return setProblem(local);
+    setProblem(null);
     setBusy(true);
     const { error } = await supabase.auth.updateUser({ password });
     setBusy(false);
-    if (error) return toast.error(error.message);
+    // Not a toast: this stops somebody, so it has to still be on screen while
+    // they fix it, next to the rules it is about.
+    if (error) return setProblem(describePasswordError(error.message));
     toast.success("Password updated");
     navigate({ to: "/account" });
   }
@@ -48,17 +60,21 @@ function UpdatePasswordPage() {
           </CardHeader>
           <CardContent>
             {ready && (
-              <form onSubmit={onSubmit} className="space-y-3">
-                <div>
-                  <Label htmlFor="new-pw">New password</Label>
-                  <PasswordInput
-                    id="new-pw"
-                    required
-                    minLength={8}
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                  />
-                </div>
+              <form onSubmit={onSubmit} className="space-y-4">
+                <NewPasswordField
+                  id="new-pw"
+                  label="New password"
+                  autoFocus
+                  disabled={busy}
+                  value={password}
+                  onChange={setPassword}
+                  personal={[email]}
+                />
+                {problem && (
+                  <Alert variant="destructive">
+                    <AlertDescription>{problem}</AlertDescription>
+                  </Alert>
+                )}
                 <Button type="submit" className="w-full" disabled={busy}>
                   {busy ? "Updating..." : "Update password"}
                 </Button>


### PR DESCRIPTION
## What was wrong

Choosing a password gave you no rules at all. The form asked for eight characters, and if Supabase disagreed you got its refusal in a toast that auto-dismissed:

> Password is known to be weak and easy to guess, please choose a different one.

That message names no rule, so there is nothing to do about it except guess again. It also disappears while you are still reading it.

## What a member sees now

The rules are listed next to the field **before** anything is typed, and each one ticks off as you meet it:

- At least 15 characters
- Not one character or short pattern repeated
- Not built out of your name, your email, or the club's name
- Not one of the passwords found in public data breaches

Above them, one line of guidance: length is what makes a password hard to guess, not punctuation, and four unrelated words are easier to type on a phone than a short one full of symbols.

If something is wrong, it now says what and stays on screen in an alert next to the rules, not a toast. "A bit short. Add 5 more characters to reach 15." A leaked password gets told it turned up in a data breach and what to do instead. The alert clears as soon as you start fixing it.

Both screens that set a password: `/update-password` (the emailed reset link) and the Change password card on `/account`.

**Nobody is locked out and nobody has to change anything.** The rules apply when a password is *set*, never when one is used to sign in, so a member holding an older eight-character password keeps signing in with it. No forced rotation either.

## Why these rules

Following [NIST SP 800-63B-4](https://pages.nist.gov/800-63-4/sp800-63b.html) (August 2025) and the [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html), not the "one capital, one number, one symbol" habit:

- **15 characters** is what NIST requires when the password is the only factor, which is our case. Eight is only permitted when a second factor backs it up. The alternative to a password here is the emailed sign-in link, so a real minimum costs nobody anything.
- **No composition rules, deliberately.** 800-63B-4 says verifiers SHALL NOT impose them. They are not merely dated, they are counterproductive: told to add a capital, a digit and a symbol, people produce `Password1!` and `Summer2026!`, which is the most common shape in every credential-stuffing list. Every character is allowed here, spaces and emoji included, and nothing is required to appear.
- **The breach check** is the control that actually stops account takeover, since almost every real one starts with a password lifted from someone else's leak.
- **The two middle rules** are ours. Each closes a way to reach 15 characters without gaining any guesswork (`aaaaaaaaaaaaaaa`, or a password that is mostly the member's surname). Neither asks for a kind of character, so neither is a composition rule. "Built out of" is a share, not a substring match: a word has to account for a third of the password before it counts, so "Hill" and "Rose" (surnames, and also ordinary words) do not fail an honest passphrase.
- **72 is a ceiling, not a demand,** and it only appears in the list once you break it. bcrypt (what Supabase hashes with) ignores everything past byte 72, so a longer passphrase would be silently truncated to something shorter than you think you set. Counted in bytes, so accented characters use it up faster, and the message says so when the two counts disagree.

Every rule that can stop the button is a rule on the list. A green list next to a refusal is the exact thing this change exists to remove.

## The breach check

Supabase already ran this server side, which is where the original message came from, and it still does: that is the authority. What is new is that the same lookup now runs **as you type**, so the answer arrives before you commit to a password instead of after.

It uses Have I Been Pwned's k-anonymity range API: the password is SHA-1'd, only the first five hex characters of the hash are sent, and the matching suffixes are compared in the browser. The password never leaves the device and neither does its full hash. The request sends `Add-Padding: true` so the response size does not leak which prefix was asked for; that header is not CORS-safelisted, so if the preflight is refused it is dropped for the session rather than failing the check silently.

A definite "breached" stops the form, because the red cross has to mean something. "Checking" and "unknown" do not: nobody should be unable to set a password because a third party is having an afternoon.

## One thing to do outside this PR

The 15-character floor is enforced in the browser. The server-side floor is Supabase's `password_min_length`, which is dashboard configuration and cannot be set from this repo. To make the rule real rather than advertised, set it to **15** under Authentication → Sign In / Providers, leave leaked-password protection **on**, and leave required-characters **off**. Noted in `docs/passwords.md`.

## Changes

| File | |
| --- | --- |
| `src/lib/password-policy.ts` | the rules, pure and unit tested. The labels in it are the copy shown on screen, so a rule cannot change without its wording changing too |
| `src/lib/pwned-passwords.ts` | the HIBP range lookup |
| `src/components/site/NewPasswordField.tsx` | the field, the rules, and their live state |
| `src/routes/update-password.tsx`, `src/routes/_authenticated/account.tsx` | both call sites, toast replaced with an inline alert |
| `docs/passwords.md` | the policy, the sources, and where each half is enforced |

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (1666 passing, 49 new) and `bun run build` all pass. Screens checked in the running app at 390px and 1280px: empty, failing, checking, over-length and passing states.

Second commit is the fixes from a review pass of the first: six places where the listed rules and the enforced rules had drifted apart, plus the CORS fallback above.