### PR TITLE
Let button rows wrap instead of overflowing on a phone

### DIFF
--- a/src/components/site/BlogPostEditor.tsx
+++ b/src/components/site/BlogPostEditor.tsx
@@ -328,7 +328,7 @@ export function BlogPostEditor({
       </div>
       <div>
         <Label htmlFor="post-cover-image">Cover image</Label>
-        <div className="mt-1.5 flex items-center gap-3">
+        <div className="mt-1.5 flex flex-wrap items-center gap-3">
           {coverUrl && (
             <img
               src={coverUrl}

--- a/src/components/site/KbArticleReader.tsx
+++ b/src/components/site/KbArticleReader.tsx
@@ -422,7 +422,7 @@ function Thread({
                 placeholder="Reply..."
                 className="text-sm"
               />
-              <div className="flex gap-2">
+              <div className="flex flex-wrap gap-2">
                 <Button
                   size="sm"
                   disabled={busy || !replyBody.trim()}
@@ -516,7 +516,7 @@ function AnnotationCard({
             maxLength={5000}
             className="text-sm"
           />
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <Button
               size="sm"
               disabled={busy || !draft.trim()}

--- a/src/routes/_authenticated/manager.calendar.tsx
+++ b/src/routes/_authenticated/manager.calendar.tsx
@@ -763,7 +763,7 @@ function ManagerCalendarPage() {
                                 />
                                 Show an &quot;invite only&quot; badge
                               </label>
-                              <div className="flex items-end gap-2">
+                              <div className="flex flex-wrap items-end gap-2">
                                 <Button
                                   size="sm"
                                   onClick={() => saveEdit(ev)}

--- a/src/routes/_authenticated/manager.check-in.tsx
+++ b/src/routes/_authenticated/manager.check-in.tsx
@@ -253,7 +253,7 @@ function CheckInPage() {
             Mark who is on the mat. Checking someone in uses one of their sessions.
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           <Button asChild variant="outline">
             <Link to="/manager/calendar">Calendar</Link>
           </Button>

--- a/src/routes/_authenticated/manager.kb.tsx
+++ b/src/routes/_authenticated/manager.kb.tsx
@@ -1810,7 +1810,7 @@ function KnowledgeBaseManager() {
                   {preview ? `Version ${preview.version}: ${preview.title}` : "Preview"}
                 </CardTitle>
                 {preview && (
-                  <div className="flex items-center gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
                     {/* Said plainly, because the panel now shows text that is NOT
                         what members are reading, and nothing else on the page says
                         so. */}

--- a/src/routes/_authenticated/manager.membership-plans.tsx
+++ b/src/routes/_authenticated/manager.membership-plans.tsx
@@ -296,7 +296,7 @@ function PlanCard({
           onKindChange={(kind) => onPatch(plan.id, planTypePatch(kind))}
           onFieldChange={(patch) => onPatch(plan.id, patch)}
         />
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           <Button size="sm" disabled={!dirty || savingId === plan.id} onClick={() => onSave(plan)}>
             {savingId === plan.id ? "Saving..." : "Save"}
           </Button>

--- a/src/routes/blog/$slug.tsx
+++ b/src/routes/blog/$slug.tsx
@@ -121,7 +121,7 @@ function CommentComposer({
       {remaining <= 200 && (
         <p className="text-xs text-muted-foreground">{remaining} characters left</p>
       )}
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         <Button size="sm" disabled={busy || !body.trim()} onClick={handleSubmit}>
           {busy ? "Posting..." : "Post"}
         </Button>


### PR DESCRIPTION
## What changes

Seven rows of buttons across the site now wrap onto a second line on a narrow screen instead of running off the side. Nothing else changes: every button does exactly what it did before, and no wide-screen layout moves, because wrapping only kicks in when the content does not fit.

Where a manager or member will notice it:

- **Check in** (`/manager/check-in`) — the Calendar and Users buttons at the top. This is the phone-in-hand screen managers use on the mat, so it is the one that most needed it.
- **Knowledge base article** — the Reply and Cancel buttons under an annotation, and Save/Cancel when editing one.
- **Knowledge base editor** (`/manager/kb`) — the "Not live. Members are reading version N." banner and its "Back to the editor" button, which is the longest of these rows and the most likely to overflow.
- **Blog post** — the Post and Cancel buttons under the comment box.
- **Membership plans** (`/manager/membership-plans`) — the Save and Duplicate pair on each plan card.
- **Calendar** (`/manager/calendar`) — the Save and Cancel pair when editing an entry.
- **Blog post editor** — the cover image row, where the preview thumbnail and the upload button shared a single line.

Left alone deliberately: the site header and the marketing call-to-action blocks on `/classes` and `/first-class` already change layout at a breakpoint rather than relying on wrapping.

## Why

Follow-up to #27, which fixed the same overflow on `/manager/memberships`. Reviewing that change surfaced Check in as the last manager header row with the problem; sweeping for the same pattern found the nested rows above. The top-of-page rows were the visible bug, most of the nested ones are lower risk (short `Save`/`Cancel` labels inside cards) but the same shape, so they are fixed together rather than left to resurface.

## Worth knowing when reviewing

Every one of these screens is behind sign-in, so none of them is covered by the PR-screenshots job, which only shoots the public pages. There is no automated visual confirmation of these changes; the two worth eyeballing at phone width are the blog post editor's cover image row and the knowledge base preview banner.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (1594 passing) and `bun run build` all pass locally. No behavioral logic changed, so no test or doc updates were needed.