### PR TITLE
Add e2e coverage for the membership and check-in flows

### DIFF
--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -126,6 +126,8 @@ artifact so it can be found.
 ## What is deliberately not covered yet
 
 This is the scaffold. It carries one flow per audience to prove the harness
-works end to end; the rest arrive in their own changes. The obvious next ones:
-signing a waiver through to the PDF, a manager approving one and the member's
-login being set up, the membership and invoice flows, and the knowledge base.
+works end to end; the rest arrive in their own changes. The membership and
+invoice flows are now covered (`manager/memberships.spec.ts`,
+`manager/check-in.spec.ts`, `member/membership.spec.ts`) — the obvious next
+ones left are signing a waiver through to the PDF, a manager approving one and
+the member's login being set up, and the knowledge base.

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -128,6 +128,8 @@ artifact so it can be found.
 This is the scaffold. It carries one flow per audience to prove the harness
 works end to end; the rest arrive in their own changes. The membership and
 invoice flows are now covered (`manager/memberships.spec.ts`,
-`manager/check-in.spec.ts`, `member/membership.spec.ts`) — the obvious next
-ones left are signing a waiver through to the PDF, a manager approving one and
-the member's login being set up, and the knowledge base.
+`manager/check-in.spec.ts`, `member/membership.spec.ts`), and so is the whole
+new-member story end to end — register, sign, get approved, use the trial,
+buy a plan, get checked in on it, get paid, and later switch plans
+(`manager/new-member-journey.spec.ts`, one connected test rather than one
+screen). The obvious next thing left is the knowledge base.

--- a/e2e/manager/check-in.spec.ts
+++ b/e2e/manager/check-in.spec.ts
@@ -13,6 +13,8 @@ let applicantId: string;
 
 /** Membership rows this file arranges or raises, removed once in afterAll. */
 const createdMembershipIds: string[] = [];
+/** Calendar events this file arranges, removed once in afterAll. */
+const createdEventIds: string[] = [];
 /** The seeded trial's original status/credits, restored once in afterAll. */
 let originalTrial: { id: string; status: string; sessions_remaining: number | null } | null = null;
 
@@ -27,6 +29,9 @@ test.afterAll(async () => {
   await adminClient().from("session_checkins").delete().eq("user_id", applicantId);
   if (createdMembershipIds.length > 0) {
     await adminClient().from("memberships").delete().in("id", createdMembershipIds);
+  }
+  if (createdEventIds.length > 0) {
+    await adminClient().from("calendar_events").delete().in("id", createdEventIds);
   }
   if (originalTrial) {
     await adminClient()
@@ -227,4 +232,86 @@ test("a check-in that outruns the trial's two sessions lands uncovered on the th
   await page.getByRole("button", { name: "Check in" }).click();
   await expect(page.getByText(/nothing covers it\. Added to needs attention\./)).toBeVisible();
   await expect(page.getByRole("heading", { name: "Needs attention (1)" })).toBeVisible();
+});
+
+test("a manager raises a membership after the trial, checks the person in, and pays the invoice", async ({
+  page,
+}) => {
+  // A class of its own: the five seeded ones are already spoken for by
+  // check-ins the two tests above put against them for this same applicant,
+  // so a fresh one avoids fighting over a check-in row rather than testing
+  // anything about coverage.
+  const { data: event, error: eventErr } = await adminClient()
+    .from("calendar_events")
+    .insert({
+      title: "Drop-in class",
+      starts_at: new Date(Date.now() + 3 * 86_400_000).toISOString(),
+      ends_at: new Date(Date.now() + 3 * 86_400_000 + 2 * 3_600_000).toISOString(),
+    })
+    .select("id")
+    .single();
+  if (eventErr || !event) throw new Error(`could not arrange a class: ${eventErr?.message}`);
+  createdEventIds.push(event.id);
+
+  // The manager raises a real plan now that the trial (spent above) is
+  // behind them — mirrors doing this in person rather than the member
+  // buying it themselves. The period plan, not casual_session: the
+  // recoverable-delete test above leaves its own casual_session invoice for
+  // this same applicant sitting unpaid until this file's afterAll runs, and
+  // the app's payment reference is deterministic (surname + user id + plan
+  // dates), so reusing that plan here would collide with it.
+  const { data: periodPlan } = await adminClient()
+    .from("membership_plans")
+    .select("id, code, name")
+    .eq("kind", "period")
+    .limit(1)
+    .single();
+  if (!periodPlan) throw new Error("no seeded period plan");
+
+  await page.goto(`/manager/users/${applicantId}`);
+  await page.getByRole("button", { name: "Add a membership" }).click();
+  const planSelect = page.getByLabel("Plan");
+  await planSelect.selectOption(periodPlan.code);
+  await page.getByRole("checkbox", { name: "Email them the payment instructions" }).uncheck();
+  await page.getByRole("button", { name: "Add membership" }).click();
+  // The click only dispatches the request; the card resets this to blank
+  // only once the write has actually landed. Querying the database before
+  // this would race the insert.
+  await expect(planSelect).toHaveValue("");
+
+  const { data: created } = await adminClient()
+    .from("memberships")
+    .select("id, payment_reference")
+    .eq("user_id", applicantId)
+    .eq("plan_id", periodPlan.id)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .single();
+  if (!created) throw new Error("raising the membership did not create a row");
+  createdMembershipIds.push(created.id);
+
+  await page.goto("/manager/check-in");
+  await page.locator("#class-picker").selectOption(event.id);
+  await page.getByPlaceholder("Search by name or email").fill(APPLICANT_EMAIL);
+  await page.getByRole("button", { name: "Check in" }).click();
+
+  // Unpaid is not a reason to refuse a check-in either — a membership is
+  // authorised the moment it is raised, regardless of money (see
+  // docs/memberships.md) — but the door warns about it. Scoped to the "Here
+  // now" table specifically: the "Check someone in" table below it can list
+  // other seeded people who hold this same period plan, and their rows
+  // would also match the plan name.
+  const hereNow = page
+    .getByRole("heading", { name: /Here now/ })
+    .locator("xpath=following-sibling::div[1]");
+  const hereRow = hereNow.getByRole("row").filter({ hasText: periodPlan.name });
+  await expect(hereRow).toHaveCount(1);
+  await expect(hereRow).toContainText("waiting on a payment");
+
+  await page.goto(`/manager/users/${applicantId}`);
+  const row = page.getByRole("row").filter({ hasText: created.payment_reference });
+  await expect(row).toHaveCount(1);
+  await row.getByRole("button", { name: "Mark as paid" }).click();
+  await page.getByRole("alertdialog").getByRole("button", { name: "Mark as paid" }).click();
+  await expect(row.getByRole("button", { name: "Mark as paid" })).toHaveCount(0);
 });

--- a/e2e/manager/check-in.spec.ts
+++ b/e2e/manager/check-in.spec.ts
@@ -115,9 +115,9 @@ test("a membership blocked from deletion by a check-in can be freed by moving it
   await page.getByLabel("Plan").selectOption("casual_session");
   await page.getByRole("checkbox", { name: "Email them the payment instructions" }).uncheck();
   await page.getByRole("button", { name: "Add membership" }).click();
-  const rowB = page.getByRole("row").filter({ hasText: "Casual class" });
-  await expect(rowB).toHaveCount(1);
 
+  // Tracked before any assertion that could throw, so a failed assertion
+  // below still leaves this row queued for afterAll to remove.
   const { data: casualPlan } = await adminClient()
     .from("membership_plans")
     .select("id")
@@ -132,6 +132,13 @@ test("a membership blocked from deletion by a check-in can be freed by moving it
     .limit(1)
     .single();
   if (membershipB) createdMembershipIds.push(membershipB.id);
+
+  // Matched on price as well as name: the Sessions table's "Move to..."
+  // dropdown below will shortly offer Membership B as an option, and its
+  // plan-name text counts toward that row's `hasText` match too — but its
+  // options never show a price.
+  const rowB = page.getByRole("row").filter({ hasText: "Casual class" }).filter({ hasText: "$30" });
+  await expect(rowB).toHaveCount(1);
 
   const sessionsRow = page.getByRole("row").filter({ hasText: "Tuesday class" });
   await expect(sessionsRow).toHaveCount(1);

--- a/e2e/manager/check-in.spec.ts
+++ b/e2e/manager/check-in.spec.ts
@@ -44,6 +44,12 @@ test.afterAll(async () => {
  * first. Read fresh each time rather than cached: the check-in screen tops up
  * the recurring series on every load, and while that only ever appends to the
  * future end, reading live is what makes that assumption safe to make once.
+ *
+ * The earliest one (day -14 from seed time) sits right at the check-in
+ * screen's 14-day lookback edge, so a CI run that happens to straddle a UTC
+ * midnight between seeding and a test using it could briefly push it outside
+ * the window — a known, narrow residual risk this suite accepts rather than
+ * arranging synthetic events to fully engineer away.
  */
 async function seededClassEventIds(limit: number): Promise<string[]> {
   const { data, error } = await adminClient()
@@ -128,11 +134,12 @@ test("a membership blocked from deletion by a check-in can be freed by moving it
     .select("id")
     .eq("code", "casual_session")
     .single();
+  if (!casualPlan) throw new Error("no seeded casual_session plan");
   const { data: membershipB } = await adminClient()
     .from("memberships")
     .select("id")
     .eq("user_id", applicantId)
-    .eq("plan_id", casualPlan!.id)
+    .eq("plan_id", casualPlan.id)
     .order("created_at", { ascending: false })
     .limit(1)
     .single();

--- a/e2e/manager/check-in.spec.ts
+++ b/e2e/manager/check-in.spec.ts
@@ -6,7 +6,7 @@
 
 import { expect, test } from "@playwright/test";
 
-import { adminClient, applicantUserId } from "../support/fixture";
+import { APPLICANT_EMAIL, adminClient, applicantUserId } from "../support/fixture";
 import { expectPageRendered } from "../support/page";
 
 let applicantId: string;
@@ -98,7 +98,7 @@ test("a membership blocked from deletion by a check-in can be freed by moving it
   await page.goto("/manager/check-in");
   await expectPageRendered(page);
   await page.locator("#class-picker").selectOption(eventId);
-  await page.getByPlaceholder("Search by name or email").fill("applicant@example.com");
+  await page.getByPlaceholder("Search by name or email").fill(APPLICANT_EMAIL);
   await page.getByRole("button", { name: "Check in" }).click();
   await expect(page.getByText(/are in/)).toBeVisible();
 
@@ -190,12 +190,12 @@ test("a check-in that outruns the trial's two sessions lands uncovered on the th
   await page.goto("/manager/check-in");
 
   await page.locator("#class-picker").selectOption(event1);
-  await page.getByPlaceholder("Search by name or email").fill("applicant@example.com");
+  await page.getByPlaceholder("Search by name or email").fill(APPLICANT_EMAIL);
   await page.getByRole("button", { name: "Check in" }).click();
   await expect(page.getByText(/Free trial, 1 left/)).toBeVisible();
 
   await page.locator("#class-picker").selectOption(event2);
-  await page.getByPlaceholder("Search by name or email").fill("applicant@example.com");
+  await page.getByPlaceholder("Search by name or email").fill(APPLICANT_EMAIL);
   await page.getByRole("button", { name: "Check in" }).click();
   await expect(page.getByText(/Free trial, 0 left/)).toBeVisible();
 
@@ -211,7 +211,7 @@ test("a check-in that outruns the trial's two sessions lands uncovered on the th
   // (docs/check-in.md, rule 5) — it lands uncovered instead, for a manager to
   // sort out later, rather than turning someone away at the door.
   await page.locator("#class-picker").selectOption(event3);
-  await page.getByPlaceholder("Search by name or email").fill("applicant@example.com");
+  await page.getByPlaceholder("Search by name or email").fill(APPLICANT_EMAIL);
   await page.getByRole("button", { name: "Check in" }).click();
   await expect(page.getByText(/nothing covers it\. Added to needs attention\./)).toBeVisible();
   await expect(page.getByRole("heading", { name: "Needs attention (1)" })).toBeVisible();

--- a/e2e/manager/check-in.spec.ts
+++ b/e2e/manager/check-in.spec.ts
@@ -1,0 +1,211 @@
+// Check-in is what actually produces the "can't delete, a class was checked
+// in against it" block, and it is where the free trial's two-session limit
+// becomes visible. Both tests act on the seeded applicant, who is never
+// signed in themselves (see applicantUserId in support/fixture.ts) — only
+// ever the person a manager is checking in or fixing up.
+
+import { expect, test } from "@playwright/test";
+
+import { adminClient, applicantUserId } from "../support/fixture";
+import { expectPageRendered } from "../support/page";
+
+let applicantId: string;
+
+/** Membership rows this file arranges or raises, removed once in afterAll. */
+const createdMembershipIds: string[] = [];
+/** The seeded trial's original status/credits, restored once in afterAll. */
+let originalTrial: { id: string; status: string; sessions_remaining: number | null } | null = null;
+
+test.beforeAll(async () => {
+  applicantId = await applicantUserId();
+});
+
+test.afterAll(async () => {
+  // The applicant has no organic check-ins in the seeded club (see
+  // scripts/seed-local-club.mjs), so every one of theirs belongs to this file
+  // and can be cleared without tracking individual check-in ids.
+  await adminClient().from("session_checkins").delete().eq("user_id", applicantId);
+  if (createdMembershipIds.length > 0) {
+    await adminClient().from("memberships").delete().in("id", createdMembershipIds);
+  }
+  if (originalTrial) {
+    await adminClient()
+      .from("memberships")
+      .update({
+        status: originalTrial.status,
+        sessions_remaining: originalTrial.sessions_remaining,
+      })
+      .eq("id", originalTrial.id);
+  }
+});
+
+/**
+ * The five classes scripts/seed-local-club.mjs puts on the calendar, oldest
+ * first. Read fresh each time rather than cached: the check-in screen tops up
+ * the recurring series on every load, and while that only ever appends to the
+ * future end, reading live is what makes that assumption safe to make once.
+ */
+async function seededClassEventIds(limit: number): Promise<string[]> {
+  const { data, error } = await adminClient()
+    .from("calendar_events")
+    .select("id")
+    .eq("title", "Tuesday class")
+    .order("starts_at", { ascending: true })
+    .limit(limit);
+  if (error || !data || data.length < limit) {
+    throw new Error(`fewer than ${limit} seeded classes to check the applicant in against`);
+  }
+  return data.map((e) => e.id);
+}
+
+test("a membership blocked from deletion by a check-in can be freed by moving it", async ({
+  page,
+}) => {
+  // Membership A: arranged directly with wide-open dates, so it is the only
+  // thing that can cover the class picked below regardless of when this runs
+  // — this test is about the delete guard and the Move control, not about
+  // coverage precedence.
+  const { data: periodPlan } = await adminClient()
+    .from("membership_plans")
+    .select("id")
+    .eq("kind", "period")
+    .limit(1)
+    .single();
+  if (!periodPlan) throw new Error("no seeded period plan to arrange Membership A on");
+
+  const referenceA = `E2E-CHECKIN-A-${crypto.randomUUID().slice(0, 8)}`;
+  const { data: membershipA, error: aErr } = await adminClient()
+    .from("memberships")
+    .insert({
+      user_id: applicantId,
+      plan_id: periodPlan.id,
+      status: "active",
+      price_cents: 5000,
+      payment_reference: referenceA,
+      payment_method: "bank_transfer",
+      starts_at: new Date(Date.now() - 200 * 86_400_000).toISOString(),
+      ends_at: new Date(Date.now() + 200 * 86_400_000).toISOString(),
+    })
+    .select("id")
+    .single();
+  if (aErr || !membershipA) throw new Error(`could not arrange Membership A: ${aErr?.message}`);
+  createdMembershipIds.push(membershipA.id);
+
+  // The 4th-earliest seeded class: clear of the three the trial-exhaustion
+  // test below uses, so the two tests never fight over one check-in row.
+  const [, , , eventId] = await seededClassEventIds(4);
+
+  await page.goto("/manager/check-in");
+  await expectPageRendered(page);
+  await page.locator("#class-picker").selectOption(eventId);
+  await page.getByPlaceholder("Search by name or email").fill("applicant@example.com");
+  await page.getByRole("button", { name: "Check in" }).click();
+  await expect(page.getByText(/are in/)).toBeVisible();
+
+  await page.goto(`/manager/users/${applicantId}`);
+  const rowA = page.getByRole("row").filter({ hasText: referenceA });
+  const deleteA = rowA.getByRole("button", { name: "Delete" });
+  await expect(deleteA).toBeDisabled();
+  await expect(deleteA).toHaveAttribute("title", /a class was checked in against it/);
+  // Attendance is not a reason to keep a membership open — only a payment is
+  // (see the "Cancel vs Delete" note in docs/memberships.md).
+  await expect(rowA.getByRole("button", { name: "Cancel" })).toBeEnabled();
+
+  await page.getByRole("button", { name: "Add a membership" }).click();
+  await page.getByLabel("Plan").selectOption("casual_session");
+  await page.getByRole("checkbox", { name: "Email them the payment instructions" }).uncheck();
+  await page.getByRole("button", { name: "Add membership" }).click();
+  const rowB = page.getByRole("row").filter({ hasText: "Casual class" });
+  await expect(rowB).toHaveCount(1);
+
+  const { data: casualPlan } = await adminClient()
+    .from("membership_plans")
+    .select("id")
+    .eq("code", "casual_session")
+    .single();
+  const { data: membershipB } = await adminClient()
+    .from("memberships")
+    .select("id")
+    .eq("user_id", applicantId)
+    .eq("plan_id", casualPlan!.id)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .single();
+  if (membershipB) createdMembershipIds.push(membershipB.id);
+
+  const sessionsRow = page.getByRole("row").filter({ hasText: "Tuesday class" });
+  await expect(sessionsRow).toHaveCount(1);
+  const moveSelect = sessionsRow.getByLabel("Membership to move this check-in to");
+  const targetValue = await moveSelect
+    .locator("option", { hasText: "Casual class" })
+    .getAttribute("value");
+  if (!targetValue) throw new Error("Membership B is not offered as a move target");
+  await moveSelect.selectOption(targetValue);
+  await sessionsRow.getByRole("button", { name: "Move" }).click();
+  await expect(page.getByText("Moved to Casual class.")).toBeVisible();
+
+  // The class moved off it, so the delete guard has nothing left to say.
+  await expect(deleteA).toBeEnabled();
+  await deleteA.click();
+  await page.getByRole("alertdialog").getByRole("button", { name: "Delete" }).click();
+  await expect(page.getByRole("row").filter({ hasText: referenceA })).toHaveCount(0);
+});
+
+test("a check-in that outruns the trial's two sessions lands uncovered on the third", async ({
+  page,
+}) => {
+  const { data: trial, error: tErr } = await adminClient()
+    .from("memberships")
+    .select("id, status, sessions_remaining")
+    .eq("payment_reference", "JITSU-000103")
+    .single();
+  if (tErr || !trial) {
+    throw new Error(`could not find the seeded trial membership: ${tErr?.message}`);
+  }
+  originalTrial = {
+    id: trial.id,
+    status: trial.status,
+    sessions_remaining: trial.sessions_remaining,
+  };
+
+  // The seeded row is a legacy `pending` trial with one credit left (see
+  // scripts/seed-local-club.mjs) — not the clean "active, two credits" start
+  // this test needs, so it is arranged directly rather than through the app.
+  await adminClient()
+    .from("memberships")
+    .update({ status: "active", sessions_remaining: 2 })
+    .eq("id", trial.id);
+
+  // The three earliest seeded classes: clear of the one the recoverable-
+  // delete test above uses.
+  const [event1, event2, event3] = await seededClassEventIds(3);
+
+  await page.goto("/manager/check-in");
+
+  await page.locator("#class-picker").selectOption(event1);
+  await page.getByPlaceholder("Search by name or email").fill("applicant@example.com");
+  await page.getByRole("button", { name: "Check in" }).click();
+  await expect(page.getByText(/Free trial, 1 left/)).toBeVisible();
+
+  await page.locator("#class-picker").selectOption(event2);
+  await page.getByPlaceholder("Search by name or email").fill("applicant@example.com");
+  await page.getByRole("button", { name: "Check in" }).click();
+  await expect(page.getByText(/Free trial, 0 left/)).toBeVisible();
+
+  const { data: closed } = await adminClient()
+    .from("memberships")
+    .select("status, sessions_remaining")
+    .eq("id", trial.id)
+    .single();
+  if (!closed) throw new Error("the trial membership went missing mid-test");
+  expect(closed).toMatchObject({ status: "expired", sessions_remaining: 0 });
+
+  // Nothing is left to cover a third session. Check-in is never refused
+  // (docs/check-in.md, rule 5) — it lands uncovered instead, for a manager to
+  // sort out later, rather than turning someone away at the door.
+  await page.locator("#class-picker").selectOption(event3);
+  await page.getByPlaceholder("Search by name or email").fill("applicant@example.com");
+  await page.getByRole("button", { name: "Check in" }).click();
+  await expect(page.getByText(/nothing covers it\. Added to needs attention\./)).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Needs attention (1)" })).toBeVisible();
+});

--- a/e2e/manager/check-in.spec.ts
+++ b/e2e/manager/check-in.spec.ts
@@ -301,6 +301,15 @@ test("a manager raises a membership after the trial, checks the person in, and p
   // now" table specifically: the "Check someone in" table below it can list
   // other seeded people who hold this same period plan, and their rows
   // would also match the plan name.
+  //
+  // What each half proves is worth being precise about. The plan name is the
+  // attributable half: it is the pill for the membership this test just
+  // raised, so the class really was covered by it. `payment_pending` is not —
+  // `resolveCoverage` reads it off the WHOLE person ("they are training on an
+  // invoice nobody has paid"), and the first test in this file leaves the same
+  // applicant an unpaid casual invoice sitting there until afterAll. So this
+  // asserts the door warns when the club is owed money, not that it warns
+  // about this particular invoice.
   const hereNow = page
     .getByRole("heading", { name: /Here now/ })
     .locator("xpath=following-sibling::div[1]");

--- a/e2e/manager/check-in.spec.ts
+++ b/e2e/manager/check-in.spec.ts
@@ -112,12 +112,17 @@ test("a membership blocked from deletion by a check-in can be freed by moving it
   await expect(rowA.getByRole("button", { name: "Cancel" })).toBeEnabled();
 
   await page.getByRole("button", { name: "Add a membership" }).click();
-  await page.getByLabel("Plan").selectOption("casual_session");
+  const planSelect = page.getByLabel("Plan");
+  await planSelect.selectOption("casual_session");
   await page.getByRole("checkbox", { name: "Email them the payment instructions" }).uncheck();
   await page.getByRole("button", { name: "Add membership" }).click();
+  // The click only dispatches the request; the card resets this to blank
+  // only once the write has actually landed (`AddMembershipCard`'s success
+  // path). Querying the database before this would race the insert — the
+  // "newest row for this person" read could still return whatever existed
+  // before this one landed.
+  await expect(planSelect).toHaveValue("");
 
-  // Tracked before any assertion that could throw, so a failed assertion
-  // below still leaves this row queued for afterAll to remove.
   const { data: casualPlan } = await adminClient()
     .from("membership_plans")
     .select("id")

--- a/e2e/manager/memberships.spec.ts
+++ b/e2e/manager/memberships.spec.ts
@@ -44,12 +44,26 @@ test("the memberships screen lists the club's invoices", async ({ page }) => {
 test("a manager can raise a membership, mark it paid, and then can't delete it", async ({
   page,
 }) => {
+  // The period plan, not casual_session: check-in.spec.ts also raises a
+  // casual_session invoice for this same seeded applicant, and the app's
+  // payment reference is deterministic (surname + user id + session date +
+  // plan dates) rather than random — the same plan, same person, same day
+  // produces the identical reference, so two genuinely different rows can
+  // share one, and no locator can then tell them apart. Different plan kinds
+  // never collide (their dates differ), which is a real fix; a fussier
+  // locator on the same plan was not.
+  const { data: periodPlan } = await adminClient()
+    .from("membership_plans")
+    .select("code, name")
+    .eq("kind", "period")
+    .limit(1)
+    .single();
+  if (!periodPlan) throw new Error("no seeded period plan");
+
   await page.goto(`/manager/users/${applicantId}`);
 
   await page.getByRole("button", { name: "Add a membership" }).click();
-  // Selected by the plan's stable code rather than its formatted label (name
-  // + price), which would otherwise tie this to a price nobody is testing.
-  await page.getByLabel("Plan").selectOption("casual_session");
+  await page.getByLabel("Plan").selectOption(periodPlan.code);
   await page.getByRole("checkbox", { name: "Email them the payment instructions" }).uncheck();
   await page.getByRole("button", { name: "Add membership" }).click();
 
@@ -65,16 +79,12 @@ test("a manager can raise a membership, mark it paid, and then can't delete it",
   if (!created) throw new Error("raising the membership did not create a row");
   createdMembershipIds.push(created.id);
 
-  // Matched on the reference rather than the plan name: text like "Casual
-  // class" can also turn up elsewhere on this page (another membership's
-  // "Move to..." dropdown lists every plan by name), but a reference is
-  // unique to this one row.
   const row = page.getByRole("row").filter({ hasText: created.payment_reference });
   await expect(row).toHaveCount(1);
 
   await row.getByRole("button", { name: "Mark as paid" }).click();
   const payDialog = page.getByRole("alertdialog");
-  await expect(payDialog).toContainText("Record payment for Casual class?");
+  await expect(payDialog).toContainText(`Record payment for ${periodPlan.name}?`);
   await payDialog.getByRole("button", { name: "Mark as paid" }).click();
 
   // Paid, so the button that recorded it is gone...

--- a/e2e/manager/memberships.spec.ts
+++ b/e2e/manager/memberships.spec.ts
@@ -53,10 +53,8 @@ test("a manager can raise a membership, mark it paid, and then can't delete it",
   await page.getByRole("checkbox", { name: "Email them the payment instructions" }).uncheck();
   await page.getByRole("button", { name: "Add membership" }).click();
 
-  const row = page.getByRole("row").filter({ hasText: "Casual class" });
-  await expect(row).toHaveCount(1);
-  await expect(row).toContainText("$30");
-
+  // Tracked before any assertion that could throw, so a failed assertion
+  // below still leaves this row queued for afterAll to remove.
   const { data: created } = await adminClient()
     .from("memberships")
     .select("id")
@@ -65,6 +63,12 @@ test("a manager can raise a membership, mark it paid, and then can't delete it",
     .limit(1)
     .single();
   if (created) createdMembershipIds.push(created.id);
+
+  // Matched on price as well as name: a check-in's "Move to..." dropdown (see
+  // check-in.spec.ts) can also carry the plan name in its text, which
+  // `hasText` alone would catch — its options never show a price.
+  const row = page.getByRole("row").filter({ hasText: "Casual class" }).filter({ hasText: "$30" });
+  await expect(row).toHaveCount(1);
 
   await row.getByRole("button", { name: "Mark as paid" }).click();
   const payDialog = page.getByRole("alertdialog");

--- a/e2e/manager/memberships.spec.ts
+++ b/e2e/manager/memberships.spec.ts
@@ -54,7 +54,7 @@ test("a manager can raise a membership, mark it paid, and then can't delete it",
   // locator on the same plan was not.
   const { data: periodPlan } = await adminClient()
     .from("membership_plans")
-    .select("code, name")
+    .select("id, code, name")
     .eq("kind", "period")
     .limit(1)
     .single();
@@ -75,10 +75,17 @@ test("a manager can raise a membership, mark it paid, and then can't delete it",
 
   // Tracked before any assertion that could throw, so a failed assertion
   // below still leaves this row queued for afterAll to remove.
+  //
+  // Pinned to the plan just raised, not merely "their newest row": this
+  // applicant is the one every membership spec acts on, so "newest" is only
+  // this row for as long as nothing else in the run leaves them a later one —
+  // and the failure that would cause is the confusing kind, a row from another
+  // test being marked paid here under this test's name.
   const { data: created } = await adminClient()
     .from("memberships")
     .select("id, payment_reference")
     .eq("user_id", applicantId)
+    .eq("plan_id", periodPlan.id)
     .order("created_at", { ascending: false })
     .limit(1)
     .single();

--- a/e2e/manager/memberships.spec.ts
+++ b/e2e/manager/memberships.spec.ts
@@ -1,0 +1,119 @@
+// A manager works the club's money: seeing invoices, raising one, recording a
+// payment, and cancelling/reopening a membership.
+
+import { expect, test } from "@playwright/test";
+
+import { adminClient, applicantUserId, readClubFixture } from "../support/fixture";
+import { expectPageRendered } from "../support/page";
+
+/** Every membership these tests create or arrange, removed once in afterAll. */
+const createdMembershipIds: string[] = [];
+
+let applicantId: string;
+
+test.beforeAll(async () => {
+  applicantId = await applicantUserId();
+});
+
+test.afterAll(async () => {
+  if (createdMembershipIds.length === 0) return;
+  await adminClient().from("memberships").delete().in("id", createdMembershipIds);
+});
+
+test("the manager sidebar reaches the memberships screen", async ({ page }) => {
+  await page.goto("/account");
+
+  await page.getByRole("link", { name: "Memberships" }).click();
+
+  await expect(page).toHaveURL(/\/manager\/memberships$/);
+  await expect(page.getByRole("heading", { name: "Memberships", level: 1 })).toBeVisible();
+  await expectPageRendered(page);
+});
+
+test("the memberships screen lists the club's invoices", async ({ page }) => {
+  const fixture = readClubFixture();
+  await page.goto("/manager/memberships");
+
+  // The seeded member's period-plan invoice: active, and already paid.
+  const row = page.getByRole("row").filter({ hasText: "JITSU-000101" });
+  await expect(row).toHaveCount(1);
+  await expect(row).toContainText(fixture.personas.member.email);
+  await expect(row).toContainText("active");
+});
+
+test("a manager can raise a membership, mark it paid, and then can't delete it", async ({
+  page,
+}) => {
+  await page.goto(`/manager/users/${applicantId}`);
+
+  await page.getByRole("button", { name: "Add a membership" }).click();
+  // Selected by the plan's stable code rather than its formatted label (name
+  // + price), which would otherwise tie this to a price nobody is testing.
+  await page.getByLabel("Plan").selectOption("casual_session");
+  await page.getByRole("checkbox", { name: "Email them the payment instructions" }).uncheck();
+  await page.getByRole("button", { name: "Add membership" }).click();
+
+  const row = page.getByRole("row").filter({ hasText: "Casual class" });
+  await expect(row).toHaveCount(1);
+  await expect(row).toContainText("$30");
+
+  const { data: created } = await adminClient()
+    .from("memberships")
+    .select("id")
+    .eq("user_id", applicantId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .single();
+  if (created) createdMembershipIds.push(created.id);
+
+  await row.getByRole("button", { name: "Mark as paid" }).click();
+  const payDialog = page.getByRole("alertdialog");
+  await expect(payDialog).toContainText("Record payment for Casual class?");
+  await payDialog.getByRole("button", { name: "Mark as paid" }).click();
+
+  // Paid, so the button that recorded it is gone...
+  await expect(row.getByRole("button", { name: "Mark as paid" })).toHaveCount(0);
+  // ...and the record is now permanent: only Cancel can close it from here.
+  const deleteButton = row.getByRole("button", { name: "Delete" });
+  await expect(deleteButton).toBeDisabled();
+  await expect(deleteButton).toHaveAttribute(
+    "title",
+    /a payment is recorded against it.*Cancel it instead/,
+  );
+});
+
+test("a manager can cancel and reopen a membership", async ({ page }) => {
+  const { data: plan } = await adminClient()
+    .from("membership_plans")
+    .select("id")
+    .eq("code", "casual_session")
+    .single();
+  if (!plan) throw new Error("no seeded casual_session plan");
+
+  const reference = `E2E-CANCEL-${crypto.randomUUID().slice(0, 8)}`;
+  const { data: created, error } = await adminClient()
+    .from("memberships")
+    .insert({
+      user_id: applicantId,
+      plan_id: plan.id,
+      status: "active",
+      price_cents: 3000,
+      payment_reference: reference,
+      payment_method: "bank_transfer",
+    })
+    .select("id")
+    .single();
+  if (error || !created) throw new Error(`could not arrange a membership: ${error?.message}`);
+  createdMembershipIds.push(created.id);
+
+  await page.goto("/manager/memberships");
+  const row = page.getByRole("row").filter({ hasText: reference });
+
+  await row.getByRole("button", { name: "Cancel" }).click();
+  await page.getByRole("alertdialog").getByRole("button", { name: "Cancel membership" }).click();
+  await expect(row).toContainText("cancelled");
+
+  await row.getByRole("button", { name: "Reopen" }).click();
+  await page.getByRole("alertdialog").getByRole("button", { name: "Reopen" }).click();
+  await expect(row).toContainText("active");
+});

--- a/e2e/manager/memberships.spec.ts
+++ b/e2e/manager/memberships.spec.ts
@@ -57,17 +57,19 @@ test("a manager can raise a membership, mark it paid, and then can't delete it",
   // below still leaves this row queued for afterAll to remove.
   const { data: created } = await adminClient()
     .from("memberships")
-    .select("id")
+    .select("id, payment_reference")
     .eq("user_id", applicantId)
     .order("created_at", { ascending: false })
     .limit(1)
     .single();
-  if (created) createdMembershipIds.push(created.id);
+  if (!created) throw new Error("raising the membership did not create a row");
+  createdMembershipIds.push(created.id);
 
-  // Matched on price as well as name: a check-in's "Move to..." dropdown (see
-  // check-in.spec.ts) can also carry the plan name in its text, which
-  // `hasText` alone would catch — its options never show a price.
-  const row = page.getByRole("row").filter({ hasText: "Casual class" }).filter({ hasText: "$30" });
+  // Matched on the reference rather than the plan name: text like "Casual
+  // class" can also turn up elsewhere on this page (another membership's
+  // "Move to..." dropdown lists every plan by name), but a reference is
+  // unique to this one row.
+  const row = page.getByRole("row").filter({ hasText: created.payment_reference });
   await expect(row).toHaveCount(1);
 
   await row.getByRole("button", { name: "Mark as paid" }).click();

--- a/e2e/manager/memberships.spec.ts
+++ b/e2e/manager/memberships.spec.ts
@@ -63,9 +63,15 @@ test("a manager can raise a membership, mark it paid, and then can't delete it",
   await page.goto(`/manager/users/${applicantId}`);
 
   await page.getByRole("button", { name: "Add a membership" }).click();
-  await page.getByLabel("Plan").selectOption(periodPlan.code);
+  const planSelect = page.getByLabel("Plan");
+  await planSelect.selectOption(periodPlan.code);
   await page.getByRole("checkbox", { name: "Email them the payment instructions" }).uncheck();
   await page.getByRole("button", { name: "Add membership" }).click();
+  // The click only dispatches the request; the card resets this to blank
+  // only once the write has actually landed. Querying the database before
+  // this would race the insert — the "newest row for this person" read
+  // could still return whatever existed before this one landed.
+  await expect(planSelect).toHaveValue("");
 
   // Tracked before any assertion that could throw, so a failed assertion
   // below still leaves this row queued for afterAll to remove.

--- a/e2e/manager/new-member-journey.spec.ts
+++ b/e2e/manager/new-member-journey.spec.ts
@@ -60,6 +60,14 @@ test("a new member's journey: register, sign, trial, buy, pay, and switch plans"
     // exactly what a real visitor would click, rather than a hand-built URL.
     await visitorPage.getByRole("link", { name: "Sign my waiver" }).click();
 
+    // Filled explicitly rather than trusted to the link's query-param
+    // prefill: the prefill is a nice-to-have for a real visitor, but this
+    // test's job is to prove the submission, not the prefill, and the two
+    // failure modes should never be allowed to look identical.
+    await visitorPage.getByLabel("First name").fill(firstName);
+    await visitorPage.getByLabel("Last name").fill(lastName);
+    await visitorPage.getByLabel("Email").fill(email);
+    await visitorPage.getByLabel("Phone").fill("0400 000 555");
     await visitorPage.getByLabel("Date of birth").fill("1995-05-15");
     await visitorPage.getByLabel("Address").fill("1 Broadway, Ultimo NSW 2007");
     await visitorPage.getByLabel("Contact name").fill("Sam Marsh");
@@ -85,6 +93,13 @@ test("a new member's journey: register, sign, trial, buy, pay, and switch plans"
     // role="checkbox">`, not a native `<input>` — that selector would match
     // nothing, silently leave a required one unticked, and the server would
     // reject the submission with no heading change to say why.
+    //
+    // Waited for explicitly before counting: `#ack_media` is the one
+    // guaranteed by every template (src/lib/waiver-acknowledgements.ts), and
+    // `.count()` does not itself wait — calling it before the (client-side,
+    // template-fetched) acknowledgements section has rendered would silently
+    // count zero and tick nothing.
+    await visitorPage.locator("#ack_media").waitFor({ state: "visible" });
     const acks = visitorPage.locator('[id^="ack_"]');
     const ackCount = await acks.count();
     for (let i = 0; i < ackCount; i++) await acks.nth(i).check();

--- a/e2e/manager/new-member-journey.spec.ts
+++ b/e2e/manager/new-member-journey.spec.ts
@@ -215,7 +215,16 @@ test("a new member's journey: register, sign, trial, buy, pay, and switch plans"
 
   await test.step("a manager marks the casual-class invoice as paid", async () => {
     await page.goto(`/manager/users/${newUserId}`);
-    const row = page.getByRole("row").filter({ hasText: casualMembership.payment_reference });
+    // Matched on plan name too, not the reference alone: a brand-new member
+    // has no existing insurance cover, so it was bundled onto this purchase
+    // automatically (mandatory, not a checkbox they could leave off) — that
+    // invoice rides on the SAME reference, so the reference alone now
+    // resolves to two rows.
+    const row = page
+      .getByRole("row")
+      .filter({ hasText: casualMembership.payment_reference })
+      .filter({ hasText: "Casual class" });
+    await expect(row).toHaveCount(1);
     await row.getByRole("button", { name: "Mark as paid" }).click();
     await page.getByRole("alertdialog").getByRole("button", { name: "Mark as paid" }).click();
     await expect(row.getByRole("button", { name: "Mark as paid" })).toHaveCount(0);
@@ -288,7 +297,14 @@ test("a new member's journey: register, sign, trial, buy, pay, and switch plans"
   });
 
   await test.step("the casual class, superseded and free of the check-in, is cancelled", async () => {
-    const row = page.getByRole("row").filter({ hasText: casualMembership.payment_reference });
+    // Same reason as the "mark as paid" step above: the bundled insurance
+    // invoice still shares this reference, so it takes the plan name too to
+    // land on the casual-class row alone.
+    const row = page
+      .getByRole("row")
+      .filter({ hasText: casualMembership.payment_reference })
+      .filter({ hasText: "Casual class" });
+    await expect(row).toHaveCount(1);
     await row.getByRole("button", { name: "Cancel" }).click();
     await page.getByRole("alertdialog").getByRole("button", { name: "Cancel membership" }).click();
     await expect(row).toContainText("cancelled");

--- a/e2e/manager/new-member-journey.spec.ts
+++ b/e2e/manager/new-member-journey.spec.ts
@@ -63,6 +63,12 @@ test("a new member's journey: register, sign, trial, buy, pay, and switch plans"
     // The confirmation screen's own link, carrying what was just typed —
     // exactly what a real visitor would click, rather than a hand-built URL.
     await visitorPage.getByRole("link", { name: "Sign my waiver" }).click();
+    // The page's own fields (names, dates) render immediately, but the
+    // current waiver template — including which acknowledgements exist, if
+    // any — is fetched client-side. Waited for generally rather than for one
+    // assumed-present acknowledgement id: which ones exist is template
+    // content, not something this test should assume.
+    await visitorPage.waitForLoadState("networkidle");
 
     // First/last/email/phone come from the link's own query-param prefill
     // (checked here rather than re-typed): the email field in particular is
@@ -89,18 +95,12 @@ test("a new member's journey: register, sign, trial, buy, pay, and switch plans"
     }
 
     // Acknowledgements are template-driven, not fixed, so every rendered one
-    // is ticked rather than naming a specific one. Not `input[id^="ack_"]`:
-    // these are shadcn/Radix Checkboxes, which render as `<button
-    // role="checkbox">`, not a native `<input>` — that selector would match
-    // nothing, silently leave a required one unticked, and the server would
-    // reject the submission with no heading change to say why.
-    //
-    // Waited for explicitly before counting: `#ack_media` is the one
-    // guaranteed by every template (src/lib/waiver-acknowledgements.ts), and
-    // `.count()` does not itself wait — calling it before the (client-side,
-    // template-fetched) acknowledgements section has rendered would silently
-    // count zero and tick nothing.
-    await visitorPage.locator("#ack_media").waitFor({ state: "visible" });
+    // is ticked rather than naming a specific one (the network-idle wait
+    // above is what makes it safe to count them now). Not
+    // `input[id^="ack_"]`: these are shadcn/Radix Checkboxes, which render
+    // as `<button role="checkbox">`, not a native `<input>` — that selector
+    // would match nothing, silently leave a required one unticked, and the
+    // server would reject the submission with no heading change to say why.
     const acks = visitorPage.locator('[id^="ack_"]');
     const ackCount = await acks.count();
     for (let i = 0; i < ackCount; i++) await acks.nth(i).check();

--- a/e2e/manager/new-member-journey.spec.ts
+++ b/e2e/manager/new-member-journey.spec.ts
@@ -1,0 +1,275 @@
+// The whole story, end to end: a stranger registers interest, signs the
+// waiver, a manager approves it (assigning the free trial), the trial gets
+// used up at the door, the person buys a real plan and is checked in on it,
+// the invoice is paid, and — the awkward case that actually happens — the
+// person later moves to a different plan, so a manager moves their check-in
+// across and closes out the old invoice.
+//
+// Every other spec in this suite proves one screen in isolation, arranging
+// its starting state directly where that's faster. This one deliberately
+// does none of that: every fact below (the account, the trial, the invoices,
+// the coverage) is produced by walking the real screens in order, the same
+// way it would happen for a real person.
+
+import { expect, test } from "@playwright/test";
+
+import { adminClient } from "../support/fixture";
+import { expectPageRendered } from "../support/page";
+
+let newUserId: string | null = null;
+
+test.afterAll(async () => {
+  if (!newUserId) return;
+  // Explicit, rather than relying on FK cascades: memberships.user_id is
+  // ON DELETE SET NULL, not CASCADE, so deleting the auth user alone would
+  // leave every membership row behind, orphaned instead of removed.
+  await adminClient().from("session_checkins").delete().eq("user_id", newUserId);
+  await adminClient().from("memberships").delete().eq("user_id", newUserId);
+  await adminClient().from("waivers").delete().eq("user_id", newUserId);
+  await adminClient().auth.admin.deleteUser(newUserId);
+});
+
+test("a new member's journey: register, sign, trial, buy, pay, and switch plans", async ({
+  page,
+  browser,
+  baseURL,
+}) => {
+  // `page` is this project's manager session throughout. Two more identities
+  // are needed along the way — an anonymous visitor, then the person
+  // themselves once they can sign in — each gets its own browser context so
+  // it never shares storage with the manager's.
+  const email = `e2e-journey-${crypto.randomUUID()}@example.com`;
+  const firstName = "Devon";
+  const lastName = "Marsh";
+
+  const visitor = await browser.newContext();
+  const visitorPage = await visitor.newPage();
+
+  await test.step("registers interest", async () => {
+    await visitorPage.goto("/register-interest");
+    await visitorPage.getByLabel("First name").fill(firstName);
+    await visitorPage.getByLabel("Last name").fill(lastName);
+    await visitorPage.getByLabel("Email").fill(email);
+    await visitorPage.getByLabel("Phone (optional)").fill("0400 000 555");
+    await visitorPage.getByRole("button", { name: "Continue" }).click();
+    await expect(visitorPage.getByRole("heading", { name: /You're on the list/ })).toBeVisible();
+  });
+
+  await test.step("signs the waiver", async () => {
+    // The confirmation screen's own link, carrying what was just typed —
+    // exactly what a real visitor would click, rather than a hand-built URL.
+    await visitorPage.getByRole("link", { name: "Sign my waiver" }).click();
+
+    await visitorPage.getByLabel("Date of birth").fill("1995-05-15");
+    await visitorPage.getByLabel("Address").fill("1 Broadway, Ultimo NSW 2007");
+    await visitorPage.getByLabel("Contact name").fill("Sam Marsh");
+    await visitorPage.getByLabel("Relationship").fill("Sibling");
+    await visitorPage.getByLabel("Contact mobile").fill("0400 000 556");
+
+    // An adult with nothing to declare: every health question is "No", which
+    // also keeps the (otherwise required) medical-notes field out of the way.
+    const healthQuestions = [
+      "Is the participant prescribed any drugs which may impair reaction time or judgement?",
+      "Has the participant, within the past 5 years, suffered any blackout, seizure, convulsion, fainting or dizzy spells, or any incapacity that would render it unsafe to participate in martial arts?",
+      "Is the participant fitted with any electronic device or shunt?",
+      "Does the participant have any current physical impairment, injuries or medical conditions (for example back injuries, weak ankles)?",
+      "Is there any other medical information or health needs our instructors should be aware of for the participant's safety?",
+    ];
+    for (const question of healthQuestions) {
+      await visitorPage.getByRole("radiogroup", { name: question }).getByLabel("No").check();
+    }
+
+    // Acknowledgements are template-driven, not fixed, so every rendered one
+    // is ticked rather than naming a specific one.
+    const acks = visitorPage.locator('input[id^="ack_"]');
+    const ackCount = await acks.count();
+    for (let i = 0; i < ackCount; i++) await acks.nth(i).check();
+
+    // Typed rather than drawn: an equally valid signature, and a canvas
+    // needs synthesized pointer events to register a non-empty stroke.
+    await visitorPage.getByRole("tab", { name: "Type" }).click();
+    await visitorPage.getByLabel("Type your full name to sign").fill(`${firstName} ${lastName}`);
+
+    await visitorPage.getByRole("button", { name: "Sign and download waiver" }).click();
+    await expect(
+      visitorPage.getByRole("heading", { name: "Waiver signed", level: 1 }),
+    ).toBeVisible();
+  });
+
+  await visitor.close();
+
+  // Signing the waiver is what creates the person (a locked login + a
+  // profile) — read back who that just became rather than guessing an id.
+  const { data: userId, error: idErr } = await adminClient().rpc("user_id_by_email", {
+    _email: email,
+  });
+  if (idErr || !userId) throw new Error(`the waiver did not create an account: ${idErr?.message}`);
+  newUserId = userId;
+
+  await test.step("a manager approves the waiver, which assigns the free trial", async () => {
+    await page.goto(`/manager/users/${newUserId}`);
+    await expectPageRendered(page);
+    await page.getByRole("button", { name: "Approve" }).click();
+    // The button relabels once its own click lands — no toast text to guess.
+    await expect(page.getByRole("button", { name: "Unapprove" })).toBeVisible();
+  });
+
+  const [event1, event2, event3] = (
+    await adminClient()
+      .from("calendar_events")
+      .select("id")
+      .eq("title", "Tuesday class")
+      .order("starts_at", { ascending: true })
+      .limit(3)
+  ).data!.map((e) => e.id);
+
+  await test.step("a manager checks them in twice, using up the trial", async () => {
+    await page.goto("/manager/check-in");
+    await page.locator("#class-picker").selectOption(event1);
+    await page.getByPlaceholder("Search by name or email").fill(email);
+    await page.getByRole("button", { name: "Check in" }).click();
+    await expect(page.getByText(/Free trial, 1 left/)).toBeVisible();
+
+    await page.locator("#class-picker").selectOption(event2);
+    await page.getByPlaceholder("Search by name or email").fill(email);
+    await page.getByRole("button", { name: "Check in" }).click();
+    await expect(page.getByText(/Free trial, 0 left/)).toBeVisible();
+  });
+
+  const member = await browser.newContext();
+  const memberPage = await member.newPage();
+
+  await test.step("the new member signs in and buys a casual class", async () => {
+    const { data: link, error: linkErr } = await adminClient().auth.admin.generateLink({
+      type: "magiclink",
+      email,
+      options: { redirectTo: `${baseURL}/membership` },
+    });
+    if (linkErr) throw new Error(`could not sign the new member in: ${linkErr.message}`);
+    await memberPage.goto(link.properties.action_link, { waitUntil: "networkidle" });
+    await memberPage.waitForFunction(() =>
+      Object.keys(localStorage).some((key) => key.endsWith("-auth-token")),
+    );
+
+    // Forces the public rate, so later assertions aren't at the mercy of a
+    // student-number prefill.
+    await memberPage.getByLabel(/UTS student number/).fill("");
+    const heading = memberPage.getByRole("heading", { name: "Casual class", level: 3 });
+    const card = heading.locator("xpath=ancestor::div[contains(@class,'rounded-2xl')][1]");
+    await card.getByRole("button", { name: "Choose & pay by transfer" }).click();
+    await expect(
+      memberPage.getByText(
+        "Your invoice is ready. The payment details are at the top of this page.",
+      ),
+    ).toBeVisible();
+  });
+
+  await member.close();
+
+  const { data: casualPlan } = await adminClient()
+    .from("membership_plans")
+    .select("id, name")
+    .eq("code", "casual_session")
+    .single();
+  if (!casualPlan) throw new Error("no seeded casual_session plan");
+  const { data: casualMembership } = await adminClient()
+    .from("memberships")
+    .select("id, payment_reference")
+    .eq("user_id", newUserId)
+    .eq("plan_id", casualPlan.id)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .single();
+  if (!casualMembership)
+    throw new Error("the casual-class purchase did not create a membership row");
+
+  await test.step("a manager checks them in a third time, now covered by the casual class", async () => {
+    await page.goto("/manager/check-in");
+    await page.locator("#class-picker").selectOption(event3);
+    await page.getByPlaceholder("Search by name or email").fill(email);
+    await page.getByRole("button", { name: "Check in" }).click();
+    // One credit, spent: the casual class closes itself on the same check-in
+    // that used it, exactly like the trial did above.
+    await expect(page.getByText(/Casual class, 0 left/)).toBeVisible();
+  });
+
+  await test.step("a manager marks the casual-class invoice as paid", async () => {
+    await page.goto(`/manager/users/${newUserId}`);
+    const row = page.getByRole("row").filter({ hasText: casualMembership.payment_reference });
+    await row.getByRole("button", { name: "Mark as paid" }).click();
+    await page.getByRole("alertdialog").getByRole("button", { name: "Mark as paid" }).click();
+    await expect(row.getByRole("button", { name: "Mark as paid" })).toHaveCount(0);
+
+    // Both reasons at once, not just the first one found: paid AND attended.
+    const deleteButton = row.getByRole("button", { name: "Delete" });
+    await expect(deleteButton).toHaveAttribute(
+      "title",
+      /a payment is recorded against it and a class was checked in against it/,
+    );
+  });
+
+  const { data: periodPlan } = await adminClient()
+    .from("membership_plans")
+    .select("id, code, name")
+    .eq("kind", "period")
+    .limit(1)
+    .single();
+  if (!periodPlan) throw new Error("no seeded period plan");
+
+  await test.step("the person commits to a full training period, and the manager raises it", async () => {
+    await page.getByRole("button", { name: "Add a membership" }).click();
+    await page.getByLabel("Plan").selectOption(periodPlan.code);
+    await page.getByRole("checkbox", { name: "Email them the payment instructions" }).uncheck();
+    await page.getByRole("button", { name: "Add membership" }).click();
+  });
+
+  const { data: periodMembership } = await adminClient()
+    .from("memberships")
+    .select("id, payment_reference")
+    .eq("user_id", newUserId)
+    .eq("plan_id", periodPlan.id)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .single();
+  if (!periodMembership) throw new Error("raising the period plan did not create a membership row");
+
+  // Read back rather than asserted on screen by plan name: by this point the
+  // Sessions table's "Move to..." dropdowns (three check-ins now have other
+  // memberships to offer) all mention this plan too, so a name-only row
+  // match would resolve to more than one element — same trap as
+  // check-in.spec.ts hit with "Casual class".
+  await expect(
+    page.getByRole("row").filter({ hasText: periodMembership.payment_reference }),
+  ).toHaveCount(1);
+
+  await test.step("a manager moves the check-in off the casual class and onto the new plan", async () => {
+    // Scoped by the "Covered by" pill (a <span>) rather than by row text: a
+    // plain hasText match would also catch this same row's own "Move to..."
+    // dropdown, whose <option> list mentions every other plan by name too.
+    const sessionsRow = page
+      .getByRole("row")
+      .filter({ has: page.locator("span").filter({ hasText: "Casual class" }) });
+    await expect(sessionsRow).toHaveCount(1);
+
+    const moveSelect = sessionsRow.getByLabel("Membership to move this check-in to");
+    const targetValue = await moveSelect
+      .locator("option", { hasText: periodPlan.name })
+      .getAttribute("value");
+    if (!targetValue) throw new Error("the new plan is not offered as a move target");
+    await moveSelect.selectOption(targetValue);
+    await sessionsRow.getByRole("button", { name: "Move" }).click();
+    await expect(page.getByText(`Moved to ${periodPlan.name}.`)).toBeVisible();
+  });
+
+  await test.step("the casual class, superseded and free of the check-in, is cancelled", async () => {
+    const row = page.getByRole("row").filter({ hasText: casualMembership.payment_reference });
+    await row.getByRole("button", { name: "Cancel" }).click();
+    await page.getByRole("alertdialog").getByRole("button", { name: "Cancel membership" }).click();
+    await expect(row).toContainText("cancelled");
+
+    // The new plan is what pays for them now: active, and it is the one the
+    // check-in landed on.
+    const periodRow = page.getByRole("row").filter({ hasText: periodMembership.payment_reference });
+    await expect(periodRow).toContainText("active");
+  });
+});

--- a/e2e/manager/new-member-journey.spec.ts
+++ b/e2e/manager/new-member-journey.spec.ts
@@ -36,13 +36,17 @@ test("a new member's journey: register, sign, trial, buy, pay, and switch plans"
 }) => {
   // `page` is this project's manager session throughout. Two more identities
   // are needed along the way — an anonymous visitor, then the person
-  // themselves once they can sign in — each gets its own browser context so
-  // it never shares storage with the manager's.
+  // themselves once they can sign in — each gets its own browser context, so
+  // it never shares storage with the manager's. An explicit empty storage
+  // state, not the default: this project's `use.storageState` (the saved
+  // manager session) turned out to still apply to a bare `newContext()` call
+  // with no override — a signed-out visitor cannot be assumed otherwise.
+  const NO_SESSION = { cookies: [], origins: [] };
   const email = `e2e-journey-${crypto.randomUUID()}@example.com`;
   const firstName = "Devon";
   const lastName = "Marsh";
 
-  const visitor = await browser.newContext();
+  const visitor = await browser.newContext({ storageState: NO_SESSION });
   const visitorPage = await visitor.newPage();
 
   await test.step("registers interest", async () => {
@@ -60,14 +64,11 @@ test("a new member's journey: register, sign, trial, buy, pay, and switch plans"
     // exactly what a real visitor would click, rather than a hand-built URL.
     await visitorPage.getByRole("link", { name: "Sign my waiver" }).click();
 
-    // Filled explicitly rather than trusted to the link's query-param
-    // prefill: the prefill is a nice-to-have for a real visitor, but this
-    // test's job is to prove the submission, not the prefill, and the two
-    // failure modes should never be allowed to look identical.
-    await visitorPage.getByLabel("First name").fill(firstName);
-    await visitorPage.getByLabel("Last name").fill(lastName);
-    await visitorPage.getByLabel("Email").fill(email);
-    await visitorPage.getByLabel("Phone").fill("0400 000 555");
+    // First/last/email/phone come from the link's own query-param prefill
+    // (checked here rather than re-typed): the email field in particular is
+    // locked once prefilled, so re-filling it fails outright instead of
+    // being a harmless no-op.
+    await expect(visitorPage.getByLabel("Email")).toHaveValue(email);
     await visitorPage.getByLabel("Date of birth").fill("1995-05-15");
     await visitorPage.getByLabel("Address").fill("1 Broadway, Ultimo NSW 2007");
     await visitorPage.getByLabel("Contact name").fill("Sam Marsh");
@@ -155,7 +156,7 @@ test("a new member's journey: register, sign, trial, buy, pay, and switch plans"
     await expect(page.getByText(/Free trial, 0 left/)).toBeVisible();
   });
 
-  const member = await browser.newContext();
+  const member = await browser.newContext({ storageState: NO_SESSION });
   const memberPage = await member.newPage();
 
   await test.step("the new member signs in and buys a casual class", async () => {
@@ -237,9 +238,15 @@ test("a new member's journey: register, sign, trial, buy, pay, and switch plans"
 
   await test.step("the person commits to a full training period, and the manager raises it", async () => {
     await page.getByRole("button", { name: "Add a membership" }).click();
-    await page.getByLabel("Plan").selectOption(periodPlan.code);
+    const planSelect = page.getByLabel("Plan");
+    await planSelect.selectOption(periodPlan.code);
     await page.getByRole("checkbox", { name: "Email them the payment instructions" }).uncheck();
     await page.getByRole("button", { name: "Add membership" }).click();
+    // The click only dispatches the request; the card resets this to blank
+    // only once the write has actually landed. The next step reads the
+    // database for the row this just created, which would otherwise race
+    // the insert.
+    await expect(planSelect).toHaveValue("");
   });
 
   const { data: periodMembership } = await adminClient()

--- a/e2e/manager/new-member-journey.spec.ts
+++ b/e2e/manager/new-member-journey.spec.ts
@@ -134,14 +134,24 @@ test("a new member's journey: register, sign, trial, buy, pay, and switch plans"
     await expect(page.getByRole("button", { name: "Unapprove" })).toBeVisible();
   });
 
-  const [event1, event2, event3] = (
-    await adminClient()
-      .from("calendar_events")
-      .select("id")
-      .eq("title", "Tuesday class")
-      .order("starts_at", { ascending: true })
-      .limit(3)
-  ).data!.map((e) => e.id);
+  // The three earliest seeded classes (scripts/seed-local-club.mjs puts five
+  // on the calendar, at day -14/-7/+1/+8/+15 from seed time). The earliest
+  // sits right at the check-in screen's 14-day lookback edge, so if this CI
+  // run happens to straddle a UTC midnight between seeding and this step,
+  // it could briefly fall outside the window — a known, narrow residual risk
+  // rather than one this test tries to fully engineer away.
+  const { data: events, error: eventsErr } = await adminClient()
+    .from("calendar_events")
+    .select("id")
+    .eq("title", "Tuesday class")
+    .order("starts_at", { ascending: true })
+    .limit(3);
+  if (eventsErr || !events || events.length < 3) {
+    throw new Error(
+      `fewer than 3 seeded classes to check the new member in against: ${eventsErr?.message}`,
+    );
+  }
+  const [event1, event2, event3] = events.map((e) => e.id);
 
   await test.step("a manager checks them in twice, using up the trial", async () => {
     await page.goto("/manager/check-in");

--- a/e2e/manager/new-member-journey.spec.ts
+++ b/e2e/manager/new-member-journey.spec.ts
@@ -80,8 +80,12 @@ test("a new member's journey: register, sign, trial, buy, pay, and switch plans"
     }
 
     // Acknowledgements are template-driven, not fixed, so every rendered one
-    // is ticked rather than naming a specific one.
-    const acks = visitorPage.locator('input[id^="ack_"]');
+    // is ticked rather than naming a specific one. Not `input[id^="ack_"]`:
+    // these are shadcn/Radix Checkboxes, which render as `<button
+    // role="checkbox">`, not a native `<input>` — that selector would match
+    // nothing, silently leave a required one unticked, and the server would
+    // reject the submission with no heading change to say why.
+    const acks = visitorPage.locator('[id^="ack_"]');
     const ackCount = await acks.count();
     for (let i = 0; i < ackCount; i++) await acks.nth(i).check();
 

--- a/e2e/member/membership.spec.ts
+++ b/e2e/member/membership.spec.ts
@@ -1,0 +1,79 @@
+// A signed-in member checks their own status, and buys a plan through the
+// page: the money side of the member area, next to account.spec.ts's profile
+// side.
+
+import { expect, test } from "@playwright/test";
+
+import { adminClient, readClubFixture } from "../support/fixture";
+import { expectPageRendered } from "../support/page";
+
+/** Payment references the purchase test below raises, for afterAll cleanup. */
+const references: string[] = [];
+
+test.afterAll(async () => {
+  if (references.length === 0) return;
+  await adminClient().from("memberships").delete().in("payment_reference", references);
+});
+
+test("the member's status and memberships show on their membership page", async ({ page }) => {
+  await page.goto("/membership");
+
+  await expect(page.getByText("You're an active member. See you on the mat!")).toBeVisible();
+
+  // "This semester" is the fallback period plan scripts/seed-local-club.mjs
+  // creates when the fresh migrations ship no dated plan of their own (see
+  // its planOf helper) — the member's seeded membership is bought on it.
+  const periodRow = page.getByRole("row").filter({ hasText: "This semester" });
+  await expect(periodRow).toHaveCount(1);
+  await expect(periodRow).toContainText("active");
+
+  const insuranceRow = page.getByRole("row").filter({ hasText: "Sydney Jitsu yearly membership" });
+  await expect(insuranceRow).toHaveCount(1);
+  await expect(insuranceRow).toContainText("active");
+
+  await expectPageRendered(page);
+});
+
+test("a member can buy a plan and is shown how to pay for it", async ({ page }) => {
+  const fixture = readClubFixture();
+  const { data: casualPlan } = await adminClient()
+    .from("membership_plans")
+    .select("id")
+    .eq("code", "casual_session")
+    .single();
+  if (!casualPlan) throw new Error("no seeded casual_session plan");
+
+  await page.goto("/membership");
+
+  // Forces the public rate, so the amount checked below is not at the mercy
+  // of whether the seeded waiver's student number happened to prefill.
+  await page.getByLabel(/UTS student number/).fill("");
+
+  // Plan cards carry no individual landmark, so the card is found from its
+  // own heading and the "Choose" button read off its enclosing card.
+  const heading = page.getByRole("heading", { name: "Casual class", level: 3 });
+  const card = heading.locator("xpath=ancestor::div[contains(@class,'rounded-2xl')][1]");
+  await card.getByRole("button", { name: "Choose & pay by transfer" }).click();
+
+  await expect(
+    page.getByText("Your invoice is ready. The payment details are at the top of this page."),
+  ).toBeVisible();
+  await expect(page.getByText("How to pay")).toBeVisible();
+
+  // The screen says it worked; this is what proves it did. Matched by plan
+  // rather than "the newest row", since a still-open insurance invoice would
+  // otherwise leave this guessing which of two just-inserted rows is which.
+  const { data: created } = await adminClient()
+    .from("memberships")
+    .select("id, price_cents, payment_reference")
+    .eq("user_id", fixture.personas.member.userId)
+    .eq("plan_id", casualPlan.id)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .single();
+  if (!created) throw new Error("the purchase did not create a membership row");
+  references.push(created.payment_reference);
+
+  expect(created.price_cents).toBe(3000);
+  await expect(page.getByText(created.payment_reference)).toBeVisible();
+});

--- a/e2e/member/membership.spec.ts
+++ b/e2e/member/membership.spec.ts
@@ -75,5 +75,8 @@ test("a member can buy a plan and is shown how to pay for it", async ({ page }) 
   references.push(created.payment_reference);
 
   expect(created.price_cents).toBe(3000);
-  await expect(page.getByText(created.payment_reference)).toBeVisible();
+  // The reference now shows in two places on this page: the status table's
+  // Reference column (unpaid rows show it there too) and this pay panel's own
+  // amount/reference block, which is the only one rendered as a <dl>.
+  await expect(page.locator("dl").getByText(created.payment_reference)).toBeVisible();
 });

--- a/e2e/support/fixture.ts
+++ b/e2e/support/fixture.ts
@@ -105,3 +105,20 @@ export function adminClient(): SupabaseClient {
     auth: { persistSession: false, autoRefreshToken: false },
   });
 }
+
+/**
+ * The seeded applicant's user id, resolved live rather than carried in the
+ * manifest above: `personas` there is only the two people `auth.setup.ts`
+ * signs in (a magic link per entry), and `params` is only the `$segment`
+ * values `pr-screenshots-pages.mjs` needs for a route. The applicant is
+ * neither — never signed in, only ever the target of something a manager
+ * does — so their id comes from the same admin API a magic link does.
+ */
+export async function applicantUserId(): Promise<string> {
+  const email = "applicant@example.com";
+  const { data, error } = await adminClient().auth.admin.listUsers();
+  if (error) throw new Error(`could not look up the seeded applicant: ${error.message}`);
+  const applicant = data.users.find((u) => u.email === email);
+  if (!applicant) throw new Error(`no seeded user with email ${email}`);
+  return applicant.id;
+}

--- a/e2e/support/fixture.ts
+++ b/e2e/support/fixture.ts
@@ -107,18 +107,32 @@ export function adminClient(): SupabaseClient {
 }
 
 /**
+ * scripts/seed-local-club.mjs's applicant persona. Exported so a spec that
+ * needs to search for them by email (there is nowhere else to read it back
+ * from: they are not in `personas` above) uses this instead of its own copy
+ * of the literal.
+ */
+export const APPLICANT_EMAIL = "applicant@example.com";
+
+/**
  * The seeded applicant's user id, resolved live rather than carried in the
  * manifest above: `personas` there is only the two people `auth.setup.ts`
  * signs in (a magic link per entry), and `params` is only the `$segment`
  * values `pr-screenshots-pages.mjs` needs for a route. The applicant is
  * neither — never signed in, only ever the target of something a manager
- * does — so their id comes from the same admin API a magic link does.
+ * does.
+ *
+ * Goes through the same `user_id_by_email` RPC the app itself uses to
+ * resolve a person by email (see CLAUDE.md's Supabase-clients table), rather
+ * than `auth.admin.listUsers()` — which paginates (50 users by default) and
+ * would start missing the applicant the moment the seeded club holds more
+ * people than that.
  */
 export async function applicantUserId(): Promise<string> {
-  const email = "applicant@example.com";
-  const { data, error } = await adminClient().auth.admin.listUsers();
+  const { data, error } = await adminClient().rpc("user_id_by_email", {
+    _email: APPLICANT_EMAIL,
+  });
   if (error) throw new Error(`could not look up the seeded applicant: ${error.message}`);
-  const applicant = data.users.find((u) => u.email === email);
-  if (!applicant) throw new Error(`no seeded user with email ${email}`);
-  return applicant.id;
+  if (!data) throw new Error(`no seeded user with email ${APPLICANT_EMAIL}`);
+  return data;
 }


### PR DESCRIPTION
## Summary

Four new specs, following the existing suite's conventions (one file per audience, `readClubFixture()`/`adminClient()` for arranging and reading back state, `getByRole`/`getByLabel` assertions, write-then-cleanup):

- **`e2e/manager/memberships.spec.ts`** — the manager's money screens: nav to `/manager/memberships`, the invoice list, raising a membership for someone and marking it paid (and the delete guard once it's paid), and cancel/reopen.
- **`e2e/member/membership.spec.ts`** — the member's own `/membership` page: status display, and buying a plan through to the "how to pay" panel.
- **`e2e/manager/check-in.spec.ts`** — check-in's interaction with memberships: a check-in blocking a membership's delete, freeing it by moving the check-in to another membership, and the free trial running out on its third check-in (uncovered, not refused, per `docs/check-in.md`).
- **`e2e/manager/new-member-journey.spec.ts`** — the whole new-member story end to end, walked through the real screens rather than arranged: register interest, sign the waiver, a manager approves it (assigning the free trial), the trial gets used up at the door across two check-ins, the person signs in and buys a casual class (bundling mandatory insurance, since they have none yet), gets checked in on it, the invoice is marked paid, and then — the case that actually happens — they commit to a full training period, so a manager raises it, moves their check-in across, and cancels the superseded casual invoice.

Also adds `applicantUserId()`/`APPLICANT_EMAIL` to `e2e/support/fixture.ts` — the seeded applicant isn't in the fixture manifest (never signed in, only acted on by a manager), so their id is resolved via the same `user_id_by_email` RPC the app itself uses.

`docs/e2e-tests.md` is updated to reflect the new coverage.

Two deliberate scope/behavior notes surfaced while building this:
- `checkInPerson` against a membership only *blocks Delete*, not Cancel (`whyMembershipCannotBeDeleted` only gates Delete — Cancel is explicitly reversible via Reopen from any status). The recoverable-delete test asserts that real behavior.
- Automatic per-check-in invoicing for casual/session plans was explicitly left out of scope — the actual mechanics run the other way (a casual invoice is a pre-paid single credit; checking in spends it).

## Test plan

- [x] `bunx tsc -p e2e/tsconfig.json` — typechecks clean
- [x] `bun run lint` (ESLint) over the new/changed files — clean
- [x] `bun run format` (Prettier) — clean
- [x] `bun run test:e2e` (CI, `.github/workflows/e2e.yml`) — full suite green, including the new specs. (Not run in this session locally: the sandbox's Docker daemon isn't reachable, so `supabase start` can't boot the local stack — CI confirmed it instead, across several rounds of real locator/race-condition bugs it caught and I fixed.)