### PR TITLE
Add 3 UX bar rules: load errors, confirm friction, loading a11y

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -655,6 +655,13 @@ Then hold the change to this:
 - **A toast is not a UI for anything that matters.** It auto-dismisses, it is
   easy to miss on a phone, and it leaves nothing to press. Use it for "saved",
   not for "your waiver did not go through".
+- **That rule applies to a failed load, not just a failed submit.** A list page
+  that catches a fetch error with only `toast.error(...)` and then renders an
+  empty table is indistinguishable from "there's nothing here" once the toast
+  fades — the manager has no way to tell a genuinely empty list from a broken
+  one. Keep the error on screen (a `loadError`-style state) with a retry
+  action; `manager.contact-messages.tsx` is the pattern to copy, not the
+  `toast.error()` + empty-table pattern most manager list pages default to.
 - **Never lose someone's input.** A failed submit keeps the form filled and
   offers the retry. Ask for as little as possible in the first place, and prefill
   what we already know (the waiver does this with `getMyLatestWaiver`). Every
@@ -666,12 +673,27 @@ Then hold the change to this:
   happen** — in words, before the click. Approving a waiver emails the member and
   unlocks their login; activating a membership grants a role. The person pressing
   the button should already know that.
+- **Match that confirm's friction to reversibility, and build it one way.** A
+  reversible action (cancel, hide, reorder) should just happen, with an undo
+  option if you want a safety net — a modal gate on it only slows down the 99%
+  of clicks that were correct. Save the hard stop for actions that are both
+  irreversible and consequential, like the waiver-approval example above, and
+  build that stop as the app's own `AlertDialog` (see `manager.blog.tsx`'s
+  delete confirmation), never the browser's `window.confirm()`. Confirming
+  everything trains people to click through without reading, which is exactly
+  what makes the one confirm that matters stop working.
 - **Mobile first.** Most of this club's traffic is phones. Check at ~375px wide,
   keep tap targets thumb-sized, and never hide something behind hover alone.
 - **Accessibility is part of "done", not a follow-up.** Real `<button>` and `<a>`
   elements, labels tied to their inputs, `role="status"` / `aria-live` on async
   updates, visible focus, contrast through the theme tokens. `AuthPending` and
   `SubmitStatus` are small, correct examples to copy.
+- **Copy that live-region wiring, not just the look, onto every loading state.**
+  A page that renders its own bare `Loading...` text instead of reusing
+  `AuthPending`/`SubmitStatus` still needs `role="status"` (or
+  `aria-live="polite"`) on it — otherwise a screen-reader user gets no signal
+  that anything is happening or has finished, even though a sighted user sees
+  the same information those two components already announce correctly.
 - **Look at it.** For a UI change, run the app and open the screen (the `/run`
   skill launches it), or read the PR-screenshots artifact. Note what that job
   does _not_ catch: a route that handles its own loader error and renders a card


### PR DESCRIPTION
## Summary

Adds three new bullets to CLAUDE.md's "The UX bar" section, each extending an existing rule to close a gap found while auditing manager pages against it:

- **Load errors get the same treatment as submit errors.** Several manager list pages (`manager.users.tsx`, `manager.blog.tsx`, etc.) catch a fetch failure with only `toast.error(...)` and then render an empty table — indistinguishable from "there's nothing here" once the toast fades. `manager.contact-messages.tsx` already does this correctly (persisted `loadError` state + retry) and is now named as the pattern to copy.
- **Match confirm friction to reversibility, and build it one way.** The repo currently mixes `window.confirm()` (17 sites across 9 files), a single proper `AlertDialog` (`manager.blog.tsx`'s delete), and — on `manager.waivers.tsx`'s Approve button — no confirmation at all, despite that action emailing the member and unlocking their login (the doc's own worked example of what should require a confirm). The new rule triages by reversibility: reversible actions get undo-after, not a modal; irreversible + consequential ones get the app's `AlertDialog`, never `window.confirm()`.
- **Loading states need `role="status"`/`aria-live`, not just the visual look.** 25 files render bare `Loading...` text with no live-region markup, while `AuthPending`/`SubmitStatus` (already named in the doc as the model) wire this up correctly.

This is documentation only — no application code changed. The gaps above are named as candidates for a follow-up fix, not fixed here.

## Test plan

- [x] Docs-only change; no code paths touched.
- [x] Verified every cited file:line reference directly (grep/read) before writing the rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_019RhyEWNpjaFE6eWgfr1Hqo)_