### PR TITLE
Membership: pay from the page, with the club's account as copyable fields

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -908,7 +908,7 @@ manager-only. Keys in use:
 
 | Key                            | Holds                                                                                                                                                   |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `invoice_payment_instructions` | Markdown shown on an invoice. Falls back to a built-in stub when unset.                                                                                 |
+| `invoice_payment_instructions` | Markdown shown on an invoice: in the payment email, and in the member's "how to pay" panel on `/membership`. Falls back to a built-in stub when unset.  |
 | `contact_messages_seen_at`     | ISO instant a manager last opened `/manager/contact-messages`. Club-wide, not per manager. Unset means nobody ever has, so every message counts unread. |
 
 Being key/value is what let the contact-message unread count ship without a

--- a/docs/database.md
+++ b/docs/database.md
@@ -906,10 +906,11 @@ grants off.
 `key` PK, `value`, `updated_at`, `updated_by → auth.users(id)`. **RLS:**
 manager-only. Keys in use:
 
-| Key                            | Holds                                                                                                                                                   |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `invoice_payment_instructions` | Markdown shown on an invoice: in the payment email, and in the member's "how to pay" panel on `/membership`. Falls back to a built-in stub when unset.  |
-| `contact_messages_seen_at`     | ISO instant a manager last opened `/manager/contact-messages`. Club-wide, not per manager. Unset means nobody ever has, so every message counts unread. |
+| Key                            | Holds                                                                                                                                                                                                                                                                                                                      |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `invoice_payment_details`      | **JSON.** The club's bank account (account name, BSB, account number, bank, plus optional SWIFT/BIC and addresses, plus a note), shown field by field with a copy button each on `/membership` and in the payment email. Anything that is not a complete account parses as "not published yet". See `docs/memberships.md`. |
+| `invoice_payment_instructions` | **Legacy.** The free-text markdown that `invoice_payment_details` replaced. Nothing member-facing reads it; `/manager/settings` shows it read-only while the account fields are still empty. Pending deletion.                                                                                                             |
+| `contact_messages_seen_at`     | ISO instant a manager last opened `/manager/contact-messages`. Club-wide, not per manager. Unset means nobody ever has, so every message counts unread.                                                                                                                                                                    |
 
 Being key/value is what let the contact-message unread count ship without a
 migration. It is also its limit: a value here is a single club-wide fact, so

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -123,12 +123,8 @@ own), and reconciliation, activation and cancellation follow the same
 ## Paying an invoice
 
 The member sees everything they need to pay on `/membership` itself: a **How to
-pay** panel above the plan list carrying the amount, the payment reference (with
-a copy button, because the reference is what someone re-opens the page for while
-standing in their banking app), and the club's own account details. That last
-part is the manager-set markdown from `/manager/settings`, read through the same
-helper the invoice email uses, so the page and the email can never quote
-different bank details. Any signed-in person can read the club's details, not
+pay** panel above the plan list carrying the amount, the payment reference, and
+the club's bank account. Any signed-in person can read the club's account, not
 only someone who owes money.
 
 The panel appears only while something is unpaid, and it counts **transfers, not
@@ -137,11 +133,51 @@ reference, so it shows as one payment with the split underneath, matching the
 single combined amount the email quotes. The memberships table above it stays the
 per-row record.
 
-**The invoice email is unchanged** and still goes out on every purchase. This is
-a second copy of the same details, not a replacement, so a member who deleted the
-email is not stuck. If the club's details cannot be loaded, the amount and
-reference (the member's own data) still render and the panel points at the email
-for the rest.
+**The invoice email is a second copy of the same details, not a replacement**, so
+a member who deleted the email is not stuck, and it links back to the page.
+
+### The club's account is fields, not prose
+
+The account is eight named values under the `club_settings` key
+`invoice_payment_details` (a JSON blob), edited on `/manager/settings`, and
+**every one of them has its own copy button** on the page. That is the whole
+reason it is structured: a member is in a banking app on a phone, and a block of
+prose gives them one thing to select by hand.
+
+- **Account name, BSB, account number, bank** are required **together**. A
+  half-filled account never parses, because it looks payable: somebody copies the
+  BSB, finds no account number, and guesses. An incomplete set is treated exactly
+  like nothing published.
+- **SWIFT/BIC, bank address, account holder address** are each optional and sit
+  behind a "Paying from overseas?" disclosure, hidden entirely when all three are
+  blank. Australia has no IBAN, so the BIC (the same thing as a SWIFT code, 8 or
+  11 characters) plus the BSB and account number is what a sending bank abroad
+  asks for.
+- **The note** is the one free-text field left, markdown, with no copy button.
+
+The BSB is stored as six bare digits and displayed **and copied** as `062-000`,
+formatted in one place (`clubPaymentFieldValue`) so what is on screen and what
+lands on the clipboard cannot disagree. `CLUB_ACCOUNT_FIELDS` /
+`CLUB_INTERNATIONAL_FIELDS` in `src/lib/validation.ts` are the single ordered
+list both the page and the email walk, which is what stops the two drifting.
+
+**An overseas transfer often arrives short**, because a bank in the middle took a
+cut. Reconciliation matches on the reference _and the exact amount_
+(`matchesMembershipReference`), so a short payment does not activate anything and
+waits for a manager. The overseas block says so before anyone pays.
+
+### Before the club has published an account
+
+The page and the email both say the club has not published its details yet and to
+get in touch, rather than rendering an empty block. `/manager/settings` leads with
+a warning while that is true, and shows whatever free text is left in the old
+`invoice_payment_instructions` row read-only, so the values can be copied across.
+Nothing member-facing reads that legacy row any more; it is deleted in a later
+change.
+
+A failed **read** of the settings is kept apart from a club that never published
+anything (`readClubPaymentDetails` returns `ok`), because the two say different
+things to somebody about to transfer money.
 
 ## Manager screens & the manager agent API
 

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -120,6 +120,29 @@ own), and reconciliation, activation and cancellation follow the same
 `edit_invoice` / bank-reconciliation flow as any other plan — see
 `.claude/skills/uts-manager-agent/SKILL.md` and `/manager/reconciliation`.
 
+## Paying an invoice
+
+The member sees everything they need to pay on `/membership` itself: a **How to
+pay** panel above the plan list carrying the amount, the payment reference (with
+a copy button, because the reference is what someone re-opens the page for while
+standing in their banking app), and the club's own account details. That last
+part is the manager-set markdown from `/manager/settings`, read through the same
+helper the invoice email uses, so the page and the email can never quote
+different bank details. Any signed-in person can read the club's details, not
+only someone who owes money.
+
+The panel appears only while something is unpaid, and it counts **transfers, not
+rows**: a plan bought with yearly insurance is two pending memberships behind one
+reference, so it shows as one payment with the split underneath, matching the
+single combined amount the email quotes. The memberships table above it stays the
+per-row record.
+
+**The invoice email is unchanged** and still goes out on every purchase. This is
+a second copy of the same details, not a replacement, so a member who deleted the
+email is not stuck. If the club's details cannot be loaded, the amount and
+reference (the member's own data) still render and the panel points at the email
+for the rest.
+
 ## Manager screens & the manager agent API
 
 | Manager UI                  | Manager agent actions                            | What it does                                   |

--- a/src/components/site/ClubAccountDetails.tsx
+++ b/src/components/site/ClubAccountDetails.tsx
@@ -1,0 +1,124 @@
+import { Mail } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import { CopyButton } from "@/components/site/CopyButton";
+import { invoiceMarkdownComponents } from "@/lib/invoice-markdown";
+import {
+  CLUB_ACCOUNT_FIELDS,
+  CLUB_INTERNATIONAL_FIELDS,
+  clubPaymentFieldValue,
+  hasInternationalDetails,
+} from "@/lib/validation";
+import type { ClubPaymentDetails, ClubPaymentFieldKey } from "@/lib/validation";
+import { cn } from "@/lib/utils";
+
+interface FieldSpec {
+  readonly key: ClubPaymentFieldKey;
+  readonly label: string;
+  readonly copyLabel: string;
+  readonly mono: boolean;
+}
+
+/**
+ * One labelled value with its own copy button.
+ *
+ * The button is the point of the whole component: a member is in their banking
+ * app, on a phone, and every character they retype by hand is a chance to send
+ * money to the wrong account. So the copied string is the displayed string, and
+ * the BSB's hyphen is added in one place (`clubPaymentFieldValue`) so what is on
+ * screen and what is on the clipboard cannot disagree.
+ */
+function DetailRow({ field, details }: { field: FieldSpec; details: ClubPaymentDetails }) {
+  const value = clubPaymentFieldValue(details, field.key);
+  if (!value) return null;
+  return (
+    <div className="border-t py-2.5 first:border-t-0 first:pt-0">
+      <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {field.label}
+      </dt>
+      <dd className="mt-1 flex flex-wrap items-center justify-between gap-2">
+        <span
+          className={cn(
+            "font-semibold text-foreground",
+            field.mono ? "break-all font-mono tracking-wide" : "break-words",
+          )}
+        >
+          {value}
+        </span>
+        <CopyButton text={value} label={field.copyLabel} />
+      </dd>
+    </div>
+  );
+}
+
+export interface ClubAccountDetailsProps {
+  /** Null when the club has not published a complete set of details. */
+  details: ClubPaymentDetails | null;
+  /** True when the settings could not be read at all, which is not the same thing. */
+  unreadable?: boolean;
+}
+
+/**
+ * The club's bank account, as a member reads it: the domestic fields always, the
+ * overseas ones behind a disclosure, and the club's own note last.
+ *
+ * Shared by the member's "how to pay" panel and the manager's preview of it, so
+ * a manager editing these fields is looking at what a member will actually get
+ * rather than an approximation of it.
+ */
+export function ClubAccountDetails({ details, unreadable = false }: ClubAccountDetailsProps) {
+  if (!details) {
+    return (
+      <p className="flex items-start gap-2 text-sm text-muted-foreground">
+        <Mail className="mt-0.5 h-4 w-4 shrink-0" />
+        {unreadable
+          ? "We could not load the club's account details just now. Reload the page to try again, or reply to your invoice email and we'll send them over."
+          : "The club has not published its account details yet. Reply to your invoice email or use the contact page and we'll send them over."}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <dl className="rounded-lg border bg-background p-4">
+        {CLUB_ACCOUNT_FIELDS.map((f) => (
+          <DetailRow key={f.key} field={f} details={details} />
+        ))}
+      </dl>
+
+      {/* Almost everyone here is paying domestically from a phone, so the
+          overseas fields stay folded away rather than pushing the BSB and the
+          account number down the screen. A native <details> keeps it keyboard
+          and screen-reader operable with no state of our own. */}
+      {hasInternationalDetails(details) && (
+        <details className="rounded-lg border bg-background">
+          <summary className="cursor-pointer px-4 py-3 text-sm font-medium marker:text-muted-foreground">
+            Paying from overseas?
+          </summary>
+          <div className="border-t px-4 py-3">
+            <dl>
+              {CLUB_INTERNATIONAL_FIELDS.map((f) => (
+                <DetailRow key={f.key} field={f} details={details} />
+              ))}
+            </dl>
+            {/* Not a disclaimer for its own sake. An overseas transfer often
+                arrives short because a bank in the middle took a cut, and
+                reconciliation matches on the exact amount, so a short payment
+                sits unmatched until a manager picks it up by hand. Saying so
+                here is cheaper for everyone than saying it afterwards. */}
+            <p className="mt-3 border-t pt-3 text-xs text-muted-foreground">
+              Banks along the way can take fees out of an international transfer, so ask yours to
+              send the full amount. If it arrives short we will still sort it out, it just takes us
+              a little longer.
+            </p>
+          </div>
+        </details>
+      )}
+
+      {details.note && (
+        <div className="text-sm text-muted-foreground">
+          <ReactMarkdown components={invoiceMarkdownComponents}>{details.note}</ReactMarkdown>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/site/CopyButton.tsx
+++ b/src/components/site/CopyButton.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+
+interface CopyButtonProps {
+  /** The exact string put on the clipboard. */
+  text: string;
+  /** Button label, e.g. "Copy reference". Also the accessible name. */
+  label: string;
+  className?: string;
+}
+
+/**
+ * Copy one string to the clipboard, with a transient "copied" tick.
+ *
+ * Clipboard access can be refused outright (older browsers, no secure context,
+ * a permission prompt the person dismissed), so the failure path matters: every
+ * caller keeps the value visible on screen, and the toast tells the person to
+ * select it by hand rather than leaving a button that silently does nothing.
+ */
+export function CopyButton({ text, label, className }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className={className}
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(text);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        } catch {
+          toast.error("Couldn't copy. Select and copy manually.");
+        }
+      }}
+    >
+      {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+      {label}
+    </Button>
+  );
+}
+
+export default CopyButton;

--- a/src/lib/club-settings.server.test.ts
+++ b/src/lib/club-settings.server.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/integrations/supabase/types";
 import { DEFAULT_INVOICE_INSTRUCTIONS } from "./validation";
-import { getInvoiceInstructions } from "./club-settings.server";
+import { getInvoiceInstructions, readInvoiceInstructions } from "./club-settings.server";
 
 /** Fake admin whose club_settings row returns `value`. */
 function settingsAdmin(value: string | null) {
@@ -17,6 +17,55 @@ function settingsAdmin(value: string | null) {
     }),
   } as unknown as SupabaseClient<Database>;
 }
+
+/** Fake admin whose club_settings read comes back as a PostgREST error. */
+function erroringAdmin() {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => Promise.resolve({ data: null, error: { message: "boom" } }),
+        }),
+      }),
+    }),
+  } as unknown as SupabaseClient<Database>;
+}
+
+describe("readInvoiceInstructions", () => {
+  // "Nobody set any" and "we could not read them" both end up as the default
+  // for the email, but the member's page says different things about them, so
+  // the raw read has to keep them apart.
+  it("reports a settled empty answer when nothing is stored", async () => {
+    await expect(readInvoiceInstructions(settingsAdmin(null))).resolves.toEqual({
+      ok: true,
+      value: null,
+    });
+    await expect(readInvoiceInstructions(settingsAdmin("   "))).resolves.toEqual({
+      ok: true,
+      value: null,
+    });
+  });
+
+  it("reports a failed read as not ok, whether it errors or throws", async () => {
+    await expect(readInvoiceInstructions(erroringAdmin())).resolves.toEqual({
+      ok: false,
+      value: null,
+    });
+    const throwing = {
+      from: () => {
+        throw new Error("boom");
+      },
+    } as unknown as SupabaseClient<Database>;
+    await expect(readInvoiceInstructions(throwing)).resolves.toEqual({ ok: false, value: null });
+  });
+
+  it("hands back the stored markdown, trimmed", async () => {
+    await expect(readInvoiceInstructions(settingsAdmin("  BSB 062-000  "))).resolves.toEqual({
+      ok: true,
+      value: "BSB 062-000",
+    });
+  });
+});
 
 describe("getInvoiceInstructions", () => {
   it("returns the stored markdown when set", async () => {
@@ -34,12 +83,15 @@ describe("getInvoiceInstructions", () => {
     );
   });
 
-  it("falls back to the default when the lookup throws", async () => {
-    const admin = {
+  it("falls back to the default when the lookup fails, so the email still sends", async () => {
+    const throwing = {
       from: () => {
         throw new Error("boom");
       },
     } as unknown as SupabaseClient<Database>;
-    await expect(getInvoiceInstructions(admin)).resolves.toBe(DEFAULT_INVOICE_INSTRUCTIONS);
+    await expect(getInvoiceInstructions(throwing)).resolves.toBe(DEFAULT_INVOICE_INSTRUCTIONS);
+    await expect(getInvoiceInstructions(erroringAdmin())).resolves.toBe(
+      DEFAULT_INVOICE_INSTRUCTIONS,
+    );
   });
 });

--- a/src/lib/club-settings.server.test.ts
+++ b/src/lib/club-settings.server.test.ts
@@ -2,7 +2,18 @@ import { describe, expect, it } from "vitest";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/integrations/supabase/types";
 import { DEFAULT_INVOICE_INSTRUCTIONS } from "./validation";
-import { getInvoiceInstructions, readInvoiceInstructions } from "./club-settings.server";
+import { getInvoiceInstructions, readClubPaymentDetails } from "./club-settings.server";
+
+const ACCOUNT = {
+  account_name: "UTS Jitsu Club Inc",
+  bsb: "062000",
+  account_number: "12345678",
+  bank_name: "Commonwealth Bank of Australia",
+  swift_bic: "CTBAAU2S",
+  bank_address: "Sydney NSW 2000, Australia",
+  account_holder_address: "1 Broadway, Ultimo NSW 2007",
+  note: "",
+};
 
 /** Fake admin whose club_settings row returns `value`. */
 function settingsAdmin(value: string | null) {
@@ -31,38 +42,52 @@ function erroringAdmin() {
   } as unknown as SupabaseClient<Database>;
 }
 
-describe("readInvoiceInstructions", () => {
-  // "Nobody set any" and "we could not read them" both end up as the default
-  // for the email, but the member's page says different things about them, so
-  // the raw read has to keep them apart.
+const throwingAdmin = {
+  from: () => {
+    throw new Error("boom");
+  },
+} as unknown as SupabaseClient<Database>;
+
+describe("readClubPaymentDetails", () => {
+  it("returns the stored account", async () => {
+    const res = await readClubPaymentDetails(settingsAdmin(JSON.stringify(ACCOUNT)));
+    expect(res.ok).toBe(true);
+    expect(res.details?.bsb).toBe("062000");
+    expect(res.details?.swift_bic).toBe("CTBAAU2S");
+  });
+
+  // "Nobody published an account" and "we could not read the store" are
+  // different answers, because the screens say different things about them to
+  // somebody who is about to transfer money.
   it("reports a settled empty answer when nothing is stored", async () => {
-    await expect(readInvoiceInstructions(settingsAdmin(null))).resolves.toEqual({
+    await expect(readClubPaymentDetails(settingsAdmin(null))).resolves.toEqual({
       ok: true,
-      value: null,
-    });
-    await expect(readInvoiceInstructions(settingsAdmin("   "))).resolves.toEqual({
-      ok: true,
-      value: null,
+      details: null,
     });
   });
 
   it("reports a failed read as not ok, whether it errors or throws", async () => {
-    await expect(readInvoiceInstructions(erroringAdmin())).resolves.toEqual({
+    await expect(readClubPaymentDetails(erroringAdmin())).resolves.toEqual({
       ok: false,
-      value: null,
+      details: null,
     });
-    const throwing = {
-      from: () => {
-        throw new Error("boom");
-      },
-    } as unknown as SupabaseClient<Database>;
-    await expect(readInvoiceInstructions(throwing)).resolves.toEqual({ ok: false, value: null });
+    await expect(readClubPaymentDetails(throwingAdmin)).resolves.toEqual({
+      ok: false,
+      details: null,
+    });
   });
 
-  it("hands back the stored markdown, trimmed", async () => {
-    await expect(readInvoiceInstructions(settingsAdmin("  BSB 062-000  "))).resolves.toEqual({
+  // A blob that no longer parses must read as "not published", never as a
+  // partial account: half an account is what sends money to the wrong place.
+  it("treats an unparseable or incomplete blob as nothing published", async () => {
+    await expect(readClubPaymentDetails(settingsAdmin("not json"))).resolves.toEqual({
       ok: true,
-      value: "BSB 062-000",
+      details: null,
+    });
+    const halfAnAccount = JSON.stringify({ ...ACCOUNT, account_number: "" });
+    await expect(readClubPaymentDetails(settingsAdmin(halfAnAccount))).resolves.toEqual({
+      ok: true,
+      details: null,
     });
   });
 });
@@ -83,13 +108,8 @@ describe("getInvoiceInstructions", () => {
     );
   });
 
-  it("falls back to the default when the lookup fails, so the email still sends", async () => {
-    const throwing = {
-      from: () => {
-        throw new Error("boom");
-      },
-    } as unknown as SupabaseClient<Database>;
-    await expect(getInvoiceInstructions(throwing)).resolves.toBe(DEFAULT_INVOICE_INSTRUCTIONS);
+  it("falls back to the default when the lookup fails", async () => {
+    await expect(getInvoiceInstructions(throwingAdmin)).resolves.toBe(DEFAULT_INVOICE_INSTRUCTIONS);
     await expect(getInvoiceInstructions(erroringAdmin())).resolves.toBe(
       DEFAULT_INVOICE_INSTRUCTIONS,
     );

--- a/src/lib/club-settings.server.test.ts
+++ b/src/lib/club-settings.server.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/integrations/supabase/types";
+import { DEFAULT_INVOICE_INSTRUCTIONS } from "./validation";
+import { getInvoiceInstructions } from "./club-settings.server";
+
+/** Fake admin whose club_settings row returns `value`. */
+function settingsAdmin(value: string | null) {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () =>
+            Promise.resolve({ data: value == null ? null : { value }, error: null }),
+        }),
+      }),
+    }),
+  } as unknown as SupabaseClient<Database>;
+}
+
+describe("getInvoiceInstructions", () => {
+  it("returns the stored markdown when set", async () => {
+    await expect(getInvoiceInstructions(settingsAdmin("Pay to BSB 062-000"))).resolves.toBe(
+      "Pay to BSB 062-000",
+    );
+  });
+
+  it("falls back to the default when unset or blank", async () => {
+    await expect(getInvoiceInstructions(settingsAdmin(null))).resolves.toBe(
+      DEFAULT_INVOICE_INSTRUCTIONS,
+    );
+    await expect(getInvoiceInstructions(settingsAdmin("   "))).resolves.toBe(
+      DEFAULT_INVOICE_INSTRUCTIONS,
+    );
+  });
+
+  it("falls back to the default when the lookup throws", async () => {
+    const admin = {
+      from: () => {
+        throw new Error("boom");
+      },
+    } as unknown as SupabaseClient<Database>;
+    await expect(getInvoiceInstructions(admin)).resolves.toBe(DEFAULT_INVOICE_INSTRUCTIONS);
+  });
+});

--- a/src/lib/club-settings.server.ts
+++ b/src/lib/club-settings.server.ts
@@ -1,0 +1,35 @@
+// Reads of the `club_settings` key/value store that more than one flow needs.
+//
+// The club's receiving bank details (account name, BSB, PayID, whatever the
+// managers wrote) are one value under `invoice_payment_instructions`. They used
+// to live in `membership-email.server.ts` because the invoice email was the only
+// thing that rendered them; the member's own membership page shows them too now,
+// so they belong to neither caller.
+//
+// Server-only by convention rather than by dependency: nothing here imports a
+// secret, but every caller passes a service-role client, and the store is
+// manager-only under RLS.
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/integrations/supabase/types";
+import { DEFAULT_INVOICE_INSTRUCTIONS } from "@/lib/validation";
+
+type AdminClient = SupabaseClient<Database>;
+
+/**
+ * The manager-set markdown payment instructions shown on invoices. Falls back to
+ * a default until a manager customizes it. Never throws — a lookup hiccup falls
+ * back to the default rather than blocking the invoice email or hiding the
+ * payment details from a member who owes money.
+ */
+export async function getInvoiceInstructions(admin: AdminClient): Promise<string> {
+  try {
+    const { data } = await admin
+      .from("club_settings")
+      .select("value")
+      .eq("key", "invoice_payment_instructions")
+      .maybeSingle();
+    return data?.value?.trim() || DEFAULT_INVOICE_INSTRUCTIONS;
+  } catch {
+    return DEFAULT_INVOICE_INSTRUCTIONS;
+  }
+}

--- a/src/lib/club-settings.server.ts
+++ b/src/lib/club-settings.server.ts
@@ -1,41 +1,34 @@
 // Reads of the `club_settings` key/value store that more than one flow needs.
 //
-// The club's receiving bank details (account name, BSB, PayID, whatever the
-// managers wrote) are one value under `invoice_payment_instructions`. They used
-// to live in `membership-email.server.ts` because the invoice email was the only
-// thing that rendered them; the member's own membership page shows them too now,
-// so they belong to neither caller.
+// The club's bank account lives here under `invoice_payment_details`, as a JSON
+// blob of named fields (account name, BSB, account number, bank, plus the
+// overseas ones). Both the member's "how to pay" panel and the invoice email
+// render it, so the read belongs to neither of them.
+//
+// `invoice_payment_instructions` is the free text this replaced. Nothing
+// member-facing reads it any more; it survives only so the manager settings
+// screen can show what was there while the new fields are still empty.
 //
 // Server-only by convention rather than by dependency: nothing here imports a
 // secret, but every caller passes a service-role client, and the store is
 // manager-only under RLS.
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/integrations/supabase/types";
-import { DEFAULT_INVOICE_INSTRUCTIONS } from "@/lib/validation";
+import { DEFAULT_INVOICE_INSTRUCTIONS, parseClubPaymentDetails } from "@/lib/validation";
+import type { ClubPaymentDetails } from "@/lib/validation";
 
 type AdminClient = SupabaseClient<Database>;
 
-/**
- * The raw read. Three outcomes, deliberately kept apart:
- *
- * - `{ ok: true, value: "..." }` — a manager has written instructions.
- * - `{ ok: true, value: null }` — nobody ever has. A real, settled answer.
- * - `{ ok: false }` — the store could not be read at all.
- *
- * The last two collapse into the same fallback for the invoice email, but not
- * for the member's page: "here is the generic wording, the club never filled in
- * its account" and "we could not reach our own settings just now" are different
- * things to put in front of someone about to transfer money, and only the second
- * is worth telling them to go back to their email for. Never throws.
- */
-export async function readInvoiceInstructions(
+/** One key's raw value, or `ok: false` when the store could not be read. */
+async function readSetting(
   admin: AdminClient,
+  key: string,
 ): Promise<{ ok: boolean; value: string | null }> {
   try {
     const { data, error } = await admin
       .from("club_settings")
       .select("value")
-      .eq("key", "invoice_payment_instructions")
+      .eq("key", key)
       .maybeSingle();
     if (error) return { ok: false, value: null };
     return { ok: true, value: data?.value?.trim() || null };
@@ -45,12 +38,32 @@ export async function readInvoiceInstructions(
 }
 
 /**
- * The manager-set markdown payment instructions shown on invoices. Falls back to
- * a default until a manager customizes it. Never throws — a lookup hiccup falls
- * back to the default rather than blocking the invoice email or hiding the
- * payment details from a member who owes money.
+ * The club's bank account. Three outcomes, deliberately kept apart:
+ *
+ * - `{ ok: true, details: {...} }` — a complete set of account details.
+ * - `{ ok: true, details: null }` — nobody has published them yet, or what is
+ *   stored is not a complete set. A real, settled answer.
+ * - `{ ok: false, details: null }` — the store could not be read at all.
+ *
+ * The screens say different things about the last two, which is the whole reason
+ * this does not collapse them: "the club has not put its account details up yet,
+ * ask us" and "we could not reach our own settings just now, try again" send a
+ * member who is about to transfer money to two different places. Never throws.
+ */
+export async function readClubPaymentDetails(
+  admin: AdminClient,
+): Promise<{ ok: boolean; details: ClubPaymentDetails | null }> {
+  const { ok, value } = await readSetting(admin, "invoice_payment_details");
+  return { ok, details: ok ? parseClubPaymentDetails(value) : null };
+}
+
+/**
+ * The free text that used to be the payment instructions. Manager screen only:
+ * it is shown read-only, beside the empty form, so the values in it can be
+ * copied across into the fields. Falls back to the seeded default and never
+ * throws, because failing to show a reference copy is not worth an error.
  */
 export async function getInvoiceInstructions(admin: AdminClient): Promise<string> {
-  const { value } = await readInvoiceInstructions(admin);
+  const { value } = await readSetting(admin, "invoice_payment_instructions");
   return value ?? DEFAULT_INVOICE_INSTRUCTIONS;
 }

--- a/src/lib/club-settings.server.ts
+++ b/src/lib/club-settings.server.ts
@@ -16,20 +16,41 @@ import { DEFAULT_INVOICE_INSTRUCTIONS } from "@/lib/validation";
 type AdminClient = SupabaseClient<Database>;
 
 /**
+ * The raw read. Three outcomes, deliberately kept apart:
+ *
+ * - `{ ok: true, value: "..." }` — a manager has written instructions.
+ * - `{ ok: true, value: null }` — nobody ever has. A real, settled answer.
+ * - `{ ok: false }` — the store could not be read at all.
+ *
+ * The last two collapse into the same fallback for the invoice email, but not
+ * for the member's page: "here is the generic wording, the club never filled in
+ * its account" and "we could not reach our own settings just now" are different
+ * things to put in front of someone about to transfer money, and only the second
+ * is worth telling them to go back to their email for. Never throws.
+ */
+export async function readInvoiceInstructions(
+  admin: AdminClient,
+): Promise<{ ok: boolean; value: string | null }> {
+  try {
+    const { data, error } = await admin
+      .from("club_settings")
+      .select("value")
+      .eq("key", "invoice_payment_instructions")
+      .maybeSingle();
+    if (error) return { ok: false, value: null };
+    return { ok: true, value: data?.value?.trim() || null };
+  } catch {
+    return { ok: false, value: null };
+  }
+}
+
+/**
  * The manager-set markdown payment instructions shown on invoices. Falls back to
  * a default until a manager customizes it. Never throws — a lookup hiccup falls
  * back to the default rather than blocking the invoice email or hiding the
  * payment details from a member who owes money.
  */
 export async function getInvoiceInstructions(admin: AdminClient): Promise<string> {
-  try {
-    const { data } = await admin
-      .from("club_settings")
-      .select("value")
-      .eq("key", "invoice_payment_instructions")
-      .maybeSingle();
-    return data?.value?.trim() || DEFAULT_INVOICE_INSTRUCTIONS;
-  } catch {
-    return DEFAULT_INVOICE_INSTRUCTIONS;
-  }
+  const { value } = await readInvoiceInstructions(admin);
+  return value ?? DEFAULT_INVOICE_INSTRUCTIONS;
 }

--- a/src/lib/email-templates/membership-payment.test.tsx
+++ b/src/lib/email-templates/membership-payment.test.tsx
@@ -1,0 +1,118 @@
+// The invoice email and the "how to pay" panel are two views of ONE set of
+// values, kept in step by walking the same field list. That is the rule these
+// tests exist to hold: the sharing is real, but nothing asserted the email
+// actually rendered it, so a change to the list or to this template could quietly
+// leave the two quoting different bank details.
+import * as React from "react";
+import { render } from "@react-email/render";
+import { describe, expect, it } from "vitest";
+
+import { MembershipPaymentEmail } from "./membership-payment";
+import { CLUB_ACCOUNT_FIELDS, clubPaymentDetailsSchema } from "@/lib/validation";
+
+const DETAILS = clubPaymentDetailsSchema.parse({
+  account_name: "UTS Jitsu Club Inc",
+  bsb: "062000",
+  account_number: "12345678",
+  bank_name: "Commonwealth Bank of Australia",
+});
+
+const OVERSEAS = clubPaymentDetailsSchema.parse({
+  ...DETAILS,
+  swift_bic: "CTBAAU2S",
+  bank_address: "Sydney NSW 2000, Australia",
+  account_holder_address: "1 Broadway, Ultimo NSW 2007, Australia",
+});
+
+const PROPS = {
+  siteName: "UTS Jitsu",
+  siteUrl: "https://jitsu.au",
+  memberName: "Ada",
+  planName: "Semester 2 2026",
+  amount: "$245",
+  reference: "UTSJ-LOVE-A1B2",
+  details: DETAILS,
+  membershipUrl: "https://jitsu.au/membership",
+};
+
+// react-dom/server splits interpolated text with <!-- --> markers, so compare
+// against the visible copy rather than the raw markup.
+const visibleText = (html: string) =>
+  html
+    .replace(/<!--.*?-->/g, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const renderHtml = (props: object = {}) =>
+  render(React.createElement(MembershipPaymentEmail, { ...PROPS, ...props }));
+
+describe("MembershipPaymentEmail", () => {
+  it("carries the amount, the reference and the club's account", async () => {
+    const text = visibleText(await renderHtml());
+    expect(text).toContain("$245");
+    expect(text).toContain("UTSJ-LOVE-A1B2");
+    expect(text).toContain("UTS Jitsu Club Inc");
+    expect(text).toContain("12345678");
+    expect(text).toContain("Commonwealth Bank of Australia");
+  });
+
+  // The BSB is stored as six bare digits and hyphenated in exactly one place.
+  // If the email ever printed the raw value, it would disagree with both the
+  // page and what a member copied off it.
+  it("prints the BSB hyphenated, the same as the page and the clipboard", async () => {
+    const text = visibleText(await renderHtml());
+    expect(text).toContain("062-000");
+    expect(text).not.toContain("062000");
+  });
+
+  // Adding a field to the shared list without teaching the email about it should
+  // be a failing test, not a silent divergence between the email and the page.
+  it("renders every field the shared list defines", async () => {
+    const text = visibleText(await renderHtml());
+    for (const field of CLUB_ACCOUNT_FIELDS) {
+      expect(text).toContain(field.label);
+    }
+  });
+
+  it("adds the overseas block, and the warning about fees, when there is one", async () => {
+    const text = visibleText(await renderHtml({ details: OVERSEAS }));
+    expect(text).toContain("Paying from overseas");
+    expect(text).toContain("CTBAAU2S");
+    expect(text).toContain("Sydney NSW 2000, Australia");
+    expect(text).toContain("1 Broadway, Ultimo NSW 2007, Australia");
+    // Not decoration: a fee-shortened transfer does not auto-reconcile.
+    expect(text).toMatch(/take fees out of an international transfer/i);
+  });
+
+  it("leaves the overseas block out entirely when the club has not filled it in", async () => {
+    const text = visibleText(await renderHtml());
+    expect(text).not.toContain("Paying from overseas");
+    expect(text).not.toMatch(/SWIFT/i);
+  });
+
+  it("renders the club's note when there is one", async () => {
+    const withNote = { ...DETAILS, note: "Prefer PayID? Send to pay@jitsu.au." };
+    const text = visibleText(await renderHtml({ details: withNote }));
+    expect(text).toContain("Prefer PayID? Send to pay@jitsu.au.");
+  });
+
+  // Between this shipping and a manager filling the form in, there is no account
+  // to name. The email must say so rather than print an empty block.
+  it("says the details are not published yet rather than printing an empty block", async () => {
+    const text = visibleText(await renderHtml({ details: null }));
+    expect(text).toMatch(/have not published our account details yet/i);
+    // The member's own data still renders: they can see what they owe.
+    expect(text).toContain("$245");
+    expect(text).toContain("UTSJ-LOVE-A1B2");
+    // But nothing bank-shaped leaks through.
+    expect(text).not.toContain("062-000");
+    expect(text).not.toContain("12345678");
+    expect(text).not.toContain("UTS Jitsu Club Inc");
+  });
+
+  it("points at the page, where the values have copy buttons", async () => {
+    const html = await renderHtml();
+    expect(html).toContain("https://jitsu.au/membership");
+  });
+});

--- a/src/lib/email-templates/membership-payment.tsx
+++ b/src/lib/email-templates/membership-payment.tsx
@@ -13,6 +13,13 @@ import {
   Text,
 } from "@react-email/components";
 import ReactMarkdown from "react-markdown";
+import {
+  CLUB_ACCOUNT_FIELDS,
+  CLUB_INTERNATIONAL_FIELDS,
+  clubPaymentFieldValue,
+  hasInternationalDetails,
+} from "@/lib/validation";
+import type { ClubPaymentDetails } from "@/lib/validation";
 
 interface MembershipPaymentEmailProps {
   siteName: string;
@@ -21,15 +28,36 @@ interface MembershipPaymentEmailProps {
   planName: string;
   amount: string;
   reference: string;
-  /** Manager-set markdown payment instructions (bank details, PayID, etc.). */
-  instructions: string;
+  /** The club's bank account, or null when it has not published one. */
+  details: ClubPaymentDetails | null;
+  /** Where a member can read the same details on the site. */
+  membershipUrl: string;
 }
 
 /**
- * The membership invoice. Carries the computed amount + unique payment reference
- * (so the transfer auto-reconciles) and renders the club's manager-set markdown
- * payment instructions.
+ * The club's account, as labelled rows. Same fields, same order and same source
+ * as the "how to pay" panel on `/membership`, walked from the same list so the
+ * email and the page cannot come to quote different bank details.
+ *
+ * No copy buttons here: this is an email, and every client renders it
+ * differently. The page is where copying works, which is why the email links to
+ * it.
  */
+const AccountRows = ({ details }: { details: ClubPaymentDetails }) => (
+  <>
+    {CLUB_ACCOUNT_FIELDS.map((field) => {
+      const value = clubPaymentFieldValue(details, field.key);
+      if (!value) return null;
+      return (
+        <React.Fragment key={field.key}>
+          <Text style={rowLabel}>{field.label}</Text>
+          <Text style={field.mono ? rowValueMono : rowValue}>{value}</Text>
+        </React.Fragment>
+      );
+    })}
+  </>
+);
+
 export const MembershipPaymentEmail = ({
   siteName,
   siteUrl,
@@ -37,7 +65,8 @@ export const MembershipPaymentEmail = ({
   planName,
   amount,
   reference,
-  instructions,
+  details,
+  membershipUrl,
 }: MembershipPaymentEmailProps) => (
   <Html lang="en" dir="ltr">
     <Head />
@@ -63,14 +92,57 @@ export const MembershipPaymentEmail = ({
           <Text style={reference_}>{reference}</Text>
         </Section>
 
-        <Section style={instructionsBox}>
-          <ReactMarkdown>{instructions}</ReactMarkdown>
-        </Section>
+        {details ? (
+          <Section style={instructionsBox}>
+            <AccountRows details={details} />
+            {hasInternationalDetails(details) && (
+              <>
+                <Hr style={hr} />
+                <Text style={sectionHeading}>Paying from overseas</Text>
+                {CLUB_INTERNATIONAL_FIELDS.map((field) => {
+                  const value = clubPaymentFieldValue(details, field.key);
+                  if (!value) return null;
+                  return (
+                    <React.Fragment key={field.key}>
+                      <Text style={rowLabel}>{field.label}</Text>
+                      <Text style={field.mono ? rowValueMono : rowValue}>{value}</Text>
+                    </React.Fragment>
+                  );
+                })}
+                <Text style={smallNote}>
+                  Banks along the way can take fees out of an international transfer, so ask yours
+                  to send the full amount. If it arrives short we will still sort it out, it just
+                  takes us a little longer.
+                </Text>
+              </>
+            )}
+            {details.note && (
+              <>
+                <Hr style={hr} />
+                <ReactMarkdown>{details.note}</ReactMarkdown>
+              </>
+            )}
+          </Section>
+        ) : (
+          <Section style={instructionsBox}>
+            <Text style={text}>
+              We have not published our account details yet. Reply to this email and we'll send them
+              straight over.
+            </Text>
+          </Section>
+        )}
 
         <Text style={text}>
           <strong>Please include the payment reference in your transfer description.</strong> It's
           how we match your payment to your membership. Once we see it, we'll activate your
           membership and email you a confirmation.
+        </Text>
+        <Text style={text}>
+          You can see these details any time on your{" "}
+          <Link href={membershipUrl} style={link}>
+            membership page
+          </Link>
+          , where each one has a copy button.
         </Text>
         <Text style={footer}>
           Paying a different way or already transferred? Just reply to this email and we'll sort it
@@ -115,6 +187,20 @@ const rowValue = {
   fontWeight: "bold" as const,
   margin: "2px 0 0",
 };
+// Digit strings people transcribe into a banking app. Monospace so a misread
+// character is visible, and letter-spaced for the same reason.
+const rowValueMono = {
+  ...rowValue,
+  fontFamily: "'Courier New', Courier, monospace",
+  letterSpacing: "0.04em",
+};
+const sectionHeading = {
+  fontSize: "13px",
+  color: "#222222",
+  fontWeight: "bold" as const,
+  margin: "0 0 4px",
+};
+const smallNote = { fontSize: "12px", color: "#777777", margin: "12px 0 0", lineHeight: "1.5" };
 const reference_ = {
   fontSize: "20px",
   color: "#008eaa",

--- a/src/lib/invoice-markdown.test.tsx
+++ b/src/lib/invoice-markdown.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ReactMarkdown from "react-markdown";
+import { invoiceMarkdownComponents } from "./invoice-markdown";
+
+function renderMarkdown(markdown: string) {
+  return render(<ReactMarkdown components={invoiceMarkdownComponents}>{markdown}</ReactMarkdown>);
+}
+
+describe("invoiceMarkdownComponents", () => {
+  // Bank details are typically written as a list. With no typography plugin in
+  // this repo, an unstyled list loses its bullets and its spacing, which is the
+  // difference between reading an account number and squinting at a blob.
+  it("styles the list a set of bank details is usually written as", () => {
+    renderMarkdown("Pay to:\n\n- Account: UTS Jitsu Club\n- BSB: 062-000\n- Account: 1234 5678");
+    expect(screen.getByText("Pay to:").className).toContain("leading-relaxed");
+    expect(screen.getByRole("list").className).toContain("list-disc");
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  // The block sits under the card's own "How to pay" title.
+  it("shifts headings down so nothing in the instructions outranks the card", () => {
+    renderMarkdown("# Bank transfer\n\n### PayID");
+    expect(screen.queryByRole("heading", { level: 1 })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 4, name: "Bank transfer" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 5, name: "PayID" })).toBeInTheDocument();
+  });
+
+  it("keeps emphasis a manager used to make a number stand out", () => {
+    renderMarkdown("BSB **062-000**, PayID `pay@jitsu.au`");
+    expect(screen.getByText("062-000").className).toContain("font-semibold");
+    expect(screen.getByText("pay@jitsu.au").className).toContain("font-mono");
+  });
+
+  it("sends a link in the instructions to a new tab", () => {
+    renderMarkdown("[Our bank](https://example.com)");
+    const link = screen.getByRole("link", { name: "Our bank" });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+});

--- a/src/lib/invoice-markdown.tsx
+++ b/src/lib/invoice-markdown.tsx
@@ -1,0 +1,71 @@
+// Styled `react-markdown` element overrides for the club's payment
+// instructions: the account name, BSB, PayID or note a manager writes at
+// `/manager/settings`.
+//
+// The site has no `@tailwindcss/typography` plugin, so the `prose` classes used
+// elsewhere in this codebase are silently inert and Tailwind's preflight then
+// strips list bullets and paragraph spacing entirely — which on this particular
+// block would run a set of bank details together into one line for somebody
+// trying to copy them into a banking app. `blog-markdown.tsx` solves the same
+// problem for post bodies; this map is the compact version, sized to sit inside
+// a card rather than to carry an article.
+//
+// Used by the member's "how to pay" panel AND by the manager's preview of it,
+// so a manager editing the instructions is looking at what the member gets.
+import type { Components } from "react-markdown";
+
+export const invoiceMarkdownComponents: Components = {
+  // Headings shift down to h4/h5: this block sits under the card's own title,
+  // so a manager's `#` must not outrank it in the page's heading outline.
+  h1: ({ children }) => (
+    <h4 className="mb-1.5 mt-4 text-base font-semibold text-foreground first:mt-0">{children}</h4>
+  ),
+  h2: ({ children }) => (
+    <h4 className="mb-1.5 mt-4 text-base font-semibold text-foreground first:mt-0">{children}</h4>
+  ),
+  h3: ({ children }) => (
+    <h5 className="mb-1.5 mt-4 text-sm font-semibold text-foreground first:mt-0">{children}</h5>
+  ),
+  h4: ({ children }) => (
+    <h5 className="mb-1.5 mt-4 text-sm font-semibold text-foreground first:mt-0">{children}</h5>
+  ),
+  h5: ({ children }) => (
+    <h6 className="mb-1.5 mt-4 text-sm font-semibold text-foreground first:mt-0">{children}</h6>
+  ),
+  h6: ({ children }) => (
+    <h6 className="mb-1.5 mt-4 text-sm font-semibold text-foreground first:mt-0">{children}</h6>
+  ),
+  p: ({ children }) => <p className="mb-3 leading-relaxed last:mb-0">{children}</p>,
+  ul: ({ children }) => <ul className="mb-3 ml-5 list-disc space-y-1 last:mb-0">{children}</ul>,
+  ol: ({ children }) => <ol className="mb-3 ml-5 list-decimal space-y-1 last:mb-0">{children}</ol>,
+  li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+  a: ({ children, href }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="break-words text-primary underline underline-offset-2 hover:no-underline"
+    >
+      {children}
+    </a>
+  ),
+  // Account numbers and BSBs are digit strings people transcribe. Bold and
+  // monospace are the two ways a manager can make one stand out, so both have
+  // to survive into what the member reads.
+  strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
+  em: ({ children }) => <em className="italic">{children}</em>,
+  code: ({ children }) => (
+    <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm text-foreground">
+      {children}
+    </code>
+  ),
+  pre: ({ children }) => (
+    <pre className="mb-3 overflow-x-auto rounded-lg bg-muted p-3 text-sm last:mb-0">{children}</pre>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="mb-3 border-l-2 border-primary/30 pl-3 italic last:mb-0">
+      {children}
+    </blockquote>
+  ),
+  hr: () => <hr className="my-4 border-border" />,
+};

--- a/src/lib/membership-email.server.test.ts
+++ b/src/lib/membership-email.server.test.ts
@@ -1,52 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/integrations/supabase/types";
-import { DEFAULT_INVOICE_INSTRUCTIONS } from "./validation";
 import {
-  getInvoiceInstructions,
   sendMembershipActivatedEmail,
   sendMembershipPaymentEmail,
 } from "./membership-email.server";
-
-/** Fake admin whose club_settings row returns `value`. */
-function settingsAdmin(value: string | null) {
-  return {
-    from: () => ({
-      select: () => ({
-        eq: () => ({
-          maybeSingle: () =>
-            Promise.resolve({ data: value == null ? null : { value }, error: null }),
-        }),
-      }),
-    }),
-  } as unknown as SupabaseClient<Database>;
-}
-
-describe("getInvoiceInstructions", () => {
-  it("returns the stored markdown when set", async () => {
-    await expect(getInvoiceInstructions(settingsAdmin("Pay to BSB 062-000"))).resolves.toBe(
-      "Pay to BSB 062-000",
-    );
-  });
-
-  it("falls back to the default when unset or blank", async () => {
-    await expect(getInvoiceInstructions(settingsAdmin(null))).resolves.toBe(
-      DEFAULT_INVOICE_INSTRUCTIONS,
-    );
-    await expect(getInvoiceInstructions(settingsAdmin("   "))).resolves.toBe(
-      DEFAULT_INVOICE_INSTRUCTIONS,
-    );
-  });
-
-  it("falls back to the default when the lookup throws", async () => {
-    const admin = {
-      from: () => {
-        throw new Error("boom");
-      },
-    } as unknown as SupabaseClient<Database>;
-    await expect(getInvoiceInstructions(admin)).resolves.toBe(DEFAULT_INVOICE_INSTRUCTIONS);
-  });
-});
 
 describe("membership emails without an API key", () => {
   const original = process.env.LOVABLE_API_KEY;

--- a/src/lib/membership-email.server.ts
+++ b/src/lib/membership-email.server.ts
@@ -12,7 +12,7 @@ import { MembershipPaymentEmail } from "@/lib/email-templates/membership-payment
 import { MembershipActivatedEmail } from "@/lib/email-templates/membership-activated";
 import { MembershipNotificationEmail } from "@/lib/email-templates/membership-notification";
 import { getManagerEmails } from "@/lib/waiver-email.server";
-import { getInvoiceInstructions } from "@/lib/club-settings.server";
+import { readClubPaymentDetails } from "@/lib/club-settings.server";
 
 const SITE_NAME = "UTS Jitsu";
 // Must match SENDER_DOMAIN so DKIM/SPF align under DMARC.
@@ -87,7 +87,9 @@ export async function sendMembershipPaymentEmail({
     return { sent: [], skipped: true };
   }
   const sendUrl = process.env.LOVABLE_SEND_URL;
-  const instructions = await getInvoiceInstructions(admin);
+  // Null covers both "never published" and "could not read": either way the
+  // email cannot name an account, and it says so rather than inventing one.
+  const { details } = await readClubPaymentDetails(admin);
 
   const memberEl = React.createElement(MembershipPaymentEmail, {
     siteName: SITE_NAME,
@@ -97,7 +99,8 @@ export async function sendMembershipPaymentEmail({
     planName,
     amount,
     reference,
-    instructions,
+    details,
+    membershipUrl: ACCOUNT_URL,
   });
   const [memberHtml, memberText, managers] = await Promise.all([
     render(memberEl),

--- a/src/lib/membership-email.server.ts
+++ b/src/lib/membership-email.server.ts
@@ -3,10 +3,6 @@
 // Pulls in server-only dependencies (the Lovable send API, the React-email
 // renderer) so it must never reach the client bundle — it is named `*.server.ts`
 // and only ever lazy-imported from inside server-function handlers.
-//
-// The club's receiving bank details live here (server-side only) because they
-// are only needed to render the payment-instructions email — they are never
-// returned to the browser.
 import * as React from "react";
 import { render } from "@react-email/render";
 import { sendLovableEmail } from "@lovable.dev/email-js";
@@ -16,7 +12,7 @@ import { MembershipPaymentEmail } from "@/lib/email-templates/membership-payment
 import { MembershipActivatedEmail } from "@/lib/email-templates/membership-activated";
 import { MembershipNotificationEmail } from "@/lib/email-templates/membership-notification";
 import { getManagerEmails } from "@/lib/waiver-email.server";
-import { DEFAULT_INVOICE_INSTRUCTIONS } from "@/lib/validation";
+import { getInvoiceInstructions } from "@/lib/club-settings.server";
 
 const SITE_NAME = "UTS Jitsu";
 // Must match SENDER_DOMAIN so DKIM/SPF align under DMARC.
@@ -30,25 +26,6 @@ export const MEMBERSHIP_REVIEW_URL = `${SITE_URL}/manager/memberships`;
 const ACCOUNT_URL = `${SITE_URL}/membership`;
 
 type AdminClient = SupabaseClient<Database>;
-
-/**
- * The manager-set markdown payment instructions shown on invoices. Read from
- * the `club_settings` store; falls back to a default until a manager customizes
- * it. Never throws — a lookup hiccup falls back to the default so it can't block
- * the invoice email.
- */
-export async function getInvoiceInstructions(admin: AdminClient): Promise<string> {
-  try {
-    const { data } = await admin
-      .from("club_settings")
-      .select("value")
-      .eq("key", "invoice_payment_instructions")
-      .maybeSingle();
-    return data?.value?.trim() || DEFAULT_INVOICE_INSTRUCTIONS;
-  } catch {
-    return DEFAULT_INVOICE_INSTRUCTIONS;
-  }
-}
 
 async function sendOne(opts: {
   apiKey: string;

--- a/src/lib/membership.functions.ts
+++ b/src/lib/membership.functions.ts
@@ -765,15 +765,20 @@ export async function listMembershipPlanRows(
  * Readable by any signed-in person, not only one with an invoice outstanding:
  * these are the club's own receiving details, they are already emailed to
  * whoever owes money, and a member who paid last week still has reason to check
- * where they sent it. Never throws — `getInvoiceInstructions` falls back to the
- * default rather than leaving someone who owes money with nothing to pay to.
+ * where they sent it.
+ *
+ * Never throws, but does report a failed read as `null` rather than as the
+ * built-in default, so the page can say "we could not load these" instead of
+ * quietly showing generic wording that names no bank account. A club that has
+ * simply never set them gets the default, exactly as the email does.
  */
 export const getPaymentInstructions = createServerFn({ method: "GET" })
   .middleware([requireSupabaseAuth])
   .handler(async () => {
     const admin = await adminClient();
-    const { getInvoiceInstructions } = await import("@/lib/club-settings.server");
-    return { instructions: await getInvoiceInstructions(admin) };
+    const { readInvoiceInstructions } = await import("@/lib/club-settings.server");
+    const { ok, value } = await readInvoiceInstructions(admin);
+    return { instructions: ok ? (value ?? DEFAULT_INVOICE_INSTRUCTIONS) : null };
   });
 
 // ---- Manager: club settings (invoice payment instructions) ----

--- a/src/lib/membership.functions.ts
+++ b/src/lib/membership.functions.ts
@@ -754,6 +754,28 @@ export async function listMembershipPlanRows(
 // the membership half: `listMembershipPlanRows` above, and the rule that reads
 // it (`sellableWindowNotifications`, in validation.ts).
 
+// ---- Member: how to pay ----
+/**
+ * The club's payment instructions (account name, BSB, PayID — whatever a
+ * manager wrote at `/manager/settings`), for the member's own membership page.
+ *
+ * The same value the invoice email renders, read through the same helper, so
+ * the page and the email can never quote different bank details.
+ *
+ * Readable by any signed-in person, not only one with an invoice outstanding:
+ * these are the club's own receiving details, they are already emailed to
+ * whoever owes money, and a member who paid last week still has reason to check
+ * where they sent it. Never throws — `getInvoiceInstructions` falls back to the
+ * default rather than leaving someone who owes money with nothing to pay to.
+ */
+export const getPaymentInstructions = createServerFn({ method: "GET" })
+  .middleware([requireSupabaseAuth])
+  .handler(async () => {
+    const admin = await adminClient();
+    const { getInvoiceInstructions } = await import("@/lib/club-settings.server");
+    return { instructions: await getInvoiceInstructions(admin) };
+  });
+
 // ---- Manager: club settings (invoice payment instructions) ----
 export const getClubSettings = createServerFn({ method: "GET" })
   .middleware([requireSupabaseAuth])

--- a/src/lib/membership.functions.ts
+++ b/src/lib/membership.functions.ts
@@ -3,7 +3,6 @@ import { requireSupabaseAuth } from "@/integrations/supabase/auth-middleware";
 import {
   buildPaymentReference,
   computeMembershipPrice,
-  DEFAULT_INVOICE_INSTRUCTIONS,
   formatCents,
   importBankStatementSchema,
   isUtsStudent,
@@ -756,46 +755,49 @@ export async function listMembershipPlanRows(
 
 // ---- Member: how to pay ----
 /**
- * The club's payment instructions (account name, BSB, PayID — whatever a
- * manager wrote at `/manager/settings`), for the member's own membership page.
- *
- * The same value the invoice email renders, read through the same helper, so
- * the page and the email can never quote different bank details.
+ * The club's bank account, for the member's own membership page: the same
+ * details the invoice email renders, read through the same helper, so the page
+ * and the email can never quote different bank details.
  *
  * Readable by any signed-in person, not only one with an invoice outstanding:
  * these are the club's own receiving details, they are already emailed to
  * whoever owes money, and a member who paid last week still has reason to check
  * where they sent it.
  *
- * Never throws, but does report a failed read as `null` rather than as the
- * built-in default, so the page can say "we could not load these" instead of
- * quietly showing generic wording that names no bank account. A club that has
- * simply never set them gets the default, exactly as the email does.
+ * Never throws. It reports a failed read (`ok: false`) separately from details
+ * that were never published, because the page says different things about them.
  */
 export const getPaymentInstructions = createServerFn({ method: "GET" })
   .middleware([requireSupabaseAuth])
   .handler(async () => {
     const admin = await adminClient();
-    const { readInvoiceInstructions } = await import("@/lib/club-settings.server");
-    const { ok, value } = await readInvoiceInstructions(admin);
-    return { instructions: ok ? (value ?? DEFAULT_INVOICE_INSTRUCTIONS) : null };
+    const { readClubPaymentDetails } = await import("@/lib/club-settings.server");
+    return await readClubPaymentDetails(admin);
   });
 
-// ---- Manager: club settings (invoice payment instructions) ----
+// ---- Manager: club settings (the club's bank account) ----
+/**
+ * The form's current values, plus whatever free text is left in the old
+ * `invoice_payment_instructions` row. That legacy string is shown read-only
+ * beside an empty form so a manager can copy the account details across; nothing
+ * member-facing renders it any more.
+ */
 export const getClubSettings = createServerFn({ method: "GET" })
   .middleware([requireSupabaseAuth])
   .handler(async ({ context }) => {
     await requireManager(context);
     const admin = await adminClient();
-    const { data, error } = await admin
-      .from("club_settings")
-      .select("value")
-      .eq("key", "invoice_payment_instructions")
-      .maybeSingle();
-    if (error) throw new Error(error.message);
-    return {
-      invoice_payment_instructions: data?.value?.trim() ? data.value : DEFAULT_INVOICE_INSTRUCTIONS,
-    };
+    const { readClubPaymentDetails, getInvoiceInstructions } =
+      await import("@/lib/club-settings.server");
+    const [{ ok, details }, legacyInstructions] = await Promise.all([
+      readClubPaymentDetails(admin),
+      getInvoiceInstructions(admin),
+    ]);
+    // A manager editing the club's account must not be shown an empty form when
+    // the truth is "we could not read it": saving would then overwrite real
+    // details with blanks.
+    if (!ok) throw new Error("Could not read the club settings. Try again.");
+    return { details, legacy_instructions: legacyInstructions };
   });
 
 export const saveClubSettings = createServerFn({ method: "POST" })
@@ -806,8 +808,8 @@ export const saveClubSettings = createServerFn({ method: "POST" })
     const admin = await adminClient();
     const { error } = await admin.from("club_settings").upsert(
       {
-        key: "invoice_payment_instructions",
-        value: data.invoice_payment_instructions,
+        key: "invoice_payment_details",
+        value: JSON.stringify(data),
         updated_at: new Date().toISOString(),
         updated_by: context.userId,
       },

--- a/src/lib/membership.test.ts
+++ b/src/lib/membership.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   buildPaymentReference,
+  clubPaymentDetailsSchema,
+  clubPaymentFieldValue,
   computeMembershipPrice,
   deriveLifecycleStatus,
+  formatBsb,
   formatCents,
+  hasInternationalDetails,
+  parseClubPaymentDetails,
   haystackContainsRef,
   insuranceSelection,
   matchesMembershipReference,
@@ -17,7 +22,6 @@ import {
   strandedPlanFields,
   planMembershipWindow,
   sanitizeSurname,
-  saveClubSettingsSchema,
   savePlanSchema,
   sellablePlans,
   sellableWindowNotifications,
@@ -671,25 +675,139 @@ describe("sellableWindowNotifications", () => {
   });
 });
 
-describe("saveClubSettingsSchema", () => {
-  it("accepts markdown instructions", () => {
-    const r = saveClubSettingsSchema.safeParse({
-      invoice_payment_instructions: "**BSB** 062-000\n**Acc** 1234 5678",
-    });
-    expect(r.success).toBe(true);
+describe("clubPaymentDetailsSchema", () => {
+  const account = (overrides: Record<string, unknown> = {}) => ({
+    account_name: "UTS Jitsu Club Inc",
+    bsb: "062-000",
+    account_number: "12345678",
+    bank_name: "Commonwealth Bank of Australia",
+    ...overrides,
   });
 
-  it("accepts empty instructions", () => {
-    expect(saveClubSettingsSchema.safeParse({ invoice_payment_instructions: "" }).success).toBe(
-      true,
+  it("accepts an account with only the four required fields", () => {
+    const r = clubPaymentDetailsSchema.safeParse(account());
+    expect(r.success).toBe(true);
+    // The optional fields settle to "" rather than undefined, so every renderer
+    // can read them without a null check.
+    expect(r.success && r.data.swift_bic).toBe("");
+    expect(r.success && r.data.note).toBe("");
+  });
+
+  it("stores a BSB as six digits however it was typed", () => {
+    for (const typed of ["062-000", "062000", "062 000"]) {
+      const r = clubPaymentDetailsSchema.safeParse(account({ bsb: typed }));
+      expect(r.success && r.data.bsb).toBe("062000");
+    }
+  });
+
+  it("rejects a BSB that is not six digits", () => {
+    expect(clubPaymentDetailsSchema.safeParse(account({ bsb: "06200" })).success).toBe(false);
+    expect(clubPaymentDetailsSchema.safeParse(account({ bsb: "0620001" })).success).toBe(false);
+    expect(clubPaymentDetailsSchema.safeParse(account({ bsb: "abcdef" })).success).toBe(false);
+  });
+
+  it("strips spaces from an account number and rejects a non-numeric one", () => {
+    const spaced = clubPaymentDetailsSchema.safeParse(account({ account_number: "1234 5678" }));
+    expect(spaced.success && spaced.data.account_number).toBe("12345678");
+    expect(clubPaymentDetailsSchema.safeParse(account({ account_number: "12-34" })).success).toBe(
+      false,
+    );
+    expect(clubPaymentDetailsSchema.safeParse(account({ account_number: "123" })).success).toBe(
+      false,
     );
   });
 
-  it("rejects instructions over the length cap", () => {
-    const r = saveClubSettingsSchema.safeParse({
-      invoice_payment_instructions: "x".repeat(5001),
-    });
-    expect(r.success).toBe(false);
+  // A half-filled account is worse than none: it looks payable, and somebody
+  // copies what is there and guesses the rest.
+  it("refuses a partly filled account", () => {
+    for (const missing of ["account_name", "bsb", "account_number", "bank_name"] as const) {
+      expect(clubPaymentDetailsSchema.safeParse(account({ [missing]: "" })).success).toBe(false);
+    }
+  });
+
+  // 8 or 11 characters, never 9 or 10: the branch part is three characters or
+  // it is absent.
+  it("accepts an 8 or 11 character SWIFT/BIC and rejects the shapes in between", () => {
+    expect(clubPaymentDetailsSchema.safeParse(account({ swift_bic: "CTBAAU2S" })).success).toBe(
+      true,
+    );
+    expect(clubPaymentDetailsSchema.safeParse(account({ swift_bic: "CTBAAU2SXXX" })).success).toBe(
+      true,
+    );
+    expect(clubPaymentDetailsSchema.safeParse(account({ swift_bic: "CTBAAU2SX" })).success).toBe(
+      false,
+    );
+    expect(clubPaymentDetailsSchema.safeParse(account({ swift_bic: "12BAAU2S" })).success).toBe(
+      false,
+    );
+  });
+
+  it("uppercases a SWIFT/BIC and treats blank as simply not given", () => {
+    const r = clubPaymentDetailsSchema.safeParse(account({ swift_bic: "ctbaau2s" }));
+    expect(r.success && r.data.swift_bic).toBe("CTBAAU2S");
+    expect(clubPaymentDetailsSchema.safeParse(account({ swift_bic: "" })).success).toBe(true);
+  });
+});
+
+describe("formatBsb", () => {
+  it("hyphenates six digits the way every Australian bank prints them", () => {
+    expect(formatBsb("062000")).toBe("062-000");
+  });
+
+  it("leaves anything that is not six digits alone rather than mangling it", () => {
+    expect(formatBsb("06200")).toBe("06200");
+    expect(formatBsb("")).toBe("");
+  });
+});
+
+describe("parseClubPaymentDetails", () => {
+  const stored = JSON.stringify({
+    account_name: "UTS Jitsu Club Inc",
+    bsb: "062000",
+    account_number: "12345678",
+    bank_name: "Commonwealth Bank of Australia",
+  });
+
+  it("reads back a stored account", () => {
+    expect(parseClubPaymentDetails(stored)?.account_name).toBe("UTS Jitsu Club Inc");
+  });
+
+  // Everything that is not a complete account is the same answer: not
+  // published. Guessing at a partial blob would put a wrong account number in
+  // front of somebody about to transfer money.
+  it("returns null for anything that is not a complete account", () => {
+    expect(parseClubPaymentDetails(null)).toBeNull();
+    expect(parseClubPaymentDetails("")).toBeNull();
+    expect(parseClubPaymentDetails("   ")).toBeNull();
+    expect(parseClubPaymentDetails("not json at all")).toBeNull();
+    expect(parseClubPaymentDetails("[]")).toBeNull();
+    // The free text this replaced, left in the wrong key.
+    expect(parseClubPaymentDetails("**BSB** 062-000")).toBeNull();
+    expect(parseClubPaymentDetails(JSON.stringify({ account_name: "UTS Jitsu" }))).toBeNull();
+  });
+});
+
+describe("clubPaymentFieldValue / hasInternationalDetails", () => {
+  const details = clubPaymentDetailsSchema.parse({
+    account_name: "UTS Jitsu Club Inc",
+    bsb: "062000",
+    account_number: "12345678",
+    bank_name: "Commonwealth Bank of Australia",
+  });
+
+  // The one field where what is shown differs from what is stored. It has to
+  // differ in exactly one place, or the hyphen ends up on screen but not on the
+  // clipboard.
+  it("hyphenates the BSB and passes every other field through untouched", () => {
+    expect(clubPaymentFieldValue(details, "bsb")).toBe("062-000");
+    expect(clubPaymentFieldValue(details, "account_number")).toBe("12345678");
+    expect(clubPaymentFieldValue(details, "account_name")).toBe("UTS Jitsu Club Inc");
+  });
+
+  it("knows when there is nothing to show an overseas payer", () => {
+    expect(hasInternationalDetails(details)).toBe(false);
+    expect(hasInternationalDetails({ ...details, swift_bic: "CTBAAU2S" })).toBe(true);
+    expect(hasInternationalDetails({ ...details, bank_address: "Sydney NSW" })).toBe(true);
   });
 });
 

--- a/src/lib/membership.test.ts
+++ b/src/lib/membership.test.ts
@@ -24,6 +24,7 @@ import {
   sessionDateTag,
   stableCode,
   startMembershipSchema,
+  unpaidInvoices,
 } from "./validation";
 
 describe("computeMembershipPrice", () => {
@@ -505,6 +506,78 @@ describe("sellablePlans", () => {
   it("is inclusive of the plan's own last day", () => {
     // 2026-11-22T10:00 UTC is still 22 Nov in Sydney (AEDT, +11).
     expect(sellablePlans([dated()], "2026-11-22T10:00:00.000Z")).toHaveLength(1);
+  });
+});
+
+describe("unpaidInvoices", () => {
+  const row = (overrides: Partial<Record<string, unknown>> = {}) => ({
+    id: "m1",
+    status: "pending",
+    plan_name: "Semester 2 2026",
+    price_cents: 24500,
+    payment_reference: "UTSJ-LOVE-A1B2",
+    ...overrides,
+  });
+
+  it("returns nothing when nothing is pending", () => {
+    expect(
+      unpaidInvoices([row({ status: "active" }), row({ id: "m2", status: "cancelled" })]),
+    ).toEqual([]);
+  });
+
+  it("carries the amount and reference of a single pending membership", () => {
+    expect(unpaidInvoices([row()])).toEqual([
+      {
+        reference: "UTSJ-LOVE-A1B2",
+        total_cents: 24500,
+        lines: [{ membership_id: "m1", plan_name: "Semester 2 2026", price_cents: 24500 }],
+      },
+    ]);
+  });
+
+  it("adds up a bundle sharing one reference into ONE transfer", () => {
+    // Buying a plan with insurance writes two memberships against one
+    // reference. The member owes one payment, and the total has to match the
+    // one the invoice email quotes.
+    const invoices = unpaidInvoices([
+      row(),
+      row({ id: "m2", plan_name: "Yearly insurance", price_cents: 6000 }),
+    ]);
+    expect(invoices).toHaveLength(1);
+    expect(invoices[0].total_cents).toBe(30500);
+    expect(invoices[0].lines.map((l) => l.plan_name)).toEqual([
+      "Semester 2 2026",
+      "Yearly insurance",
+    ]);
+  });
+
+  it("keeps separate references apart, in the order given", () => {
+    const invoices = unpaidInvoices([
+      row({ id: "m2", plan_name: "Casual class", price_cents: 2000, payment_reference: "UTSJ-B" }),
+      row(),
+    ]);
+    expect(invoices.map((i) => i.reference)).toEqual(["UTSJ-B", "UTSJ-LOVE-A1B2"]);
+    expect(invoices.map((i) => i.total_cents)).toEqual([2000, 24500]);
+  });
+
+  it("ignores an already-paid membership sharing the reference", () => {
+    // Half a bundle reconciled on its own (a manager activating one row by
+    // hand) must not be re-billed: only what is still pending is owed.
+    const invoices = unpaidInvoices([
+      row({ status: "active" }),
+      row({ id: "m2", plan_name: "Yearly insurance", price_cents: 6000 }),
+    ]);
+    expect(invoices).toEqual([
+      {
+        reference: "UTSJ-LOVE-A1B2",
+        total_cents: 6000,
+        lines: [{ membership_id: "m2", plan_name: "Yearly insurance", price_cents: 6000 }],
+      },
+    ]);
+  });
+
+  it("still bills a line whose plan could not be resolved", () => {
+    expect(unpaidInvoices([row({ plan_name: null })])[0].lines[0].plan_name).toBeNull();
   });
 });
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1149,6 +1149,68 @@ export function sellablePlans<T extends PlanWindow & { is_active: boolean }>(
   return all.filter((p) => p.is_active && (!p.ends_on || p.ends_on >= today));
 }
 
+// ---- Member: what is still owed ----
+
+/** One thing on an unpaid invoice: a plan, and what it costs. */
+export interface UnpaidInvoiceLine {
+  membership_id: string;
+  plan_name: string | null;
+  price_cents: number;
+}
+
+/** An unpaid invoice: one transfer the member owes, whatever it is made of. */
+export interface UnpaidInvoice {
+  /** What the member quotes on the transfer. Also the group's identity. */
+  reference: string;
+  /** What to transfer: every line added up. */
+  total_cents: number;
+  lines: UnpaidInvoiceLine[];
+}
+
+/**
+ * The transfers a member still owes, from their membership rows.
+ *
+ * Buying a plan that bundles yearly insurance writes TWO pending memberships
+ * sharing ONE payment reference, because reconciliation has to activate them
+ * together off a single transfer. So "pending memberships" and "invoices to pay"
+ * are different counts, and only the second is a number to put in front of a
+ * member: they owe one payment, and paying half of it against the same reference
+ * would reconcile neither.
+ *
+ * Grouping by reference is what makes them agree, and it is the same sum the
+ * invoice email already shows — the page and the email are two views of one
+ * amount, so they must not compute it differently.
+ *
+ * Input order is preserved (`getMyMemberships` hands them over newest first).
+ */
+export function unpaidInvoices(
+  memberships: readonly {
+    id: string;
+    status: string;
+    plan_name: string | null;
+    price_cents: number;
+    payment_reference: string;
+  }[],
+): UnpaidInvoice[] {
+  const byReference = new Map<string, UnpaidInvoice>();
+  for (const m of memberships) {
+    if (m.status !== "pending") continue;
+    const line = { membership_id: m.id, plan_name: m.plan_name, price_cents: m.price_cents };
+    const existing = byReference.get(m.payment_reference);
+    if (existing) {
+      existing.lines.push(line);
+      existing.total_cents += m.price_cents;
+    } else {
+      byReference.set(m.payment_reference, {
+        reference: m.payment_reference,
+        total_cents: m.price_cents,
+        lines: [line],
+      });
+    }
+  }
+  return [...byReference.values()];
+}
+
 // ---- Member: yearly insurance selection on the purchase screen ----
 
 /**

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1809,16 +1809,153 @@ export const revokeApiTokenSchema = z.object({
 });
 export type RevokeApiTokenInput = z.infer<typeof revokeApiTokenSchema>;
 
-// ---- Manager: club settings (invoice payment instructions) ----
+// ---- Manager: club settings (the club's bank account) ----
 
-/** Default invoice instructions used until a manager customizes them. */
+/**
+ * The free-text instructions this replaced. Still exported because the manager
+ * settings screen shows whatever is left in the old `club_settings` row as a
+ * read-only reference while the structured fields are empty, and that row was
+ * seeded with a stub. Nothing member-facing renders it any more.
+ */
 export const DEFAULT_INVOICE_INSTRUCTIONS =
   "Pay by bank transfer to the club account. Please include your payment reference in the transfer description so we can match your payment automatically.";
 
-export const saveClubSettingsSchema = z.object({
-  invoice_payment_instructions: z.string().trim().max(5000),
+/**
+ * A BSB is six digits identifying an Australian bank branch. Stored as the six
+ * digits alone so what a manager typed (with or without the hyphen) cannot
+ * change what a member copies; `formatBsb` puts the hyphen back for display.
+ */
+const BSB_DIGITS = /^\d{6}$/;
+
+/**
+ * BIC, the same thing as a SWIFT code: 4 letters for the bank, 2 for the country
+ * (ISO 3166-1), 2 alphanumeric for the location, and an optional 3 more for a
+ * branch. That is why it is always 8 or 11 characters and never 9 or 10.
+ *
+ * This is the field an overseas sender actually needs. Australia does not use
+ * IBAN, so there is nothing else to give them.
+ */
+const BIC = /^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$/;
+
+/** `062000` -> `062-000`. How every Australian bank prints a BSB. */
+export function formatBsb(bsb: string): string {
+  const digits = bsb.replace(/\D/g, "");
+  return BSB_DIGITS.test(digits) ? `${digits.slice(0, 3)}-${digits.slice(3)}` : bsb;
+}
+
+/**
+ * The club's bank account, as a member needs to see it.
+ *
+ * The four account fields are required TOGETHER. A half-filled account is worse
+ * than no account at all, because it looks payable: someone copies a BSB, finds
+ * no account number, and either guesses or gives up having already been told
+ * what they owe. So an incomplete set never parses, and the screens treat it
+ * exactly as "not published yet".
+ *
+ * The overseas fields are each optional. They only ever add to a set of account
+ * details that already works domestically, and a club that never takes an
+ * overseas payment should not be blocked on filling them in.
+ */
+export const clubPaymentDetailsSchema = z.object({
+  account_name: z.string().trim().min(1, "Add the account name.").max(120),
+  bsb: z
+    .string()
+    .transform((v) => v.replace(/\D/g, ""))
+    .pipe(z.string().regex(BSB_DIGITS, "A BSB is six digits, like 062-000.")),
+  account_number: z
+    .string()
+    .transform((v) => v.replace(/\s/g, ""))
+    .pipe(z.string().regex(/^\d{4,10}$/, "An account number is 4 to 10 digits.")),
+  bank_name: z.string().trim().min(1, "Add the bank's name.").max(120),
+  swift_bic: z
+    .string()
+    .trim()
+    .toUpperCase()
+    .regex(BIC, "A SWIFT/BIC code is 8 or 11 characters, like CTBAAU2S.")
+    .or(z.literal(""))
+    .default(""),
+  bank_address: z.string().trim().max(200).default(""),
+  account_holder_address: z.string().trim().max(200).default(""),
+  note: z.string().trim().max(1000).default(""),
 });
-export type SaveClubSettingsInput = z.infer<typeof saveClubSettingsSchema>;
+export type ClubPaymentDetails = z.infer<typeof clubPaymentDetailsSchema>;
+
+/** The manager form posts exactly the details. */
+export const saveClubSettingsSchema = clubPaymentDetailsSchema;
+export type SaveClubSettingsInput = ClubPaymentDetails;
+
+/**
+ * The account rows, in the order a member reads them, shared by the membership
+ * page and the invoice email so the two can never drift apart.
+ *
+ * Every one of them is a value somebody pastes into a banking app, so every one
+ * gets a copy button. `copyLabel` is carried per field rather than built from
+ * `label`, because it is the button's accessible name: seven buttons all called
+ * "Copy" are unusable by voice or screen reader, and "Copy bsb" is what
+ * lowercasing the label would produce.
+ *
+ * `mono` marks the fields that are strings of digits and letters to be
+ * transcribed, where a monospace font makes a misread digit visible.
+ */
+export const CLUB_ACCOUNT_FIELDS = [
+  { key: "account_name", label: "Account name", copyLabel: "Copy account name", mono: false },
+  { key: "bsb", label: "BSB", copyLabel: "Copy BSB", mono: true },
+  { key: "account_number", label: "Account number", copyLabel: "Copy account number", mono: true },
+  { key: "bank_name", label: "Bank", copyLabel: "Copy bank name", mono: false },
+] as const;
+
+/** The same, for someone sending from outside Australia. */
+export const CLUB_INTERNATIONAL_FIELDS = [
+  { key: "swift_bic", label: "SWIFT/BIC", copyLabel: "Copy SWIFT/BIC", mono: true },
+  { key: "bank_address", label: "Bank address", copyLabel: "Copy bank address", mono: false },
+  {
+    key: "account_holder_address",
+    label: "Account holder address",
+    copyLabel: "Copy account holder address",
+    mono: false,
+  },
+] as const;
+
+export type ClubPaymentFieldKey =
+  | (typeof CLUB_ACCOUNT_FIELDS)[number]["key"]
+  | (typeof CLUB_INTERNATIONAL_FIELDS)[number]["key"];
+
+/**
+ * The value to show and to copy for one field. Only the BSB differs from what is
+ * stored, and it must differ in exactly one place or the hyphen ends up on
+ * screen but not on the clipboard.
+ */
+export function clubPaymentFieldValue(
+  details: ClubPaymentDetails,
+  key: ClubPaymentFieldKey,
+): string {
+  return key === "bsb" ? formatBsb(details.bsb) : details[key];
+}
+
+/** True when there is at least one overseas field worth showing. */
+export function hasInternationalDetails(details: ClubPaymentDetails): boolean {
+  return CLUB_INTERNATIONAL_FIELDS.some((f) => details[f.key].trim().length > 0);
+}
+
+/**
+ * Read the stored JSON blob back. Returns null for anything that is not a
+ * complete set of account details: never written, half-written, hand-edited into
+ * invalid JSON, or written by a future version with a rule this one fails.
+ *
+ * Null is not an error state to swallow — it is what the screens render the
+ * "we have not published these yet" message from. Guessing at a partial blob
+ * would put a wrong account number in front of someone about to transfer money,
+ * which is the one outcome worth being strict about.
+ */
+export function parseClubPaymentDetails(raw: string | null): ClubPaymentDetails | null {
+  if (!raw?.trim()) return null;
+  try {
+    const parsed = clubPaymentDetailsSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
 
 // ---- Calendar (see docs/calendar.md) ----
 

--- a/src/routes/_authenticated/manager.api-tokens.tsx
+++ b/src/routes/_authenticated/manager.api-tokens.tsx
@@ -2,13 +2,14 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
-import { Check, Copy, KeyRound } from "lucide-react";
+import { KeyRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { CopyButton } from "@/components/site/CopyButton";
 import { formatDateTime } from "@/lib/dates";
 import { createApiToken, listApiTokens, revokeApiToken } from "@/lib/manager-api-tokens.functions";
 import { buildAgentPrompt } from "@/lib/manager-api-tokens";
@@ -30,30 +31,6 @@ type TokenRow = {
   revoked_at: string | null;
   active: boolean;
 };
-
-/** A small copy-to-clipboard button with a transient "copied" state. */
-function CopyButton({ text, label }: { text: string; label: string }) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      onClick={async () => {
-        try {
-          await navigator.clipboard.writeText(text);
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1500);
-        } catch {
-          toast.error("Couldn't copy. Select and copy manually.");
-        }
-      }}
-    >
-      {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
-      {label}
-    </Button>
-  );
-}
 
 function ApiTokensPage() {
   const navigate = useNavigate();

--- a/src/routes/_authenticated/manager.settings.test.tsx
+++ b/src/routes/_authenticated/manager.settings.test.tsx
@@ -1,0 +1,144 @@
+// This screen is where the club's bank account is typed in, so what is pinned
+// here is what leaves the page: the BSB stored as bare digits however it was
+// typed, an incomplete account refused before it can be saved, and the fact that
+// a manager is told, loudly, while members cannot pay.
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const getClubSettings = vi.fn();
+const saveClubSettings = vi.fn();
+const toastError = vi.fn();
+
+const ACCOUNT = {
+  account_name: "UTS Jitsu Club Inc",
+  bsb: "062000",
+  account_number: "12345678",
+  bank_name: "Commonwealth Bank of Australia",
+  swift_bic: "CTBAAU2S",
+  bank_address: "Sydney NSW 2000, Australia",
+  account_holder_address: "1 Broadway, Ultimo NSW 2007",
+  note: "",
+};
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => opts,
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@tanstack/react-start", () => ({
+  useServerFn: (fn: unknown) => fn,
+}));
+
+vi.mock("@/lib/membership.functions", () => ({
+  getClubSettings: (...args: unknown[]) => getClubSettings(...args),
+  saveClubSettings: (...args: unknown[]) => saveClubSettings(...args),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: (...args: unknown[]) => toastError(...args), success: vi.fn() },
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "u1" }, session: null, loading: false }),
+  useRoles: () => ({ roles: ["manager"], loading: false, isManager: true }),
+}));
+
+const { Route } = await import("./manager.settings");
+const SettingsPage = (Route as unknown as { component: () => ReactNode }).component;
+
+async function renderLoaded() {
+  render(<SettingsPage />);
+  await waitFor(() => expect(screen.getByLabelText("Account name")).toBeVisible());
+}
+
+beforeEach(() => {
+  getClubSettings
+    .mockReset()
+    .mockResolvedValue({ details: null, legacy_instructions: "**BSB** 062-000 (old text)" });
+  saveClubSettings.mockReset().mockResolvedValue({ ok: true });
+  toastError.mockReset();
+});
+
+describe("/manager/settings", () => {
+  it("warns that members cannot pay while no account is published", async () => {
+    await renderLoaded();
+    expect(screen.getByText(/members cannot see how to pay yet/i)).toBeVisible();
+    // The free text these fields replaced, so the values can be copied across.
+    expect(screen.getByText(/your previous instructions/i)).toBeVisible();
+    expect(screen.getByText(/old text/)).toBeVisible();
+  });
+
+  it("drops the warning and the old text once an account exists", async () => {
+    getClubSettings.mockResolvedValue({ details: ACCOUNT, legacy_instructions: "old text" });
+    await renderLoaded();
+    expect(screen.queryByText(/members cannot see how to pay yet/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/your previous instructions/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a stored BSB hyphenated, and saves it back as bare digits", async () => {
+    getClubSettings.mockResolvedValue({ details: ACCOUNT, legacy_instructions: "" });
+    await renderLoaded();
+    expect(screen.getByLabelText("BSB")).toHaveValue("062-000");
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(saveClubSettings).toHaveBeenCalled());
+    expect(saveClubSettings.mock.calls[0][0].data.bsb).toBe("062000");
+  });
+
+  it("refuses to save a half-filled account and says which box is wrong", async () => {
+    await renderLoaded();
+    await userEvent.type(screen.getByLabelText("Account name"), "UTS Jitsu Club Inc");
+    await userEvent.type(screen.getByLabelText("BSB"), "0620");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(saveClubSettings).not.toHaveBeenCalled();
+    expect(screen.getByText(/a BSB is six digits/i)).toBeVisible();
+    expect(screen.getByLabelText("BSB")).toHaveAttribute("aria-invalid", "true");
+    expect(toastError).toHaveBeenCalled();
+  });
+
+  it("clears a field's complaint as soon as it is corrected", async () => {
+    await renderLoaded();
+    await userEvent.type(screen.getByLabelText("BSB"), "0620");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(screen.getByText(/a BSB is six digits/i)).toBeVisible();
+
+    await userEvent.type(screen.getByLabelText("BSB"), "00");
+    expect(screen.queryByText(/a BSB is six digits/i)).not.toBeInTheDocument();
+  });
+
+  it("rejects a SWIFT code of the wrong length", async () => {
+    await renderLoaded();
+    await userEvent.type(screen.getByLabelText("Account name"), "UTS Jitsu Club Inc");
+    await userEvent.type(screen.getByLabelText("BSB"), "062000");
+    await userEvent.type(screen.getByLabelText("Account number"), "12345678");
+    await userEvent.type(screen.getByLabelText("Bank"), "CommBank");
+    await userEvent.type(screen.getByLabelText("SWIFT/BIC code"), "CTBAAU2SX");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(saveClubSettings).not.toHaveBeenCalled();
+    // Matched on the error's own wording, not on "8 or 11 characters", which
+    // the field's hint also says.
+    expect(screen.getByText(/like CTBAAU2S/)).toBeVisible();
+    expect(screen.getByLabelText("SWIFT/BIC code")).toHaveAttribute("aria-invalid", "true");
+  });
+
+  // The preview is the member's own component, so a manager is looking at what
+  // a member gets rather than at an approximation of it.
+  it("previews the member's panel as the form is filled in", async () => {
+    await renderLoaded();
+    const preview = screen.getByText("What members see").closest("div.rounded-xl") as HTMLElement;
+    expect(within(preview).getByText(/has not published its account details yet/i)).toBeVisible();
+
+    await userEvent.type(screen.getByLabelText("Account name"), "UTS Jitsu Club Inc");
+    await userEvent.type(screen.getByLabelText("BSB"), "062-000");
+    await userEvent.type(screen.getByLabelText("Account number"), "12345678");
+    await userEvent.type(screen.getByLabelText("Bank"), "Commonwealth Bank of Australia");
+
+    expect(within(preview).getByText("062-000")).toBeVisible();
+    expect(within(preview).getByRole("button", { name: /copy account number/i })).toBeVisible();
+  });
+});

--- a/src/routes/_authenticated/manager.settings.test.tsx
+++ b/src/routes/_authenticated/manager.settings.test.tsx
@@ -71,6 +71,25 @@ describe("/manager/settings", () => {
     expect(screen.getByText(/old text/)).toBeVisible();
   });
 
+  // The read failing and the club never having published are different things,
+  // and only one of them should put an empty form in front of a manager. An
+  // empty form here invites retyping a working account from memory, which is how
+  // one digit gets lost.
+  it("shows an error instead of an empty form when the settings cannot be read", async () => {
+    getClubSettings.mockRejectedValue(new Error("Could not read the club settings. Try again."));
+    render(<SettingsPage />);
+    await waitFor(() => expect(screen.getByRole("alert")).toBeVisible());
+
+    expect(screen.getByText(/could not load the club's payment settings/i)).toBeVisible();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeVisible();
+    // Nothing to type into means nothing to overwrite.
+    expect(screen.queryByLabelText("Account name")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+    // And no claim about what members can see, because we do not know.
+    expect(screen.queryByText(/members cannot see how to pay yet/i)).not.toBeInTheDocument();
+    expect(toastError).toHaveBeenCalled();
+  });
+
   it("drops the warning and the old text once an account exists", async () => {
     getClubSettings.mockResolvedValue({ details: ACCOUNT, legacy_instructions: "old text" });
     await renderLoaded();

--- a/src/routes/_authenticated/manager.settings.tsx
+++ b/src/routes/_authenticated/manager.settings.tsx
@@ -8,6 +8,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { getClubSettings, saveClubSettings } from "@/lib/membership.functions";
+import { invoiceMarkdownComponents } from "@/lib/invoice-markdown";
 import { useAuth, useRoles } from "@/hooks/useAuth";
 
 export const Route = createFileRoute("/_authenticated/manager/settings")({
@@ -103,8 +104,11 @@ function SettingsPage() {
               <CardDescription>How the instructions appear on the invoice.</CardDescription>
             </CardHeader>
             <CardContent>
-              <div className="prose prose-sm max-w-none prose-headings:font-bold prose-headings:text-foreground prose-p:leading-relaxed prose-strong:text-foreground">
-                <ReactMarkdown>
+              {/* The same component map the member's "how to pay" panel uses,
+                  so this preview is the member's view rather than an
+                  approximation of it. */}
+              <div className="text-sm text-muted-foreground">
+                <ReactMarkdown components={invoiceMarkdownComponents}>
                   {instructions || "_Nothing yet. Add your instructions._"}
                 </ReactMarkdown>
               </div>

--- a/src/routes/_authenticated/manager.settings.tsx
+++ b/src/routes/_authenticated/manager.settings.tsx
@@ -3,12 +3,17 @@ import { useEffect, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import ReactMarkdown from "react-markdown";
+import { AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ClubAccountDetails } from "@/components/site/ClubAccountDetails";
 import { getClubSettings, saveClubSettings } from "@/lib/membership.functions";
 import { invoiceMarkdownComponents } from "@/lib/invoice-markdown";
+import { clubPaymentDetailsSchema, formatBsb } from "@/lib/validation";
+import type { ClubPaymentDetails } from "@/lib/validation";
 import { useAuth, useRoles } from "@/hooks/useAuth";
 
 export const Route = createFileRoute("/_authenticated/manager/settings")({
@@ -18,6 +23,53 @@ export const Route = createFileRoute("/_authenticated/manager/settings")({
   component: SettingsPage,
 });
 
+/** The form's fields as strings, which is what inputs deal in. */
+type FormState = Record<keyof ClubPaymentDetails, string>;
+
+const EMPTY: FormState = {
+  account_name: "",
+  bsb: "",
+  account_number: "",
+  bank_name: "",
+  swift_bic: "",
+  bank_address: "",
+  account_holder_address: "",
+  note: "",
+};
+
+/**
+ * The boxes, in the order they are filled in. Grouped rather than flat: the
+ * account is what everybody pays into, the overseas block only ever adds to it,
+ * and mixing the two would make a required SWIFT code look plausible.
+ */
+const ACCOUNT_INPUTS = [
+  { key: "account_name", label: "Account name", placeholder: "UTS Jitsu Club Inc" },
+  { key: "bsb", label: "BSB", placeholder: "062-000", hint: "Six digits." },
+  { key: "account_number", label: "Account number", placeholder: "12345678" },
+  { key: "bank_name", label: "Bank", placeholder: "Commonwealth Bank of Australia" },
+] as const;
+
+const INTERNATIONAL_INPUTS = [
+  {
+    key: "swift_bic",
+    label: "SWIFT/BIC code",
+    placeholder: "CTBAAU2S",
+    hint: "8 or 11 characters. Australia has no IBAN, so this is what an overseas bank asks for.",
+  },
+  {
+    key: "bank_address",
+    label: "Bank address",
+    placeholder: "Sydney NSW 2000, Australia",
+    hint: "The branch address some overseas banks ask for.",
+  },
+  {
+    key: "account_holder_address",
+    label: "Account holder address",
+    placeholder: "1 Broadway, Ultimo NSW 2007, Australia",
+    hint: "The club's own address. A PO box is not accepted for international transfers.",
+  },
+] as const;
+
 function SettingsPage() {
   const navigate = useNavigate();
   const { user } = useAuth();
@@ -25,7 +77,10 @@ function SettingsPage() {
   const fetchSettings = useServerFn(getClubSettings);
   const save = useServerFn(saveClubSettings);
 
-  const [instructions, setInstructions] = useState("");
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [legacy, setLegacy] = useState("");
+  const [published, setPublished] = useState(false);
+  const [errors, setErrors] = useState<Partial<Record<keyof FormState, string>>>({});
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
@@ -36,16 +91,46 @@ function SettingsPage() {
   useEffect(() => {
     if (!isManager) return;
     fetchSettings()
-      .then((s) => setInstructions(s.invoice_payment_instructions))
+      .then((s) => {
+        setLegacy(s.legacy_instructions);
+        setPublished(s.details != null);
+        if (s.details) {
+          setForm({ ...s.details, bsb: formatBsb(s.details.bsb) });
+        }
+      })
       .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load settings"))
       .finally(() => setLoading(false));
   }, [isManager, fetchSettings]);
 
+  function set(key: keyof FormState, value: string) {
+    setForm((f) => ({ ...f, [key]: value }));
+    // Clear this field's complaint as soon as it is touched. Leaving it up while
+    // somebody fixes it reads as "still wrong" when it is not.
+    setErrors((e) => (e[key] ? { ...e, [key]: undefined } : e));
+  }
+
+  // Parsed here as well as on the server so a mistyped BSB is a message under
+  // the box rather than a failed save with nothing to point at.
+  const parsed = clubPaymentDetailsSchema.safeParse(form);
+  const preview = parsed.success ? parsed.data : null;
+
   async function onSave() {
+    if (!parsed.success) {
+      const next: Partial<Record<keyof FormState, string>> = {};
+      for (const issue of parsed.error.issues) {
+        const key = issue.path[0] as keyof FormState;
+        if (key && !next[key]) next[key] = issue.message;
+      }
+      setErrors(next);
+      toast.error("Check the highlighted fields.");
+      return;
+    }
     setSaving(true);
     try {
-      await save({ data: { invoice_payment_instructions: instructions } });
-      toast.success("Settings saved");
+      await save({ data: parsed.data });
+      setErrors({});
+      setPublished(true);
+      toast.success("Saved. Members can see these details now.");
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Save failed");
     } finally {
@@ -63,12 +148,13 @@ function SettingsPage() {
 
   return (
     <>
-      <section className="mx-auto max-w-4xl space-y-6 px-4 py-10">
+      <section className="mx-auto max-w-5xl space-y-6 px-4 py-10">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h1 className="text-3xl font-black">Club settings</h1>
             <p className="text-sm text-muted-foreground">
-              Text shown to members on their membership invoice.
+              The account members pay into. These details appear on the membership page and on every
+              invoice email.
             </p>
           </div>
           <Button asChild variant="outline">
@@ -76,46 +162,162 @@ function SettingsPage() {
           </Button>
         </div>
 
+        {/* Leads, rather than sits at the bottom: while this is showing, nobody
+            can pay us. */}
+        {!published && (
+          <div className="flex items-start gap-3 rounded-lg border border-destructive/40 bg-destructive/5 p-4">
+            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-destructive" />
+            <div className="text-sm">
+              <p className="font-medium">Members cannot see how to pay yet.</p>
+              <p className="mt-1 text-muted-foreground">
+                Fill in the account below and save. Until you do, the membership page and every
+                invoice email tell people to get in touch instead.
+              </p>
+            </div>
+          </div>
+        )}
+
         <div className="grid gap-6 lg:grid-cols-2">
-          <div className="space-y-3">
+          <div className="space-y-6">
+            <div className="space-y-4">
+              <h2 className="text-lg font-semibold">The club's account</h2>
+              {ACCOUNT_INPUTS.map((field) => (
+                <Field
+                  key={field.key}
+                  id={field.key}
+                  label={field.label}
+                  placeholder={field.placeholder}
+                  hint={"hint" in field ? field.hint : undefined}
+                  value={form[field.key]}
+                  error={errors[field.key]}
+                  onChange={(v) => set(field.key, v)}
+                />
+              ))}
+            </div>
+
+            <div className="space-y-4">
+              <div>
+                <h2 className="text-lg font-semibold">For overseas payers</h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Optional, and only shown to someone who opens "Paying from overseas?" on the
+                  membership page.
+                </p>
+              </div>
+              {INTERNATIONAL_INPUTS.map((field) => (
+                <Field
+                  key={field.key}
+                  id={field.key}
+                  label={field.label}
+                  placeholder={field.placeholder}
+                  hint={field.hint}
+                  value={form[field.key]}
+                  error={errors[field.key]}
+                  onChange={(v) => set(field.key, v)}
+                />
+              ))}
+            </div>
+
             <div>
-              <Label htmlFor="instructions">Invoice payment instructions (Markdown)</Label>
+              <Label htmlFor="note">Note (optional, Markdown)</Label>
               <p className="mt-1 text-xs text-muted-foreground">
-                Add your bank transfer details (account name, BSB, account number), PayID, or any
-                note. The amount and payment reference are added automatically.
+                Anything the boxes above don't cover, like a PayID. Shown under the account details.
               </p>
               <Textarea
-                id="instructions"
-                value={instructions}
-                onChange={(e) => setInstructions(e.target.value)}
-                rows={16}
-                maxLength={5000}
-                className="mt-2 font-mono text-sm"
+                id="note"
+                value={form.note}
+                onChange={(e) => set("note", e.target.value)}
+                rows={4}
+                maxLength={1000}
+                className="mt-2 text-sm"
               />
+              {errors.note && <p className="mt-1 text-xs text-destructive">{errors.note}</p>}
             </div>
+
             <Button onClick={onSave} disabled={saving}>
               {saving ? "Saving..." : "Save"}
             </Button>
           </div>
 
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Preview</CardTitle>
-              <CardDescription>How the instructions appear on the invoice.</CardDescription>
-            </CardHeader>
-            <CardContent>
-              {/* The same component map the member's "how to pay" panel uses,
-                  so this preview is the member's view rather than an
-                  approximation of it. */}
-              <div className="text-sm text-muted-foreground">
-                <ReactMarkdown components={invoiceMarkdownComponents}>
-                  {instructions || "_Nothing yet. Add your instructions._"}
-                </ReactMarkdown>
-              </div>
-            </CardContent>
-          </Card>
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">What members see</CardTitle>
+                <CardDescription>
+                  The same panel as the membership page, updating as you type.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ClubAccountDetails details={preview} />
+              </CardContent>
+            </Card>
+
+            {/* The free text these fields replaced. Read-only, and only worth
+                showing while the account is still empty: it is where the values
+                being typed in are most likely to be found. */}
+            {!published && legacy && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Your previous instructions</CardTitle>
+                  <CardDescription>
+                    No longer shown to anyone. Copy the details across, then this box goes away.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="text-sm text-muted-foreground">
+                    <ReactMarkdown components={invoiceMarkdownComponents}>{legacy}</ReactMarkdown>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+          </div>
         </div>
       </section>
     </>
+  );
+}
+
+function Field({
+  id,
+  label,
+  placeholder,
+  hint,
+  value,
+  error,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  placeholder: string;
+  hint?: string;
+  value: string;
+  error?: string;
+  onChange: (value: string) => void;
+}) {
+  const describedBy = [hint ? `${id}-hint` : null, error ? `${id}-error` : null]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <div>
+      <Label htmlFor={id}>{label}</Label>
+      {hint && (
+        <p id={`${id}-hint`} className="mt-1 text-xs text-muted-foreground">
+          {hint}
+        </p>
+      )}
+      <Input
+        id={id}
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={describedBy || undefined}
+        className="mt-1.5"
+      />
+      {error && (
+        <p id={`${id}-error`} className="mt-1 text-xs text-destructive">
+          {error}
+        </p>
+      )}
+    </div>
   );
 }

--- a/src/routes/_authenticated/manager.settings.tsx
+++ b/src/routes/_authenticated/manager.settings.tsx
@@ -83,6 +83,8 @@ function SettingsPage() {
   const [errors, setErrors] = useState<Partial<Record<keyof FormState, string>>>({});
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  // The load failing is its own state, not an absent one. See the panel below.
+  const [loadFailed, setLoadFailed] = useState(false);
 
   useEffect(() => {
     if (!rolesLoading && user && !isManager) navigate({ to: "/account" });
@@ -92,13 +94,21 @@ function SettingsPage() {
     if (!isManager) return;
     fetchSettings()
       .then((s) => {
+        setLoadFailed(false);
         setLegacy(s.legacy_instructions);
         setPublished(s.details != null);
         if (s.details) {
           setForm({ ...s.details, bsb: formatBsb(s.details.bsb) });
         }
       })
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load settings"))
+      .catch((e) => {
+        // Not just a toast. `getClubSettings` throws rather than return an empty
+        // account precisely so a failed read cannot be mistaken for an
+        // unpublished one; swallowing that here would put the empty form back on
+        // screen and hand a manager the overwrite it was protecting them from.
+        setLoadFailed(true);
+        toast.error(e instanceof Error ? e.message : "Failed to load settings");
+      })
       .finally(() => setLoading(false));
   }, [isManager, fetchSettings]);
 
@@ -146,6 +156,44 @@ function SettingsPage() {
     );
   }
 
+  /**
+   * The read failed, so we do not know what the club's account currently says.
+   *
+   * The form is deliberately NOT rendered here. An empty form plus "members
+   * cannot see how to pay" is a lie we cannot support, and worse, it invites a
+   * manager to retype the account from memory over the top of one that may be
+   * perfectly fine. Nothing to type into means nothing to overwrite.
+   */
+  if (loadFailed) {
+    return (
+      <section className="mx-auto max-w-5xl space-y-6 px-4 py-10">
+        <h1 className="text-3xl font-black">Club settings</h1>
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-lg border border-destructive/40 bg-destructive/5 p-4"
+        >
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-destructive" />
+          <div className="text-sm">
+            <p className="font-medium">We could not load the club's payment settings.</p>
+            <p className="mt-1 text-muted-foreground">
+              Nothing has changed, and members are unaffected. We have not shown the form because we
+              cannot tell you what is in it right now, and saving over details we could not read is
+              worse than waiting a minute.
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Button size="sm" onClick={() => window.location.reload()}>
+                Try again
+              </Button>
+              <Button asChild size="sm" variant="outline">
+                <Link to="/manager/memberships">Back to memberships</Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
   return (
     <>
       <section className="mx-auto max-w-5xl space-y-6 px-4 py-10">
@@ -163,8 +211,9 @@ function SettingsPage() {
         </div>
 
         {/* Leads, rather than sits at the bottom: while this is showing, nobody
-            can pay us. */}
-        {!published && (
+            can pay us. Suppressed when the read failed, because then we do not
+            know whether it is true. */}
+        {!published && !loadFailed && (
           <div className="flex items-start gap-3 rounded-lg border border-destructive/40 bg-destructive/5 p-4">
             <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-destructive" />
             <div className="text-sm">

--- a/src/routes/_authenticated/membership.test.tsx
+++ b/src/routes/_authenticated/membership.test.tsx
@@ -105,47 +105,101 @@ async function renderLoaded() {
   await waitFor(() => expect(screen.getByRole("heading", { name: "Membership" })).toBeVisible());
 }
 
+/** The club's account as the server hands it over: BSB stored as bare digits. */
+const ACCOUNT = {
+  account_name: "UTS Jitsu Club Inc",
+  bsb: "062000",
+  account_number: "12345678",
+  bank_name: "Commonwealth Bank of Australia",
+  swift_bic: "CTBAAU2S",
+  bank_address: "Sydney NSW 2000, Australia",
+  account_holder_address: "1 Broadway, Ultimo NSW 2007",
+  note: "",
+};
+
 beforeEach(() => {
   getMyMemberships.mockReset().mockResolvedValue(mine([pendingPlan]));
-  getPaymentInstructions
-    .mockReset()
-    .mockResolvedValue({ instructions: "Pay **UTS Jitsu Club**, BSB 062-000, acct 1234 5678." });
+  getPaymentInstructions.mockReset().mockResolvedValue({ ok: true, details: ACCOUNT });
   listMembershipPlans.mockReset().mockResolvedValue([]);
   startMembership.mockReset().mockResolvedValue({ ok: true, activated: true, reference: null });
   toastSuccess.mockReset();
 });
 
 describe("/membership: how to pay", () => {
-  it("shows the amount, the reference and the club's account details", async () => {
+  it("shows the amount, the reference and the club's account", async () => {
     await renderLoaded();
     const card = payCard()!;
     expect(card).toBeInTheDocument();
     expect(within(card).getByText("$245")).toBeVisible();
     expect(within(card).getByText(PLAN_REF)).toBeVisible();
-    // The markdown a manager wrote at /manager/settings, rendered — this is the
-    // half that used to exist only in the invoice email.
-    expect(within(card).getByText(/BSB 062-000, acct 1234 5678/)).toBeVisible();
-    expect(within(card).getByText("UTS Jitsu Club")).toBeVisible();
+    expect(within(card).getByText("UTS Jitsu Club Inc")).toBeVisible();
+    // Stored as six digits, shown the way a bank prints it.
+    expect(within(card).getByText("062-000")).toBeVisible();
+    expect(within(card).getByText("12345678")).toBeVisible();
+    expect(within(card).getByText("Commonwealth Bank of Australia")).toBeVisible();
   });
 
-  it("renders the instructions as markdown, bullets and all", async () => {
-    // Not with `prose` classes: this repo has no typography plugin, so a set of
-    // bank details written as a list would otherwise render as one run-on line.
-    getPaymentInstructions.mockResolvedValue({
-      instructions: "Pay to:\n\n- BSB: 062-000\n- Account: 1234 5678",
-    });
-    await renderLoaded();
-    const card = payCard()!;
-    expect(within(card).getByRole("list").className).toContain("list-disc");
-    expect(within(card).getAllByRole("listitem")).toHaveLength(2);
-  });
-
-  it("copies the reference, which is what a bank transfer reconciles on", async () => {
+  // A regression in any one of these sends somebody's money to the wrong place,
+  // so each button is pinned to the exact string it puts on the clipboard.
+  it("copies each field on its own, the BSB hyphenated as displayed", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText } });
     await renderLoaded();
-    await userEvent.click(within(payCard()!).getByRole("button", { name: /copy reference/i }));
-    expect(writeText).toHaveBeenCalledWith(PLAN_REF);
+    const card = within(payCard()!);
+
+    for (const [name, expected] of [
+      [/copy reference/i, PLAN_REF],
+      [/copy account name/i, "UTS Jitsu Club Inc"],
+      [/copy BSB/i, "062-000"],
+      [/copy account number/i, "12345678"],
+      [/copy bank name/i, "Commonwealth Bank of Australia"],
+    ] as const) {
+      writeText.mockClear();
+      await userEvent.click(card.getByRole("button", { name }));
+      expect(writeText).toHaveBeenCalledWith(expected);
+    }
+  });
+
+  it("keeps the overseas details out of the way until someone opens them", async () => {
+    await renderLoaded();
+    const card = within(payCard()!);
+    const disclosure = screen.getByText("Paying from overseas?").closest("details")!;
+    expect(disclosure.open).toBe(false);
+    // Present in the DOM but collapsed, which is what <details> gives us for
+    // free and what keeps it findable by in-page search.
+    expect(card.getByText("CTBAAU2S")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("Paying from overseas?"));
+    expect(disclosure.open).toBe(true);
+    expect(card.getByText(/take fees out of an international transfer/i)).toBeVisible();
+  });
+
+  it("copies the SWIFT/BIC code, which is what an overseas bank needs", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    await renderLoaded();
+    await userEvent.click(within(payCard()!).getByRole("button", { name: /copy SWIFT/i }));
+    expect(writeText).toHaveBeenCalledWith("CTBAAU2S");
+  });
+
+  it("hides the overseas block entirely when the club has not filled it in", async () => {
+    getPaymentInstructions.mockResolvedValue({
+      ok: true,
+      details: { ...ACCOUNT, swift_bic: "", bank_address: "", account_holder_address: "" },
+    });
+    await renderLoaded();
+    expect(screen.queryByText("Paying from overseas?")).not.toBeInTheDocument();
+  });
+
+  it("renders the club's note as markdown under the account", async () => {
+    getPaymentInstructions.mockResolvedValue({
+      ok: true,
+      details: { ...ACCOUNT, note: "PayID:\n\n- pay@jitsu.au\n- 0400 000 000" },
+    });
+    await renderLoaded();
+    const card = within(payCard()!);
+    expect(card.getByRole("list").className).toContain("list-disc");
+    expect(card.getAllByRole("listitem")).toHaveLength(2);
   });
 
   it("bills a bundled plan + insurance as one transfer, and shows the split", async () => {
@@ -203,15 +257,27 @@ describe("/membership: how to pay", () => {
   });
 
   it("keeps the amount and reference when the club's details fail to load", async () => {
-    // The member's own invoice is already loaded; only the club's account
-    // details are missing, so the panel degrades rather than disappearing.
+    // The member's own invoice is already loaded; only the club's account is
+    // missing, so the panel degrades rather than disappearing.
     vi.spyOn(console, "error").mockImplementation(() => {});
     getPaymentInstructions.mockRejectedValue(new Error("nope"));
     await renderLoaded();
     const card = payCard()!;
     expect(within(card).getByText("$245")).toBeVisible();
     expect(within(card).getByText(PLAN_REF)).toBeVisible();
-    expect(within(card).getByText(/invoice email we sent you/)).toBeVisible();
+    expect(within(card).getByText(/could not load the club's account details/i)).toBeVisible();
     vi.restoreAllMocks();
+  });
+
+  // Different from the read failing, and it has to read differently: this is
+  // the state between shipping and a manager filling the form in.
+  it("says the club has not published an account yet when there is none", async () => {
+    getPaymentInstructions.mockResolvedValue({ ok: true, details: null });
+    await renderLoaded();
+    const card = payCard()!;
+    expect(within(card).getByText("$245")).toBeVisible();
+    expect(within(card).getByText(PLAN_REF)).toBeVisible();
+    expect(within(card).getByText(/has not published its account details yet/i)).toBeVisible();
+    expect(within(card).queryByRole("button", { name: /copy BSB/i })).not.toBeInTheDocument();
   });
 });

--- a/src/routes/_authenticated/membership.test.tsx
+++ b/src/routes/_authenticated/membership.test.tsx
@@ -39,6 +39,23 @@ const activePlan = { ...pendingPlan, id: "m3", status: "active", paid_at: "2026-
 
 const getMyMemberships = vi.fn();
 const getPaymentInstructions = vi.fn();
+const listMembershipPlans = vi.fn();
+const startMembership = vi.fn();
+const toastSuccess = vi.fn();
+
+const FREE_PLAN = {
+  code: "open_mat",
+  name: "Open mat",
+  description: null,
+  kind: "session",
+  public_price_cents: 0,
+  student_price_cents: null,
+  session_credits: 1,
+  starts_on: null,
+  ends_on: null,
+  duration_days: null,
+  is_active: true,
+};
 
 function mine(memberships: unknown[]) {
   return {
@@ -60,10 +77,10 @@ vi.mock("@tanstack/react-start", () => ({
 }));
 
 vi.mock("@/lib/membership.functions", () => ({
-  listMembershipPlans: vi.fn().mockResolvedValue([]),
+  listMembershipPlans: (...args: unknown[]) => listMembershipPlans(...args),
   getMyMemberships: (...args: unknown[]) => getMyMemberships(...args),
   getPaymentInstructions: (...args: unknown[]) => getPaymentInstructions(...args),
-  startMembership: vi.fn(),
+  startMembership: (...args: unknown[]) => startMembership(...args),
 }));
 
 vi.mock("@/lib/code-of-conduct.functions", () => ({
@@ -71,7 +88,7 @@ vi.mock("@/lib/code-of-conduct.functions", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { error: vi.fn(), success: vi.fn() },
+  toast: { error: vi.fn(), success: (...args: unknown[]) => toastSuccess(...args) },
 }));
 
 const { Route } = await import("./membership");
@@ -93,6 +110,9 @@ beforeEach(() => {
   getPaymentInstructions
     .mockReset()
     .mockResolvedValue({ instructions: "Pay **UTS Jitsu Club**, BSB 062-000, acct 1234 5678." });
+  listMembershipPlans.mockReset().mockResolvedValue([]);
+  startMembership.mockReset().mockResolvedValue({ ok: true, activated: true, reference: null });
+  toastSuccess.mockReset();
 });
 
 describe("/membership: how to pay", () => {
@@ -155,6 +175,30 @@ describe("/membership: how to pay", () => {
   it("says nothing about paying when nothing is owed", async () => {
     getMyMemberships.mockResolvedValue(mine([activePlan]));
     await renderLoaded();
+    expect(payCard()).toBeNull();
+  });
+
+  it("points at the panel after a purchase that still owes money, not at the inbox", async () => {
+    // `startMembership` reports `activated: true` for a $0 plan even when it
+    // bundled an insurance invoice alongside it, so "you're all set" has to be
+    // decided by what is actually still owed, not by that flag.
+    listMembershipPlans.mockResolvedValue([FREE_PLAN]);
+    getMyMemberships.mockResolvedValueOnce(mine([])).mockResolvedValue(mine([pendingInsurance]));
+    await renderLoaded();
+    expect(payCard()).toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: /choose & pay/i }));
+    await waitFor(() => expect(payCard()).not.toBeNull());
+    expect(toastSuccess).toHaveBeenCalledWith(expect.stringContaining("payment details"));
+    expect(toastSuccess).not.toHaveBeenCalledWith(expect.stringContaining("all set"));
+  });
+
+  it("says you're all set when the purchase left nothing to pay", async () => {
+    listMembershipPlans.mockResolvedValue([FREE_PLAN]);
+    getMyMemberships.mockResolvedValue(mine([]));
+    await renderLoaded();
+    await userEvent.click(screen.getByRole("button", { name: /choose & pay/i }));
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(toastSuccess).toHaveBeenCalledWith(expect.stringContaining("all set"));
     expect(payCard()).toBeNull();
   });
 

--- a/src/routes/_authenticated/membership.test.tsx
+++ b/src/routes/_authenticated/membership.test.tsx
@@ -1,0 +1,173 @@
+// The point of the "how to pay" panel is that a member never has to go back to
+// their inbox to pay, so what is pinned here is the panel's content: the amount
+// they owe, the reference that reconciles it, the club's account details, and
+// the fact that a bundle is ONE transfer rather than two. The email still goes
+// out unchanged; these are the same numbers, on the page.
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const PLAN_REF = "UTSJ-LOVE-A1B2";
+
+const pendingPlan = {
+  id: "m1",
+  plan_code: "2026-s2",
+  plan_name: "Semester 2 2026",
+  kind: "period",
+  status: "pending",
+  is_student: false,
+  price_cents: 24500,
+  payment_reference: PLAN_REF,
+  payment_method: "bank_transfer",
+  paid_at: null,
+  starts_at: null,
+  ends_at: null,
+  sessions_remaining: null,
+  session_date: null,
+  created_at: "2026-08-01T00:00:00Z",
+};
+const pendingInsurance = {
+  ...pendingPlan,
+  id: "m2",
+  plan_code: "insurance_yearly",
+  plan_name: "Yearly insurance",
+  kind: "insurance",
+  price_cents: 6000,
+};
+const activePlan = { ...pendingPlan, id: "m3", status: "active", paid_at: "2026-08-02T00:00:00Z" };
+
+const getMyMemberships = vi.fn();
+const getPaymentInstructions = vi.fn();
+
+function mine(memberships: unknown[]) {
+  return {
+    lifecycle: "visitor",
+    memberships,
+    uts_student_number: null,
+    sessions_attended: 0,
+  };
+}
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => opts,
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@tanstack/react-start", () => ({
+  useServerFn: (fn: unknown) => fn,
+}));
+
+vi.mock("@/lib/membership.functions", () => ({
+  listMembershipPlans: vi.fn().mockResolvedValue([]),
+  getMyMemberships: (...args: unknown[]) => getMyMemberships(...args),
+  getPaymentInstructions: (...args: unknown[]) => getPaymentInstructions(...args),
+  startMembership: vi.fn(),
+}));
+
+vi.mock("@/lib/code-of-conduct.functions", () => ({
+  getCodeOfConductSigner: vi.fn().mockResolvedValue({ status: null }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const { Route } = await import("./membership");
+const MembershipPage = (Route as unknown as { component: () => ReactNode }).component;
+
+/** The "how to pay" card, or null when the page is not showing one. */
+function payCard(): HTMLElement | null {
+  const title = screen.queryByText("How to pay");
+  return title ? (title.closest("div.rounded-xl") as HTMLElement) : null;
+}
+
+async function renderLoaded() {
+  render(<MembershipPage />);
+  await waitFor(() => expect(screen.getByRole("heading", { name: "Membership" })).toBeVisible());
+}
+
+beforeEach(() => {
+  getMyMemberships.mockReset().mockResolvedValue(mine([pendingPlan]));
+  getPaymentInstructions
+    .mockReset()
+    .mockResolvedValue({ instructions: "Pay **UTS Jitsu Club**, BSB 062-000, acct 1234 5678." });
+});
+
+describe("/membership: how to pay", () => {
+  it("shows the amount, the reference and the club's account details", async () => {
+    await renderLoaded();
+    const card = payCard()!;
+    expect(card).toBeInTheDocument();
+    expect(within(card).getByText("$245")).toBeVisible();
+    expect(within(card).getByText(PLAN_REF)).toBeVisible();
+    // The markdown a manager wrote at /manager/settings, rendered — this is the
+    // half that used to exist only in the invoice email.
+    expect(within(card).getByText(/BSB 062-000, acct 1234 5678/)).toBeVisible();
+    expect(within(card).getByText("UTS Jitsu Club")).toBeVisible();
+  });
+
+  it("renders the instructions as markdown, bullets and all", async () => {
+    // Not with `prose` classes: this repo has no typography plugin, so a set of
+    // bank details written as a list would otherwise render as one run-on line.
+    getPaymentInstructions.mockResolvedValue({
+      instructions: "Pay to:\n\n- BSB: 062-000\n- Account: 1234 5678",
+    });
+    await renderLoaded();
+    const card = payCard()!;
+    expect(within(card).getByRole("list").className).toContain("list-disc");
+    expect(within(card).getAllByRole("listitem")).toHaveLength(2);
+  });
+
+  it("copies the reference, which is what a bank transfer reconciles on", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    await renderLoaded();
+    await userEvent.click(within(payCard()!).getByRole("button", { name: /copy reference/i }));
+    expect(writeText).toHaveBeenCalledWith(PLAN_REF);
+  });
+
+  it("bills a bundled plan + insurance as one transfer, and shows the split", async () => {
+    // Two memberships, one reference: paying half of it against that reference
+    // would reconcile neither, so the member must be shown a single total.
+    getMyMemberships.mockResolvedValue(mine([pendingPlan, pendingInsurance]));
+    await renderLoaded();
+    const card = payCard()!;
+    expect(within(card).getByText("$305")).toBeVisible();
+    expect(within(card).getAllByText(PLAN_REF)).toHaveLength(1);
+    expect(within(card).getByText("Semester 2 2026 + Yearly insurance")).toBeVisible();
+    // The split, so the total does not read as a wrong price for the plan.
+    expect(within(card).getByText("$60")).toBeVisible();
+  });
+
+  it("bills two separate references as two transfers", async () => {
+    getMyMemberships.mockResolvedValue(
+      mine([pendingPlan, { ...pendingInsurance, payment_reference: "UTSJ-LOVE-C3D4" }]),
+    );
+    await renderLoaded();
+    const card = payCard()!;
+    expect(within(card).getByText(PLAN_REF)).toBeVisible();
+    expect(within(card).getByText("UTSJ-LOVE-C3D4")).toBeVisible();
+    expect(within(card).getAllByRole("button", { name: /copy reference/i })).toHaveLength(2);
+  });
+
+  it("says nothing about paying when nothing is owed", async () => {
+    getMyMemberships.mockResolvedValue(mine([activePlan]));
+    await renderLoaded();
+    expect(payCard()).toBeNull();
+  });
+
+  it("keeps the amount and reference when the club's details fail to load", async () => {
+    // The member's own invoice is already loaded; only the club's account
+    // details are missing, so the panel degrades rather than disappearing.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    getPaymentInstructions.mockRejectedValue(new Error("nope"));
+    await renderLoaded();
+    const card = payCard()!;
+    expect(within(card).getByText("$245")).toBeVisible();
+    expect(within(card).getByText(PLAN_REF)).toBeVisible();
+    expect(within(card).getByText(/invoice email we sent you/)).toBeVisible();
+    vi.restoreAllMocks();
+  });
+});

--- a/src/routes/_authenticated/membership.tsx
+++ b/src/routes/_authenticated/membership.tsx
@@ -1,13 +1,15 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
+import ReactMarkdown from "react-markdown";
 import { Check, Mail } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Pill } from "@/components/site/StatusPill";
+import { CopyButton } from "@/components/site/CopyButton";
 import { lifecycleClass } from "@/lib/status-colours";
 import { cn } from "@/lib/utils";
 import {
@@ -16,11 +18,19 @@ import {
   insuranceSelection,
   isUtsStudent,
   sellablePlans,
+  unpaidInvoices,
   type LifecycleStatus,
+  type UnpaidInvoice,
 } from "@/lib/validation";
+import { invoiceMarkdownComponents } from "@/lib/invoice-markdown";
 import { formatDateOnly } from "@/lib/dates";
 import { CLUB_TIME_ZONE, clubLocalDate } from "@/lib/calendar";
-import { getMyMemberships, listMembershipPlans, startMembership } from "@/lib/membership.functions";
+import {
+  getMyMemberships,
+  getPaymentInstructions,
+  listMembershipPlans,
+  startMembership,
+} from "@/lib/membership.functions";
 import { getCodeOfConductSigner } from "@/lib/code-of-conduct.functions";
 import type { CodeOfConductState } from "@/lib/code-of-conduct";
 
@@ -97,14 +107,114 @@ function CodeOfConductNudge() {
   );
 }
 
+/** How a line of an invoice is named when its plan could not be resolved. */
+function lineName(planName: string | null) {
+  return planName ?? "Membership";
+}
+
+/**
+ * Everything a member needs to actually pay: the amount, the reference, and the
+ * club's account details, on the page instead of in their inbox.
+ *
+ * The invoice email still goes out exactly as before. This is the copy they can
+ * get back to without going hunting through it, which is the whole point: the
+ * reference is the thing that reconciles a transfer, and it is the thing people
+ * most often come back for while standing in their banking app.
+ */
+function HowToPay({
+  invoices,
+  instructions,
+}: {
+  invoices: UnpaidInvoice[];
+  /** Null while the club's details could not be read. See the fallback below. */
+  instructions: string | null;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>How to pay</CardTitle>
+        <CardDescription>
+          Transfer the amount below and put the reference in the description. We activate your
+          membership as soon as it lands, and email you to confirm.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {invoices.map((invoice) => (
+          <div key={invoice.reference} className="rounded-lg border bg-muted/30 p-4">
+            <p className="text-sm font-medium">
+              {invoice.lines.map((l) => lineName(l.plan_name)).join(" + ")}
+            </p>
+            <dl className="mt-3 grid gap-4 sm:grid-cols-2">
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Amount
+                </dt>
+                <dd className="mt-1 text-2xl font-bold tracking-tight">
+                  {formatCents(invoice.total_cents)}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Payment reference
+                </dt>
+                <dd className="mt-1 flex flex-wrap items-center gap-2">
+                  <span className="font-mono text-lg font-semibold tracking-wide">
+                    {invoice.reference}
+                  </span>
+                  <CopyButton text={invoice.reference} label="Copy reference" />
+                </dd>
+              </div>
+            </dl>
+            {/* A bundle is two invoices on our side and one transfer on theirs.
+                Showing the split stops the total reading as a wrong price for
+                the plan they picked. */}
+            {invoice.lines.length > 1 && (
+              <ul className="mt-4 space-y-1 border-t pt-3 text-sm text-muted-foreground">
+                {invoice.lines.map((line) => (
+                  <li key={line.membership_id} className="flex justify-between gap-4">
+                    <span>{lineName(line.plan_name)}</span>
+                    <span>{formatCents(line.price_cents)}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ))}
+
+        {instructions ? (
+          <div className="text-sm text-muted-foreground">
+            <ReactMarkdown components={invoiceMarkdownComponents}>{instructions}</ReactMarkdown>
+          </div>
+        ) : (
+          /* The amount and reference above are the member's own data and already
+             loaded; only the club's account details are missing. Say which, and
+             point at the copy that is definitely in their inbox. */
+          <p className="flex items-start gap-2 text-sm text-muted-foreground">
+            <Mail className="mt-0.5 h-4 w-4 shrink-0" />
+            We could not load the club's account details just now. They are in the invoice email we
+            sent you, or reload this page to try again.
+          </p>
+        )}
+
+        <p className="text-xs text-muted-foreground">
+          Paid already? It can take a day or two to reach us. Nothing to do, we will email you when
+          it clears.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
 function MembershipPage() {
   const navigate = useNavigate();
   const fetchPlans = useServerFn(listMembershipPlans);
   const fetchMine = useServerFn(getMyMemberships);
+  const fetchInstructions = useServerFn(getPaymentInstructions);
   const start = useServerFn(startMembership);
 
   const [plans, setPlans] = useState<Plan[]>([]);
   const [mine, setMine] = useState<Mine | null>(null);
+  const [instructions, setInstructions] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [studentNumber, setStudentNumber] = useState("");
   const [sessionDate, setSessionDate] = useState(() => new Date().toISOString().slice(0, 10));
@@ -112,6 +222,10 @@ function MembershipPage() {
   // `insuranceSelection` and is only editable while the member has cover.
   const [insuranceTicked, setInsuranceTicked] = useState<boolean | null>(null);
   const [pendingCode, setPendingCode] = useState<string | null>(null);
+  // Set after a purchase that needs paying: the "how to pay" panel sits above
+  // the plan the member just chose, which on a phone is well off screen.
+  const [scrollToPay, setScrollToPay] = useState(false);
+  const payRef = useRef<HTMLDivElement | null>(null);
 
   // A non-empty UTS student number is what makes someone a student; there is no
   // separate "I'm a student" flag. It unlocks the discounted student rate. Same
@@ -138,15 +252,27 @@ function MembershipPage() {
 
   const reload = useMemo(
     () => () => {
-      return Promise.all([fetchPlans(), fetchMine()]).then(([p, m]) => {
+      return Promise.all([
+        fetchPlans(),
+        fetchMine(),
+        // The club's account details are the one thing here the member can do
+        // without: they still get the amount and reference, and the invoice
+        // email has the rest. So a failure degrades this panel instead of
+        // failing the page.
+        fetchInstructions().catch((e) => {
+          console.error("[membership] payment instructions failed to load:", e);
+          return { instructions: null };
+        }),
+      ]).then(([p, m, s]) => {
         setPlans(p);
         setMine(m);
+        setInstructions(s.instructions);
         // Prefill the student number from the member's waiver so they don't
         // retype it (blank there means they never gave one).
         if (m.uts_student_number) setStudentNumber(m.uts_student_number);
       });
     },
-    [fetchPlans, fetchMine],
+    [fetchPlans, fetchMine, fetchInstructions],
   );
 
   useEffect(() => {
@@ -154,6 +280,14 @@ function MembershipPage() {
       .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load memberships"))
       .finally(() => setLoading(false));
   }, [reload]);
+
+  // Runs after the panel has rendered, so the ref is attached by the time we
+  // reach for it. A member who ends up with nothing to pay just clears the flag.
+  useEffect(() => {
+    if (!scrollToPay) return;
+    payRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    setScrollToPay(false);
+  }, [scrollToPay]);
 
   async function choose(plan: Plan) {
     setPendingCode(plan.code);
@@ -173,7 +307,10 @@ function MembershipPage() {
       if (res.activated) {
         toast.success("You're all set. Your membership is active.");
       } else {
-        toast.success("Check your email for bank-transfer instructions.");
+        // The details are now on this page, above the plan they just picked, so
+        // send them there rather than to their inbox. The email still goes out.
+        toast.success("Your invoice is ready. The payment details are at the top of this page.");
+        setScrollToPay(true);
       }
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Could not start membership");
@@ -192,6 +329,9 @@ function MembershipPage() {
 
   const lifecycle = mine?.lifecycle ?? "lead";
   const status = LIFECYCLE_COPY[lifecycle];
+  // What the member still owes, as transfers rather than as rows: a bundled
+  // plan + insurance is two memberships behind one reference and one payment.
+  const unpaid = unpaidInvoices(mine?.memberships ?? []);
 
   // A dated plan drops off this list on its own once its `ends_on` passes —
   // there is no manager step to retire it, and no pro rata either way.
@@ -282,16 +422,15 @@ function MembershipPage() {
                   {mine.sessions_attended === 1 ? "" : "s"} with us.
                 </p>
               )}
-              {mine.memberships.some((m) => m.status === "pending") && (
-                <p className="mt-3 flex items-center gap-2 text-sm text-muted-foreground">
-                  <Mail className="h-4 w-4" />
-                  Awaiting a bank transfer? We emailed you the account details and your payment
-                  reference. Include the reference so we can match your payment automatically.
-                </p>
-              )}
             </CardContent>
           )}
         </Card>
+
+        {unpaid.length > 0 && (
+          <div ref={payRef} className="scroll-mt-4">
+            <HowToPay invoices={unpaid} instructions={instructions} />
+          </div>
+        )}
 
         <CodeOfConductNudge />
 

--- a/src/routes/_authenticated/membership.tsx
+++ b/src/routes/_authenticated/membership.tsx
@@ -2,14 +2,14 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
-import ReactMarkdown from "react-markdown";
-import { Check, Mail } from "lucide-react";
+import { Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Pill } from "@/components/site/StatusPill";
 import { CopyButton } from "@/components/site/CopyButton";
+import { ClubAccountDetails } from "@/components/site/ClubAccountDetails";
 import { lifecycleClass } from "@/lib/status-colours";
 import { cn } from "@/lib/utils";
 import {
@@ -19,10 +19,10 @@ import {
   isUtsStudent,
   sellablePlans,
   unpaidInvoices,
+  type ClubPaymentDetails,
   type LifecycleStatus,
   type UnpaidInvoice,
 } from "@/lib/validation";
-import { invoiceMarkdownComponents } from "@/lib/invoice-markdown";
 import { formatDateOnly } from "@/lib/dates";
 import { CLUB_TIME_ZONE, clubLocalDate } from "@/lib/calendar";
 import {
@@ -123,11 +123,14 @@ function lineName(planName: string | null) {
  */
 function HowToPay({
   invoices,
-  instructions,
+  details,
+  detailsUnreadable,
 }: {
   invoices: UnpaidInvoice[];
-  /** Null while the club's details could not be read. See the fallback below. */
-  instructions: string | null;
+  /** Null when the club has not published a complete set of account details. */
+  details: ClubPaymentDetails | null;
+  /** True when the settings could not be read, which reads differently. */
+  detailsUnreadable: boolean;
 }) {
   return (
     <Card>
@@ -181,20 +184,10 @@ function HowToPay({
           </div>
         ))}
 
-        {instructions ? (
-          <div className="text-sm text-muted-foreground">
-            <ReactMarkdown components={invoiceMarkdownComponents}>{instructions}</ReactMarkdown>
-          </div>
-        ) : (
-          /* The amount and reference above are the member's own data and already
-             loaded; only the club's account details are missing. Say which, and
-             point at the copy that is definitely in their inbox. */
-          <p className="flex items-start gap-2 text-sm text-muted-foreground">
-            <Mail className="mt-0.5 h-4 w-4 shrink-0" />
-            We could not load the club's account details just now. They are in the invoice email we
-            sent you, or reload this page to try again.
-          </p>
-        )}
+        {/* The amount and reference above are the member's own data and always
+            render. Only the club's account details can be missing, and the
+            component says which kind of missing it is. */}
+        <ClubAccountDetails details={details} unreadable={detailsUnreadable} />
 
         <p className="text-xs text-muted-foreground">
           Paid already? It can take a day or two to reach us. Nothing to do, we will email you when
@@ -214,7 +207,10 @@ function MembershipPage() {
 
   const [plans, setPlans] = useState<Plan[]>([]);
   const [mine, setMine] = useState<Mine | null>(null);
-  const [instructions, setInstructions] = useState<string | null>(null);
+  const [account, setAccount] = useState<{
+    details: ClubPaymentDetails | null;
+    unreadable: boolean;
+  }>({ details: null, unreadable: false });
   const [loading, setLoading] = useState(true);
   const [studentNumber, setStudentNumber] = useState("");
   const [sessionDate, setSessionDate] = useState(() => new Date().toISOString().slice(0, 10));
@@ -255,18 +251,18 @@ function MembershipPage() {
       return Promise.all([
         fetchPlans(),
         fetchMine(),
-        // The club's account details are the one thing here the member can do
-        // without: they still get the amount and reference, and the invoice
-        // email has the rest. So a failure degrades this panel instead of
-        // failing the page.
+        // The club's account details are the one thing here the member cannot
+        // supply themselves, but they are also the one thing that is not their
+        // own data: a failure degrades this panel into "we could not load
+        // these" instead of failing the whole page.
         fetchInstructions().catch((e) => {
-          console.error("[membership] payment instructions failed to load:", e);
-          return { instructions: null };
+          console.error("[membership] club account details failed to load:", e);
+          return { ok: false, details: null };
         }),
       ]).then(([p, m, s]) => {
         setPlans(p);
         setMine(m);
-        setInstructions(s.instructions);
+        setAccount({ details: s.details, unreadable: !s.ok });
         // Prefill the student number from the member's waiver so they don't
         // retype it (blank there means they never gave one).
         if (m.uts_student_number) setStudentNumber(m.uts_student_number);
@@ -442,7 +438,11 @@ function MembershipPage() {
             a purchase lands. */}
         {unpaid.length > 0 && (
           <div ref={payRef} className="scroll-mt-20">
-            <HowToPay invoices={unpaid} instructions={instructions} />
+            <HowToPay
+              invoices={unpaid}
+              details={account.details}
+              detailsUnreadable={account.unreadable}
+            />
           </div>
         )}
 

--- a/src/routes/_authenticated/membership.tsx
+++ b/src/routes/_authenticated/membership.tsx
@@ -270,6 +270,9 @@ function MembershipPage() {
         // Prefill the student number from the member's waiver so they don't
         // retype it (blank there means they never gave one).
         if (m.uts_student_number) setStudentNumber(m.uts_student_number);
+        // Handed back as well as stored: `choose` needs to know what the member
+        // owes NOW, and reading it out of state would still see the old value.
+        return m;
       });
     },
     [fetchPlans, fetchMine, fetchInstructions],
@@ -283,16 +286,20 @@ function MembershipPage() {
 
   // Runs after the panel has rendered, so the ref is attached by the time we
   // reach for it. A member who ends up with nothing to pay just clears the flag.
+  //
+  // `?.` on the method too: this is a convenience on top of a panel that is
+  // already on screen, and an environment without `scrollIntoView` must lose the
+  // scroll, not throw out of an effect and take the whole page with it.
   useEffect(() => {
     if (!scrollToPay) return;
-    payRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    payRef.current?.scrollIntoView?.({ behavior: "smooth", block: "start" });
     setScrollToPay(false);
   }, [scrollToPay]);
 
   async function choose(plan: Plan) {
     setPendingCode(plan.code);
     try {
-      const res = await start({
+      await start({
         data: {
           plan_code: plan.code,
           is_student: isStudent,
@@ -303,14 +310,18 @@ function MembershipPage() {
         },
       });
       setInsuranceTicked(null);
-      await reload();
-      if (res.activated) {
-        toast.success("You're all set. Your membership is active.");
-      } else {
+      const refreshed = await reload();
+      // What they owe after the purchase, not whether the plan itself activated:
+      // a free plan bought with insurance bundled activates AND leaves an
+      // invoice, and "you're all set" is the wrong thing to tell someone who
+      // still has to transfer money.
+      if (unpaidInvoices(refreshed.memberships).length > 0) {
         // The details are now on this page, above the plan they just picked, so
         // send them there rather than to their inbox. The email still goes out.
         toast.success("Your invoice is ready. The payment details are at the top of this page.");
         setScrollToPay(true);
+      } else {
+        toast.success("You're all set. Your membership is active.");
       }
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Could not start membership");
@@ -426,8 +437,11 @@ function MembershipPage() {
           )}
         </Card>
 
+        {/* `scroll-mt-20` clears the member-space header (`sticky top-0 h-14`),
+            which would otherwise sit over the card's title once the scroll after
+            a purchase lands. */}
         {unpaid.length > 0 && (
-          <div ref={payRef} className="scroll-mt-4">
+          <div ref={payRef} className="scroll-mt-20">
             <HowToPay invoices={unpaid} instructions={instructions} />
           </div>
         )}


### PR DESCRIPTION
## What changes for members

Two changes stacked, both about paying an invoice without leaving the page.

### 1. The "How to pay" panel (`/membership`)

A member who owes money sees the amount, the payment reference with a copy button, and the club's account details, above the plan list. Previously the page told them to go and find the invoice email.

- A plan bought **with yearly insurance** is two invoices on our side but **one transfer** on theirs (one reference), so it shows as a single payment with the split underneath. Paying half of it against that reference would reconcile neither.
- After choosing a plan, the toast points at the panel and the page scrolls to it.

### 2. The club's account is named fields, not prose

The account was one block of manager-written markdown. It is now eight named fields, and **every value has its own copy button**:

```
Account name    UTS Jitsu Club Inc              [Copy]
BSB             062-000                         [Copy]
Account number  12345678                        [Copy]
Bank            Commonwealth Bank of Australia  [Copy]
```

Underneath, a **"Paying from overseas?"** disclosure (closed by default, hidden entirely if unused) with SWIFT/BIC, the bank's address and the club's address.

Australia has no IBAN, so the **BIC (the same thing as a SWIFT code) plus the BSB and account number** is what a sending bank abroad asks for. The overseas block also warns that banks in the middle take fees out, so ask yours to send the full amount. That is not decoration: reconciliation matches on the reference **and the exact amount**, so a fee-shortened international payment activates nothing and waits for a manager.

**Managers**: `/manager/settings` becomes a form instead of a markdown textarea, with per-field validation (a BSB is six digits, a BIC is 8 or 11 characters) and the member's own panel as the live preview, so what is previewed is what is delivered.

### What you'll feel

- **There is no fallback to the old free text**, by request. Between merge and the form being saved, the page and the invoice email say the club has not published its account details and to get in touch. `/manager/settings` leads with a warning while that is true, and shows the old text read-only so the values can be copied across. **Fill the form straight after merge.**
- The invoice email's payment block changes shape, from rendered markdown to the same labelled rows, and now links back to the page where copying works. Same trigger, same recipient, same subject.

## Technical notes

Four commits: two preparatory refactors, the panel, review fixes, then the structured fields.

- **No migration.** `club_settings.value` is `TEXT` and the table is a generic key/value store, so this is a new key (`invoice_payment_details`) written at runtime. The legacy `invoice_payment_instructions` row is left in place for the manager screen's read-only box and deleted in a follow-up.
- **The four account fields are required together**, and an incomplete set parses as `null`. A half-filled account is worse than none because it looks payable.
- **The BSB is stored as six bare digits** and formatted in exactly one place (`clubPaymentFieldValue`), so what is on screen and what lands on the clipboard cannot disagree.
- **One ordered field list** (`CLUB_ACCOUNT_FIELDS` / `CLUB_INTERNATIONAL_FIELDS` in `validation.ts`) walked by both the page and the email, which is what stops the two quoting different bank details.
- `readClubPaymentDetails` keeps "never published" apart from "could not read", because the screens say different things about them.
- New `ClubAccountDetails` component shared by the member panel and the manager preview; `CopyButton` extracted earlier is reused per row with a per-field accessible name.

Tests cover the schema and BSB/BIC rules, the three read outcomes, every copy button pinned to the exact string it copies, the overseas block's collapsed default, the not-published state, and the manager form's validation and save payload. Screenshotted at 1280px and 375px.

`bun run lint`, `bun run typecheck`, `bun run test` (1638 passing) and `bun run build` all green locally.