### PR TITLE
Call a used-up trial "used up", not "expired" or "lapsed"

### DIFF
--- a/docs/check-in.md
+++ b/docs/check-in.md
@@ -188,7 +188,11 @@ people in to a class that did not run.
 8. **No cover always says why.** "Nothing covers this class" is a dead end;
    "a membership starts after this class" or "waiting on a payment" is something
    a manager can act on. Every reason coverage resolution knows is surfaced on
-   the roster and in the attach list, rather than logged and swallowed.
+   the roster and in the attach list, rather than logged and swallowed. A closed
+   membership's reason is its label, not its stored status, so a spent class pack
+   reads "used up" and only a dated one reads "expired" (`docs/memberships.md`,
+   "What an ended membership is called"). Lower-cased there, because it is read
+   as prose after the plan name rather than as a pill.
 9. **Sessions attended is not credits used.** It counts classes trained,
    including uncovered ones. How many credits a membership has left is a separate
    number and lives on the membership.

--- a/docs/database.md
+++ b/docs/database.md
@@ -572,7 +572,10 @@ written only by `recordMembershipPayment` (bank reconciliation, or a manager
 marking it paid), and it is what the delete guard reads. `pending` is no longer
 produced by anything and survives only on rows created before the two were
 separated; `isUnpaid` in `src/lib/validation.ts` is the one definition of who
-still owes the club money.
+still owes the club money. `expired` covers two different endings — a date
+passing, and a credit plan's classes running out — so no screen prints it raw:
+what a person reads comes from the plan's kind (see "What an ended membership is
+called" in `docs/memberships.md`).
 Constraint: the student rate requires a `uts_student_number`. The `member` role
 is reconciled against these rows by `syncMemberRole` after every activation,
 cancellation and deletion — it is a label, not the access gate (see the

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -94,13 +94,18 @@ actually gets done.
   `getByLabel`), not CSS classes or test ids. If a flow is hard to address that
   way, that is usually the screen missing a label rather than the test needing a
   hook.
-- **A status column is words, not the enum value behind it.** Statuses are
-  stored lowercase but rendered through `src/lib/status-labels.ts`, and
-  `toContainText` is case-sensitive — so it is `"Active"`, not `"active"`. An
-  ended membership is worse than a casing difference: it reads "Used up" or
-  "Expired" depending on the plan behind it (`docs/memberships.md`, "What an
-  ended membership is called"). Read the label off the screen, never off the
-  database row you seeded.
+- **A membership status or funnel phase is words, not the enum behind it.**
+  Those two go through `src/lib/status-labels.ts`, and `toContainText` is
+  case-sensitive — so it is `"Active"`, not `"active"`. An ended membership is
+  worse than a casing difference: it reads "Used up" or "Expired" depending on
+  the plan behind it and on what is left on the row (`docs/memberships.md`,
+  "What an ended membership is called"). Read the label off the screen, never
+  off the database row you seeded.
+  **Only those two.** Waiver, blog-post and blog-comment pills still render
+  their raw lowercase status through the `capitalize` class, which changes
+  nothing about `textContent` — which is why `e2e/manager/waivers.spec.ts`
+  asserting `"active"` is correct and must not be "fixed" to match the rule
+  above.
 - **`expectPageRendered` catches a page that rendered a failure boundary.** Both
   the router's error boundary and its 404 arrive inside an ordinary 200
   response, so a status check alone would call a site-wide "This page didn't

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -94,6 +94,13 @@ actually gets done.
   `getByLabel`), not CSS classes or test ids. If a flow is hard to address that
   way, that is usually the screen missing a label rather than the test needing a
   hook.
+- **A status column is words, not the enum value behind it.** Statuses are
+  stored lowercase but rendered through `src/lib/status-labels.ts`, and
+  `toContainText` is case-sensitive — so it is `"Active"`, not `"active"`. An
+  ended membership is worse than a casing difference: it reads "Used up" or
+  "Expired" depending on the plan behind it (`docs/memberships.md`, "What an
+  ended membership is called"). Read the label off the screen, never off the
+  database row you seeded.
 - **`expectPageRendered` catches a page that rendered a failure boundary.** Both
   the router's error boundary and its 404 arrive inside an ordinary 200
   response, so a status check alone would call a site-wide "This page didn't

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -97,12 +97,23 @@ the screens name the ending from the plan's **kind**, not from the status:
 The person-level funnel phase has the same problem in miniature. `lapsed` is
 derived both for somebody whose paid membership ended and for somebody who came
 to their two free classes and stopped, and only the first has lapsed — the
-second is the club's warmest lead, with no membership to renew. Where their
-newest membership is still the free trial (which is always their oldest, since
-it is assigned at waiver approval, so a trial that is still newest means nothing
-followed it) the phase reads **Trial used up**, and `/membership` tells them
-"You've used your free trial classes. Pick a plan below to keep training."
-instead of offering a renewal.
+second is the club's warmest lead, with no membership to renew. The phase reads
+**Trial used up** when their newest membership is a free trial that **expired**,
+and `/membership` tells them "You've used your free trial classes. Pick a plan
+below to keep training." instead of offering a renewal. Both halves of that test
+matter:
+
+- **newest**: the trial is assigned at waiver approval, so it is always a
+  person's oldest membership. One that is still their newest means nothing
+  followed it.
+- **expired**: `lapsed` is derived from `expired` **or** `cancelled`, and a trial
+  a manager cancelled may have both its classes sitting untouched. Nothing but
+  spending the last credit closes a plan with no end date, so `expired` on a
+  credit plan is what "used up" actually means.
+
+`lifecycleLabel` owns that test, and `/membership` calls it rather than
+re-deciding, so the member's card and the manager's pill cannot disagree about
+the same person. Only the blurb is the member page's own.
 
 **The stored vocabulary is deliberately untouched.** `expired` and `lapsed` are
 still what the database, `deriveLifecycleStatus`, the `/manager/users` filter and

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -89,10 +89,25 @@ insurance really does expire: a date passed. A free trial or a casual class does
 not — it holds a **number of classes**, and it ends when they are used up. So
 the screens name the ending from the plan's **kind**, not from the status:
 
-| The plan ends with | Ended row reads | Where the rule lives                         |
-| ------------------ | --------------- | -------------------------------------------- |
-| session credits    | **Used up**     | `endsWithCredits` in `src/lib/validation.ts` |
-| a date             | **Expired**     | (`creditsRequired` on `PLAN_TYPES`)          |
+| The plan ends with | Ended row reads | When                                      |
+| ------------------ | --------------- | ----------------------------------------- |
+| session credits    | **Used up**     | the row is `expired` AND its balance is 0 |
+| session credits    | **Expired**     | `expired` with classes still on the row   |
+| a date             | **Expired**     | always                                    |
+
+`isUsedUp` in `src/lib/status-labels.ts` owns that test, and which plans are
+sold as classes comes from `endsWithCredits` in `src/lib/validation.ts` (it
+reads `creditsRequired` off `PLAN_TYPES`, so the two cannot drift).
+
+**The balance is asked, not inferred from the status**, and that middle row is
+why. A credit plan can sit `expired` with classes still in it: undoing a
+check-in refunds the credit but reopens the membership only when that same
+check-in is the one that closed it (`refundCheckInCredit` in
+`src/lib/checkin.functions.ts`), so undoing an EARLIER visit gives the class
+back and leaves the row closed. A manager can also expire a never-used trial by
+hand through `edit_invoice` or `setMembershipStatus`. "Expired" was vague enough
+to survive those; "Used up" is a specific claim, printed next to the balance on
+the same row, so it has to agree with it.
 
 The person-level funnel phase has the same problem in miniature. `lapsed` is
 derived both for somebody whose paid membership ended and for somebody who came
@@ -103,17 +118,21 @@ and `/membership` tells them "You've used your free trial classes. Pick a plan
 below to keep training." instead of offering a renewal. Both halves of that test
 matter:
 
-- **newest**: the trial is assigned at waiver approval, so it is always a
-  person's oldest membership. One that is still their newest means nothing
-  followed it.
-- **expired**: `lapsed` is derived from `expired` **or** `cancelled`, and a trial
-  a manager cancelled may have both its classes sitting untouched. Nothing but
-  spending the last credit closes a plan with no end date, so `expired` on a
-  credit plan is what "used up" actually means.
+- **newest**: the trial is assigned at waiver approval, so in practice it is a
+  person's oldest membership and one that is still their newest means nothing
+  followed it. Not an invariant the database enforces: a manager can raise an
+  invoice for an applicant before approving their waiver, which makes the trial
+  the newer row. It costs nothing when it happens, because such a trial is
+  `active` and so is neither `lapsed` nor used up.
+- **used up**: `lapsed` is derived from `expired` **or** `cancelled`, and a
+  cancelled trial may have both its classes sitting untouched. Being `expired`
+  is not proof either, for the reasons above, so the phase asks the same
+  `isUsedUp` the row's own label asks: ended, sold as classes, and none left.
 
-`lifecycleLabel` owns that test, and `/membership` calls it rather than
-re-deciding, so the member's card and the manager's pill cannot disagree about
-the same person. Only the blurb is the member page's own.
+`isTrialUsedUp` owns that test, and both `lifecycleLabel` (the manager's pill)
+and `/membership` (the member's card) call it rather than re-deciding, so the
+two cannot disagree about the same person. Only the blurb is the member page's
+own.
 
 **The stored vocabulary is deliberately untouched.** `expired` and `lapsed` are
 still what the database, `deriveLifecycleStatus`, the `/manager/users` filter and

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -81,6 +81,37 @@ the manager screens read the live catalogue now. A price change is edited in
 two places: the plan (immediate, drives what people actually pay) and the
 pricing page copy (a code change, like any other website wording).
 
+## What an ended membership is called
+
+`memberships.status = 'expired'` is one stored word for two different endings,
+and reading it out loud was wrong half the time. A training period or a year of
+insurance really does expire: a date passed. A free trial or a casual class does
+not — it holds a **number of classes**, and it ends when they are used up. So
+the screens name the ending from the plan's **kind**, not from the status:
+
+| The plan ends with | Ended row reads | Where the rule lives                         |
+| ------------------ | --------------- | -------------------------------------------- |
+| session credits    | **Used up**     | `endsWithCredits` in `src/lib/validation.ts` |
+| a date             | **Expired**     | (`creditsRequired` on `PLAN_TYPES`)          |
+
+The person-level funnel phase has the same problem in miniature. `lapsed` is
+derived both for somebody whose paid membership ended and for somebody who came
+to their two free classes and stopped, and only the first has lapsed — the
+second is the club's warmest lead, with no membership to renew. Where their
+newest membership is still the free trial (which is always their oldest, since
+it is assigned at waiver approval, so a trial that is still newest means nothing
+followed it) the phase reads **Trial used up**, and `/membership` tells them
+"You've used your free trial classes. Pick a plan below to keep training."
+instead of offering a renewal.
+
+**The stored vocabulary is deliberately untouched.** `expired` and `lapsed` are
+still what the database, `deriveLifecycleStatus`, the `/manager/users` filter and
+the manager agent API speak; only the words a human reads change. The label maps
+live in `src/lib/status-labels.ts`, the naming counterpart to
+`src/lib/status-colours.ts`, and both are keyed by their status unions so a new
+status fails the typecheck until it has been given a word and a colour. Labels
+come out sentence-cased, so callers pass `preserveCase` to `<Pill>`.
+
 ## Buying a dated plan
 
 The member purchase screen shows one card per still-sellable plan — a dated

--- a/e2e/manager/memberships.spec.ts
+++ b/e2e/manager/memberships.spec.ts
@@ -35,10 +35,15 @@ test("the memberships screen lists the club's invoices", async ({ page }) => {
   await page.goto("/manager/memberships");
 
   // The seeded member's period-plan invoice: active, and already paid.
+  //
+  // "Active", not "active": the pill renders a WORD from `status-labels.ts`,
+  // not the stored enum value, and `toContainText` is case-sensitive. Whether
+  // an ended membership reads "Expired" or "Used up" depends on its plan too,
+  // so don't assume the status column echoes the database.
   const row = page.getByRole("row").filter({ hasText: "JITSU-000101" });
   await expect(row).toHaveCount(1);
   await expect(row).toContainText(fixture.personas.member.email);
-  await expect(row).toContainText("active");
+  await expect(row).toContainText("Active");
 });
 
 test("a manager can raise a membership, mark it paid, and then can't delete it", async ({
@@ -140,9 +145,9 @@ test("a manager can cancel and reopen a membership", async ({ page }) => {
 
   await row.getByRole("button", { name: "Cancel" }).click();
   await page.getByRole("alertdialog").getByRole("button", { name: "Cancel membership" }).click();
-  await expect(row).toContainText("cancelled");
+  await expect(row).toContainText("Cancelled");
 
   await row.getByRole("button", { name: "Reopen" }).click();
   await page.getByRole("alertdialog").getByRole("button", { name: "Reopen" }).click();
-  await expect(row).toContainText("active");
+  await expect(row).toContainText("Active");
 });

--- a/e2e/manager/new-member-journey.spec.ts
+++ b/e2e/manager/new-member-journey.spec.ts
@@ -317,12 +317,12 @@ test("a new member's journey: register, sign, trial, buy, pay, and switch plans"
     await expect(row).toHaveCount(1);
     await row.getByRole("button", { name: "Cancel" }).click();
     await page.getByRole("alertdialog").getByRole("button", { name: "Cancel membership" }).click();
-    await expect(row).toContainText("cancelled");
+    await expect(row).toContainText("Cancelled");
 
     // The new plan is what pays for them now: active, and it is the one the
     // check-in landed on.
     const periodRow = page.getByRole("row").filter({ hasText: periodMembership.payment_reference });
-    await expect(periodRow).toContainText("active");
+    await expect(periodRow).toContainText("Active");
   });
 
   // Real club behaviour: someone on a period plan still occasionally pays for
@@ -419,5 +419,23 @@ test("a new member's journey: register, sign, trial, buy, pay, and switch plans"
       .eq("id", secondCasualMembership.id)
       .maybeSingle();
     expect(spent).toMatchObject({ sessions_remaining: 0, status: "expired" });
+  });
+
+  // The row above is stored as `expired`, but a casual class is one class, not
+  // a stretch of time: nothing about it went out of date, its class was used.
+  // This is the only place the whole path is provable at once — a real credit
+  // spent to zero by a real check-in, then read back off the screen a manager
+  // actually looks at (docs/memberships.md, "What an ended membership is
+  // called"). `toContainText` is case-sensitive, and sentence case is the
+  // point: these labels are words, not enum values.
+  await test.step("the spent casual class reads as used up, not expired", async () => {
+    await page.goto("/manager/memberships");
+    const row = page
+      .getByRole("row")
+      .filter({ hasText: secondCasualMembership.payment_reference })
+      .filter({ hasText: "Casual class" });
+    await expect(row).toHaveCount(1);
+    await expect(row).toContainText("Used up");
+    await expect(row).not.toContainText("Expired");
   });
 });

--- a/e2e/member/membership.spec.ts
+++ b/e2e/member/membership.spec.ts
@@ -25,11 +25,11 @@ test("the member's status and memberships show on their membership page", async 
   // its planOf helper) — the member's seeded membership is bought on it.
   const periodRow = page.getByRole("row").filter({ hasText: "This semester" });
   await expect(periodRow).toHaveCount(1);
-  await expect(periodRow).toContainText("active");
+  await expect(periodRow).toContainText("Active");
 
   const insuranceRow = page.getByRole("row").filter({ hasText: "Sydney Jitsu yearly membership" });
   await expect(insuranceRow).toHaveCount(1);
-  await expect(insuranceRow).toContainText("active");
+  await expect(insuranceRow).toContainText("Active");
 
   await expectPageRendered(page);
 });

--- a/src/lib/checkin.test.ts
+++ b/src/lib/checkin.test.ts
@@ -347,6 +347,22 @@ describe("attachableMemberships", () => {
     expect(by("old")).toMatchObject({ usable: false, reason: "not valid for this class" });
   });
 
+  // The door reads these as prose ("Free trial · 0 left · used up"), so the
+  // reason is lower-cased, but it is still the club's word for that ending: a
+  // credit plan is used up, only a dated one expires.
+  it("says a spent credit plan is used up, and a dated one expired", () => {
+    const rows = attachableMemberships(
+      [
+        trial({ id: "spent-trial", status: "expired", sessions_remaining: 0 }),
+        semester({ id: "over", status: "expired", ends_at: "2026-06-30T00:00:00.000Z" }),
+      ],
+      AT,
+    );
+    const by = (id: string) => rows.find((r) => r.id === id)!;
+    expect(by("spent-trial")).toMatchObject({ usable: false, reason: "used up" });
+    expect(by("over")).toMatchObject({ usable: false, reason: "expired" });
+  });
+
   // The point of all of it: an uncovered check-in from a class someone really
   // attended can be attached to the trial they were given afterwards.
   it("lets a later-granted trial be attached to an earlier class", () => {

--- a/src/lib/checkin.test.ts
+++ b/src/lib/checkin.test.ts
@@ -363,6 +363,17 @@ describe("attachableMemberships", () => {
     expect(by("over")).toMatchObject({ usable: false, reason: "expired" });
   });
 
+  it("does not say a credit plan is used up while a class remains on it", () => {
+    // `refundCheckInCredit` puts a credit back without reopening the row unless
+    // that same check-in closed it, so this row really occurs. The door prints
+    // the balance in the same option, which would contradict "used up".
+    const rows = attachableMemberships(
+      [trial({ id: "refunded", status: "expired", sessions_remaining: 1 })],
+      AT,
+    );
+    expect(rows[0]).toMatchObject({ usable: false, reason: "expired" });
+  });
+
   // The point of all of it: an uncovered check-in from a class someone really
   // attended can be attached to the trial they were given afterwards.
   it("lets a later-granted trial be attached to an earlier class", () => {

--- a/src/lib/checkin.ts
+++ b/src/lib/checkin.ts
@@ -9,6 +9,7 @@
 // and on the server to actually spend it, so the warning a manager reads and the
 // credit that moves can never disagree.
 import { CLUB_TIME_ZONE, clubLocalDate } from "./calendar";
+import { membershipStatusLabel } from "./status-labels";
 import { isUnpaid } from "./validation";
 import type { CheckInWarning, CoverageSource } from "./validation";
 
@@ -305,7 +306,10 @@ export function attachableMemberships(candidates: CoverageCandidate[], at: strin
         decision.coverage !== "none"
           ? null
           : m.status !== "active"
-            ? m.status
+            ? // Lower-cased on purpose: this reason is read as prose beside the
+              // others below ("Free trial · 0 left · used up"), not as a status
+              // pill, so it must not arrive title-cased mid-sentence.
+              membershipStatusLabel(m).toLowerCase()
             : m.sessions_remaining === 0
               ? "no credits left"
               : startsAfter(m, atMs)

--- a/src/lib/club-user.functions.ts
+++ b/src/lib/club-user.functions.ts
@@ -251,10 +251,12 @@ export const getClubUser = createServerFn({ method: "POST" })
         phone: summary.phone,
         roles: summary.roles,
         lifecycle_status: summary.lifecycle_status,
-        // Which lets the phase be named properly: a `lapsed` person whose
-        // newest membership is still the free trial used up their two classes,
-        // they did not let a membership run out.
+        // Their newest membership, which is what lets the phase be named
+        // properly: a `lapsed` person whose newest is a free trial that EXPIRED
+        // used up their two classes, they did not let a membership run out. Both
+        // halves are needed, since a trial a manager cancelled is neither.
         latest_plan_kind: summary.latest_plan_kind,
+        latest_membership_status: summary.latest_membership_status,
         // Classes trained, whatever paid for them: the coaching and grading
         // number, not "credits used". From the exact count, so it agrees with
         // /manager/users however long their history is.

--- a/src/lib/club-user.functions.ts
+++ b/src/lib/club-user.functions.ts
@@ -172,6 +172,7 @@ export const getClubUser = createServerFn({ method: "POST" })
         price_cents: m.price_cents,
         is_student: m.is_student,
         uts_student_number: m.uts_student_number,
+        sessions_remaining: m.sessions_remaining,
         created_at: m.created_at,
       })),
       plans: planRows,
@@ -257,6 +258,7 @@ export const getClubUser = createServerFn({ method: "POST" })
         // halves are needed, since a trial a manager cancelled is neither.
         latest_plan_kind: summary.latest_plan_kind,
         latest_membership_status: summary.latest_membership_status,
+        latest_sessions_remaining: summary.latest_sessions_remaining,
         // Classes trained, whatever paid for them: the coaching and grading
         // number, not "credits used". From the exact count, so it agrees with
         // /manager/users however long their history is.

--- a/src/lib/club-user.functions.ts
+++ b/src/lib/club-user.functions.ts
@@ -251,6 +251,10 @@ export const getClubUser = createServerFn({ method: "POST" })
         phone: summary.phone,
         roles: summary.roles,
         lifecycle_status: summary.lifecycle_status,
+        // Which lets the phase be named properly: a `lapsed` person whose
+        // newest membership is still the free trial used up their two classes,
+        // they did not let a membership run out.
+        latest_plan_kind: summary.latest_plan_kind,
         // Classes trained, whatever paid for them: the coaching and grading
         // number, not "credits used". From the exact count, so it agrees with
         // /manager/users however long their history is.
@@ -290,6 +294,9 @@ export const getClubUser = createServerFn({ method: "POST" })
       memberships: membershipRows.map((m) => ({
         id: m.id,
         plan_name: planById.get(m.plan_id)?.name ?? null,
+        // What the status is called depends on it: a plan sold as a number of
+        // classes is "used up" when it ends, not "expired".
+        kind: planById.get(m.plan_id)?.kind ?? null,
         status: m.status,
         price_cents: m.price_cents,
         payment_reference: m.payment_reference,

--- a/src/lib/club-users.test.ts
+++ b/src/lib/club-users.test.ts
@@ -348,8 +348,26 @@ describe("aggregateClubUsers", () => {
       ],
     });
     expect(u.latest_plan_name).toBe("One semester");
+    expect(u.latest_plan_kind).toBe("period");
     expect(u.latest_membership_status).toBe("active");
     expect(u.membership_count).toBe(2);
+  });
+
+  it("carries the latest plan's kind, which is what names its status on screen", () => {
+    // A used-up trial and a finished semester are both stored as `expired`. The
+    // kind is the only thing that tells the users list which word to print, and
+    // it separates "they came twice and stopped" from "the semester ended".
+    const [trialOnly] = aggregate({
+      profiles: [profile()],
+      waivers: [waiver()],
+      memberships: [membership({ plan_id: "plan-trial", price_cents: 0, status: "expired" })],
+    });
+    expect(trialOnly.lifecycle_status).toBe("lapsed");
+    expect(trialOnly.latest_plan_kind).toBe("trial");
+
+    // A lead has no memberships at all, so there is no kind to report.
+    const [aLead] = aggregate({ profiles: [], emails: [], leads: [lead()] });
+    expect(aLead.latest_plan_kind).toBeNull();
   });
 
   it("computes first-seen as the earliest of profile, waiver and membership dates", () => {

--- a/src/lib/club-users.test.ts
+++ b/src/lib/club-users.test.ts
@@ -55,6 +55,7 @@ function membership(over: Partial<ClubUserMembership> = {}): ClubUserMembership 
     price_cents: 24500,
     is_student: false,
     uts_student_number: null,
+    sessions_remaining: null,
     created_at: "2026-02-01T00:00:00Z",
     ...over,
   };
@@ -360,10 +361,21 @@ describe("aggregateClubUsers", () => {
     const [trialOnly] = aggregate({
       profiles: [profile()],
       waivers: [waiver()],
-      memberships: [membership({ plan_id: "plan-trial", price_cents: 0, status: "expired" })],
+      memberships: [
+        membership({
+          plan_id: "plan-trial",
+          price_cents: 0,
+          status: "expired",
+          sessions_remaining: 0,
+        }),
+      ],
     });
     expect(trialOnly.lifecycle_status).toBe("lapsed");
     expect(trialOnly.latest_plan_kind).toBe("trial");
+    // The balance rides along with the kind: an ended credit plan only reads as
+    // "used up" once its classes are actually gone, and a refunded check-in can
+    // leave one `expired` with a class still on it.
+    expect(trialOnly.latest_sessions_remaining).toBe(0);
 
     // A lead has no memberships at all, so there is no kind to report.
     const [aLead] = aggregate({ profiles: [], emails: [], leads: [lead()] });

--- a/src/lib/club-users.ts
+++ b/src/lib/club-users.ts
@@ -143,6 +143,13 @@ export type ClubUser = {
   gi_size: string | null;
   belt_size: string | null;
   latest_plan_name: string | null;
+  /**
+   * The kind of plan behind `latest_membership_status`, so a screen can name
+   * that status correctly: an ended trial or class pack is "used up", an ended
+   * training period is "expired". Null for a lead, or when the plan row could
+   * not be resolved.
+   */
+  latest_plan_kind: string | null;
   latest_membership_status: MembershipStatus | null;
   membership_count: number;
   /** Classes this person has been checked in to, all-time. Always 0 for a lead. */
@@ -298,6 +305,7 @@ export function aggregateClubUsers(input: {
       gi_size: p.gi_size,
       belt_size: p.belt_size,
       latest_plan_name: latest ? (planById.get(latest.plan_id)?.name ?? null) : null,
+      latest_plan_kind: latest ? (planById.get(latest.plan_id)?.kind ?? null) : null,
       latest_membership_status: latest ? (latest.status as MembershipStatus) : null,
       membership_count: ms.length,
       sessions_attended: checkinsByUser.get(p.user_id) ?? 0,
@@ -334,6 +342,7 @@ export function aggregateClubUsers(input: {
       gi_size: null,
       belt_size: null,
       latest_plan_name: null,
+      latest_plan_kind: null,
       latest_membership_status: null,
       membership_count: 0,
       // A lead has never been on the mat: there is no person record to check in.

--- a/src/lib/club-users.ts
+++ b/src/lib/club-users.ts
@@ -91,6 +91,8 @@ export type ClubUserMembership = {
   price_cents: number;
   is_student: boolean;
   uts_student_number: string | null;
+  /** Credits left. Null for a plan that was never sold as a number of classes. */
+  sessions_remaining: number | null;
   created_at: string;
 };
 
@@ -151,6 +153,12 @@ export type ClubUser = {
    */
   latest_plan_kind: string | null;
   latest_membership_status: MembershipStatus | null;
+  /**
+   * Credits left on that latest membership. Needed alongside the kind because
+   * an ended credit plan is only "used up" if its classes are actually gone: a
+   * refunded check-in can leave one `expired` with a credit still on it.
+   */
+  latest_sessions_remaining: number | null;
   membership_count: number;
   /** Classes this person has been checked in to, all-time. Always 0 for a lead. */
   sessions_attended: number;
@@ -307,6 +315,7 @@ export function aggregateClubUsers(input: {
       latest_plan_name: latest ? (planById.get(latest.plan_id)?.name ?? null) : null,
       latest_plan_kind: latest ? (planById.get(latest.plan_id)?.kind ?? null) : null,
       latest_membership_status: latest ? (latest.status as MembershipStatus) : null,
+      latest_sessions_remaining: latest ? latest.sessions_remaining : null,
       membership_count: ms.length,
       sessions_attended: checkinsByUser.get(p.user_id) ?? 0,
       first_seen_at,
@@ -344,6 +353,7 @@ export function aggregateClubUsers(input: {
       latest_plan_name: null,
       latest_plan_kind: null,
       latest_membership_status: null,
+      latest_sessions_remaining: null,
       membership_count: 0,
       // A lead has never been on the mat: there is no person record to check in.
       sessions_attended: 0,

--- a/src/lib/membership.functions.ts
+++ b/src/lib/membership.functions.ts
@@ -1371,6 +1371,7 @@ export const listClubUsers = createServerFn({ method: "GET" })
         price_cents: m.price_cents,
         is_student: m.is_student,
         uts_student_number: m.uts_student_number,
+        sessions_remaining: m.sessions_remaining,
         created_at: m.created_at,
       })),
       plans: (plans ?? []).map((p) => ({ id: p.id, name: p.name, kind: p.kind })),

--- a/src/lib/status-colours.ts
+++ b/src/lib/status-colours.ts
@@ -13,6 +13,9 @@
 // Pure data with no imports beyond types, so it stays unit-testable and can be
 // read by a server-rendered route as happily as by a component. The badge that
 // wears these classes is `@/components/site/StatusPill`.
+//
+// What a status is CALLED is the sibling question, and lives in
+// `./status-labels` for the same reason this file exists.
 import type { VerificationLabel } from "./email-verification";
 import type {
   BlogCommentStatus,

--- a/src/lib/status-labels.test.ts
+++ b/src/lib/status-labels.test.ts
@@ -34,13 +34,24 @@ describe("membershipStatusLabel", () => {
 });
 
 describe("lifecycleLabel", () => {
+  const trial = (status: string) => ({ status, kind: "trial" });
+
   it("calls a used-up trial what it is, not a lapsed membership", () => {
-    expect(lifecycleLabel("lapsed", "trial")).toBe("Trial used up");
+    expect(lifecycleLabel("lapsed", trial("expired"))).toBe("Trial used up");
+  });
+
+  it("does not claim a CANCELLED trial was used up", () => {
+    // `lapsed` is derived from expired OR cancelled. A trial a manager
+    // cancelled may have both its classes sitting untouched, and its own row
+    // (correctly) reads "Cancelled" right beside this pill.
+    expect(lifecycleLabel("lapsed", trial("cancelled"))).toBe("Lapsed");
   });
 
   it("keeps 'lapsed' for somebody whose paid membership ended", () => {
-    expect(lifecycleLabel("lapsed", "period")).toBe("Lapsed");
-    expect(lifecycleLabel("lapsed", "session")).toBe("Lapsed");
+    expect(lifecycleLabel("lapsed", { status: "expired", kind: "period" })).toBe("Lapsed");
+    expect(lifecycleLabel("lapsed", { status: "expired", kind: "session" })).toBe("Lapsed");
+    expect(lifecycleLabel("lapsed", { status: "expired", kind: null })).toBe("Lapsed");
+    expect(lifecycleLabel("lapsed")).toBe("Lapsed");
     expect(lifecycleLabel("lapsed", null)).toBe("Lapsed");
   });
 
@@ -50,8 +61,8 @@ describe("lifecycleLabel", () => {
     expect(lifecycleLabel("visitor")).toBe("Visitor");
     expect(lifecycleLabel("member")).toBe("Member");
     // A trial is somebody's newest membership all the way through the funnel,
-    // so the kind must not leak into any phase but the ended one.
-    expect(lifecycleLabel("visitor", "trial")).toBe("Visitor");
-    expect(lifecycleLabel("member", "trial")).toBe("Member");
+    // so it must not leak into any phase but the ended one.
+    expect(lifecycleLabel("visitor", trial("active"))).toBe("Visitor");
+    expect(lifecycleLabel("member", trial("expired"))).toBe("Member");
   });
 });

--- a/src/lib/status-labels.test.ts
+++ b/src/lib/status-labels.test.ts
@@ -1,0 +1,57 @@
+// The bug these pin: `memberships.status = 'expired'` is one stored word for
+// two different endings, and the club was reading it out loud both times. A
+// free trial is two classes, not a date, so it cannot expire; it gets used up.
+import { describe, expect, it } from "vitest";
+import { lifecycleLabel, membershipStatusLabel } from "./status-labels";
+
+describe("membershipStatusLabel", () => {
+  it("says a finished trial or class pack is used up, not expired", () => {
+    expect(membershipStatusLabel({ status: "expired", kind: "trial" })).toBe("Used up");
+    expect(membershipStatusLabel({ status: "expired", kind: "session" })).toBe("Used up");
+  });
+
+  it("keeps 'expired' for the plans that really do run out on a date", () => {
+    expect(membershipStatusLabel({ status: "expired", kind: "period" })).toBe("Expired");
+    expect(membershipStatusLabel({ status: "expired", kind: "insurance" })).toBe("Expired");
+  });
+
+  it("only renames the ending, never the other states", () => {
+    expect(membershipStatusLabel({ status: "active", kind: "trial" })).toBe("Active");
+    expect(membershipStatusLabel({ status: "pending", kind: "trial" })).toBe("Pending");
+    expect(membershipStatusLabel({ status: "cancelled", kind: "trial" })).toBe("Cancelled");
+  });
+
+  it("falls back to the plain word when the plan could not be resolved", () => {
+    // Several screens carry a row whose plan row is missing. Guessing "used up"
+    // there would claim a class count the club may not have sold.
+    expect(membershipStatusLabel({ status: "expired", kind: null })).toBe("Expired");
+    expect(membershipStatusLabel({ status: "expired" })).toBe("Expired");
+  });
+
+  it("passes an unknown status straight through rather than blanking the pill", () => {
+    expect(membershipStatusLabel({ status: "something_new", kind: "trial" })).toBe("something_new");
+  });
+});
+
+describe("lifecycleLabel", () => {
+  it("calls a used-up trial what it is, not a lapsed membership", () => {
+    expect(lifecycleLabel("lapsed", "trial")).toBe("Trial used up");
+  });
+
+  it("keeps 'lapsed' for somebody whose paid membership ended", () => {
+    expect(lifecycleLabel("lapsed", "period")).toBe("Lapsed");
+    expect(lifecycleLabel("lapsed", "session")).toBe("Lapsed");
+    expect(lifecycleLabel("lapsed", null)).toBe("Lapsed");
+  });
+
+  it("names the rest of the funnel unchanged", () => {
+    expect(lifecycleLabel("lead")).toBe("Lead");
+    expect(lifecycleLabel("applicant")).toBe("Applicant");
+    expect(lifecycleLabel("visitor")).toBe("Visitor");
+    expect(lifecycleLabel("member")).toBe("Member");
+    // A trial is somebody's newest membership all the way through the funnel,
+    // so the kind must not leak into any phase but the ended one.
+    expect(lifecycleLabel("visitor", "trial")).toBe("Visitor");
+    expect(lifecycleLabel("member", "trial")).toBe("Member");
+  });
+});

--- a/src/lib/status-labels.test.ts
+++ b/src/lib/status-labels.test.ts
@@ -2,30 +2,57 @@
 // two different endings, and the club was reading it out loud both times. A
 // free trial is two classes, not a date, so it cannot expire; it gets used up.
 import { describe, expect, it } from "vitest";
-import { lifecycleLabel, membershipStatusLabel } from "./status-labels";
+import { isUsedUp, lifecycleLabel, membershipStatusLabel } from "./status-labels";
 
 describe("membershipStatusLabel", () => {
+  const spent = { status: "expired", sessions_remaining: 0 };
+
   it("says a finished trial or class pack is used up, not expired", () => {
-    expect(membershipStatusLabel({ status: "expired", kind: "trial" })).toBe("Used up");
-    expect(membershipStatusLabel({ status: "expired", kind: "session" })).toBe("Used up");
+    expect(membershipStatusLabel({ ...spent, kind: "trial" })).toBe("Used up");
+    expect(membershipStatusLabel({ ...spent, kind: "session" })).toBe("Used up");
   });
 
   it("keeps 'expired' for the plans that really do run out on a date", () => {
-    expect(membershipStatusLabel({ status: "expired", kind: "period" })).toBe("Expired");
-    expect(membershipStatusLabel({ status: "expired", kind: "insurance" })).toBe("Expired");
+    expect(membershipStatusLabel({ ...spent, kind: "period" })).toBe("Expired");
+    expect(membershipStatusLabel({ ...spent, kind: "insurance" })).toBe("Expired");
+  });
+
+  it("does not say 'used up' while classes are still on the row", () => {
+    // The state this guards is reachable from the check-in screen, not just by
+    // hand: undoing a check-in refunds the credit but reopens the membership
+    // only when THAT check-in is the one that closed it, so undoing an earlier
+    // visit leaves `expired` with a class back on the row. A manager expiring a
+    // never-used trial through edit_invoice lands in the same place. The screen
+    // prints the balance next to this word, so it has to agree with it.
+    expect(membershipStatusLabel({ status: "expired", kind: "trial", sessions_remaining: 1 })).toBe(
+      "Expired",
+    );
+    expect(membershipStatusLabel({ status: "expired", kind: "trial", sessions_remaining: 2 })).toBe(
+      "Expired",
+    );
   });
 
   it("only renames the ending, never the other states", () => {
-    expect(membershipStatusLabel({ status: "active", kind: "trial" })).toBe("Active");
-    expect(membershipStatusLabel({ status: "pending", kind: "trial" })).toBe("Pending");
-    expect(membershipStatusLabel({ status: "cancelled", kind: "trial" })).toBe("Cancelled");
+    expect(membershipStatusLabel({ status: "active", kind: "trial", sessions_remaining: 0 })).toBe(
+      "Active",
+    );
+    expect(membershipStatusLabel({ status: "pending", kind: "trial", sessions_remaining: 0 })).toBe(
+      "Pending",
+    );
+    expect(
+      membershipStatusLabel({ status: "cancelled", kind: "trial", sessions_remaining: 0 }),
+    ).toBe("Cancelled");
   });
 
-  it("falls back to the plain word when the plan could not be resolved", () => {
-    // Several screens carry a row whose plan row is missing. Guessing "used up"
-    // there would claim a class count the club may not have sold.
-    expect(membershipStatusLabel({ status: "expired", kind: null })).toBe("Expired");
-    expect(membershipStatusLabel({ status: "expired" })).toBe("Expired");
+  it("falls back to the plain word when the plan or the balance is unknown", () => {
+    // Several screens carry a row whose plan row is missing, and a row sold as
+    // a window has no balance at all. Guessing "used up" for either would claim
+    // a class count the club may not have sold.
+    expect(membershipStatusLabel({ ...spent, kind: null })).toBe("Expired");
+    expect(membershipStatusLabel({ status: "expired", kind: "trial" })).toBe("Expired");
+    expect(
+      membershipStatusLabel({ status: "expired", kind: "trial", sessions_remaining: null }),
+    ).toBe("Expired");
   });
 
   it("passes an unknown status straight through rather than blanking the pill", () => {
@@ -33,8 +60,23 @@ describe("membershipStatusLabel", () => {
   });
 });
 
+describe("isUsedUp", () => {
+  // The predicate the label and the funnel phase both hang off, so it is worth
+  // pinning on its own: all three of ended, sold-as-classes, and none left.
+  it("needs the row ended, sold as classes, and empty", () => {
+    expect(isUsedUp({ status: "expired", kind: "trial", sessions_remaining: 0 })).toBe(true);
+    expect(isUsedUp({ status: "active", kind: "trial", sessions_remaining: 0 })).toBe(false);
+    expect(isUsedUp({ status: "expired", kind: "period", sessions_remaining: 0 })).toBe(false);
+    expect(isUsedUp({ status: "expired", kind: "trial", sessions_remaining: 1 })).toBe(false);
+  });
+});
+
 describe("lifecycleLabel", () => {
-  const trial = (status: string) => ({ status, kind: "trial" });
+  const trial = (status: string, sessions_remaining = 0) => ({
+    status,
+    kind: "trial",
+    sessions_remaining,
+  });
 
   it("calls a used-up trial what it is, not a lapsed membership", () => {
     expect(lifecycleLabel("lapsed", trial("expired"))).toBe("Trial used up");
@@ -47,10 +89,22 @@ describe("lifecycleLabel", () => {
     expect(lifecycleLabel("lapsed", trial("cancelled"))).toBe("Lapsed");
   });
 
+  it("does not claim a trial was used up while classes remain on it", () => {
+    // Same state as the membership-label case: refunded or hand-expired. The
+    // phase pill sits beside a row that still shows the balance.
+    expect(lifecycleLabel("lapsed", trial("expired", 1))).toBe("Lapsed");
+  });
+
   it("keeps 'lapsed' for somebody whose paid membership ended", () => {
-    expect(lifecycleLabel("lapsed", { status: "expired", kind: "period" })).toBe("Lapsed");
-    expect(lifecycleLabel("lapsed", { status: "expired", kind: "session" })).toBe("Lapsed");
-    expect(lifecycleLabel("lapsed", { status: "expired", kind: null })).toBe("Lapsed");
+    expect(
+      lifecycleLabel("lapsed", { status: "expired", kind: "period", sessions_remaining: null }),
+    ).toBe("Lapsed");
+    expect(
+      lifecycleLabel("lapsed", { status: "expired", kind: "session", sessions_remaining: 0 }),
+    ).toBe("Lapsed");
+    expect(lifecycleLabel("lapsed", { status: "expired", kind: null, sessions_remaining: 0 })).toBe(
+      "Lapsed",
+    );
     expect(lifecycleLabel("lapsed")).toBe("Lapsed");
     expect(lifecycleLabel("lapsed", null)).toBe("Lapsed");
   });

--- a/src/lib/status-labels.ts
+++ b/src/lib/status-labels.ts
@@ -1,0 +1,70 @@
+// What the club CALLS each status on screen. The naming counterpart to
+// `status-colours.ts`, which owns what one looks like, and read by the same
+// screens: `/membership`, `/manager/users`, a person's manager page and
+// `/manager/memberships`.
+//
+// It exists because `memberships.status = 'expired'` is one stored word for two
+// different endings. A training period or a year of insurance really does
+// expire: a date passed and the thing is over. A free trial or a class pack
+// cannot. It holds a NUMBER of classes, and it ends when they are used up. We
+// were telling a member their two free classes had gone out of date, which is
+// not something that can happen to them, and telling a manager the same word for
+// "the semester finished" and "they came twice and stopped" — two people who
+// need completely different follow-ups.
+//
+// The stored vocabulary is deliberately untouched: `expired` and `lapsed` are
+// what the database, the manager agent API and every filter still speak. Only
+// the words a human reads change, which is why this is a display module and not
+// a migration.
+//
+// Every label comes out ready to render, sentence case included, so callers pass
+// `preserveCase` to `<Pill>`. CSS `capitalize` would title-case a two-word label
+// into "Used Up".
+import { endsWithCredits } from "./validation";
+import type { LifecycleStatus, MembershipStatus } from "./validation";
+
+// Keyed by their unions, so adding a status fails to compile until it has been
+// given a word, exactly as the colour maps do.
+const MEMBERSHIP: Record<MembershipStatus, string> = {
+  pending: "Pending",
+  active: "Active",
+  expired: "Expired",
+  cancelled: "Cancelled",
+};
+
+const LIFECYCLE: Record<LifecycleStatus, string> = {
+  lead: "Lead",
+  applicant: "Applicant",
+  visitor: "Visitor",
+  member: "Member",
+  lapsed: "Lapsed",
+};
+
+/**
+ * What one enrolment's state is called, given the kind of plan behind it.
+ *
+ * `kind` is optional and may be null: several screens carry a membership row
+ * whose plan could not be resolved. Those fall back to the plain status word.
+ */
+export function membershipStatusLabel(m: { status: string; kind?: string | null }): string {
+  if (m.status === "expired" && endsWithCredits(m.kind)) return "Used up";
+  return MEMBERSHIP[m.status as MembershipStatus] ?? m.status;
+}
+
+/**
+ * The funnel phase, as a manager reads it.
+ *
+ * `lapsed` is derived for two very different people: somebody whose paid
+ * membership ended, and somebody who used up the free classes they were given
+ * and never bought anything. Only the first has lapsed. The second is the club's
+ * warmest lead, and telling the two apart at a glance is what the column is for.
+ *
+ * `latestPlanKind` (the newest membership's plan kind) is enough to separate
+ * them, because the free trial is assigned when a waiver is approved and is
+ * therefore always a person's OLDEST membership. A trial that is still their
+ * newest one means nothing ever followed it.
+ */
+export function lifecycleLabel(status: string, latestPlanKind?: string | null): string {
+  if (status === "lapsed" && latestPlanKind === "trial") return "Trial used up";
+  return LIFECYCLE[status as LifecycleStatus] ?? status;
+}

--- a/src/lib/status-labels.ts
+++ b/src/lib/status-labels.ts
@@ -1,7 +1,7 @@
 // What the club CALLS each status on screen. The naming counterpart to
 // `status-colours.ts`, which owns what one looks like, and read by the same
-// screens: `/membership`, `/manager/users`, a person's manager page and
-// `/manager/memberships`.
+// screens: `/membership`, `/manager/users`, a person's manager page,
+// `/manager/memberships` and the check-in board.
 //
 // It exists because `memberships.status = 'expired'` is one stored word for two
 // different endings. A training period or a year of insurance really does
@@ -40,43 +40,68 @@ const LIFECYCLE: Record<LifecycleStatus, string> = {
   lapsed: "Lapsed",
 };
 
+/** The one phase label that is not simply its status capitalised. */
+export const TRIAL_USED_UP_LABEL = "Trial used up";
+
+/** What the label layer needs to know about one enrolment. */
+export type LabelledMembership = {
+  status: string;
+  /** The plan's kind. Optional and nullable: some rows cannot resolve a plan. */
+  kind?: string | null;
+  /** Credits left on the row. Null for a plan that was never sold as classes. */
+  sessions_remaining?: number | null;
+};
+
 /**
- * What one enrolment's state is called, given the kind of plan behind it.
+ * Did this membership end because its last class was spent?
  *
- * `kind` is optional and may be null: several screens carry a membership row
- * whose plan could not be resolved. Those fall back to the plain status word.
+ * All three conditions are asked, and the credit balance is the one that does
+ * the real work. It is tempting to treat `expired` on a credit plan as proof on
+ * its own, and that is wrong: a membership can sit `expired` with classes still
+ * in it. Undoing a check-in refunds the credit but reopens the row only when
+ * that same check-in is the one that closed it (`refundCheckInCredit` in
+ * `checkin.functions.ts`), so undoing an EARLIER visit leaves `expired` with a
+ * credit back on the row. A manager can also expire a row by hand through
+ * `edit_invoice` or `setMembershipStatus`, on a trial nobody ever used.
+ *
+ * "Expired" was vague enough to survive those states. "Used up" is a specific
+ * claim, and the same screen prints the balance next to it, so it has to be read
+ * off the balance rather than inferred from the status.
  */
-export function membershipStatusLabel(m: { status: string; kind?: string | null }): string {
-  if (m.status === "expired" && endsWithCredits(m.kind)) return "Used up";
+export function isUsedUp(m: LabelledMembership): boolean {
+  return m.status === "expired" && endsWithCredits(m.kind) && m.sessions_remaining === 0;
+}
+
+/**
+ * What one enrolment's state is called, given the plan behind it and what is
+ * left on it.
+ */
+export function membershipStatusLabel(m: LabelledMembership): string {
+  if (isUsedUp(m)) return "Used up";
   return MEMBERSHIP[m.status as MembershipStatus] ?? m.status;
 }
 
-/** The one phase label that is not simply its status capitalised. */
-export const TRIAL_USED_UP_LABEL = "Trial used up";
+/**
+ * Is this person's funnel phase "they finished the free classes we gave them and
+ * bought nothing"? The club's warmest lead, and the fact both the member's own
+ * status card and the manager's pill are named from.
+ *
+ * `latest` is their newest membership. That is enough to separate this person
+ * from someone whose paid membership ended, because the free trial is assigned
+ * when a waiver is approved: a trial that is still their newest membership means
+ * nothing followed it.
+ */
+export function isTrialUsedUp(status: string, latest?: LabelledMembership | null): boolean {
+  return status === "lapsed" && latest?.kind === "trial" && isUsedUp(latest);
+}
 
 /**
  * The funnel phase, as a manager reads it.
  *
- * `lapsed` is derived for two very different people: somebody whose paid
- * membership ended, and somebody who used up the free classes they were given
- * and never bought anything. Only the first has lapsed. The second is the club's
- * warmest lead, and telling the two apart at a glance is what the column is for.
- *
- * `latest` is their newest membership, which is enough to separate them, because
- * the free trial is assigned when a waiver is approved and is therefore always a
- * person's OLDEST membership. A trial that is still their newest one means
- * nothing ever followed it.
- *
- * Both of its fields are asked, not just the kind. `lapsed` is derived from
- * `expired` OR `cancelled`, and a trial a manager cancelled was not used up: its
- * classes may be sitting there untouched. Only `expired` on a credit plan means
- * the last one was spent, since nothing else closes a plan that has no end date.
+ * `lapsed` is derived for two very different people, and `isTrialUsedUp` is what
+ * tells them apart. Everything else is its status, capitalised.
  */
-export function lifecycleLabel(
-  status: string,
-  latest?: { status: string | null; kind?: string | null } | null,
-): string {
-  if (status === "lapsed" && latest?.kind === "trial" && latest.status === "expired")
-    return TRIAL_USED_UP_LABEL;
+export function lifecycleLabel(status: string, latest?: LabelledMembership | null): string {
+  if (isTrialUsedUp(status, latest)) return TRIAL_USED_UP_LABEL;
   return LIFECYCLE[status as LifecycleStatus] ?? status;
 }

--- a/src/lib/status-labels.ts
+++ b/src/lib/status-labels.ts
@@ -51,6 +51,9 @@ export function membershipStatusLabel(m: { status: string; kind?: string | null 
   return MEMBERSHIP[m.status as MembershipStatus] ?? m.status;
 }
 
+/** The one phase label that is not simply its status capitalised. */
+export const TRIAL_USED_UP_LABEL = "Trial used up";
+
 /**
  * The funnel phase, as a manager reads it.
  *
@@ -59,12 +62,21 @@ export function membershipStatusLabel(m: { status: string; kind?: string | null 
  * and never bought anything. Only the first has lapsed. The second is the club's
  * warmest lead, and telling the two apart at a glance is what the column is for.
  *
- * `latestPlanKind` (the newest membership's plan kind) is enough to separate
- * them, because the free trial is assigned when a waiver is approved and is
- * therefore always a person's OLDEST membership. A trial that is still their
- * newest one means nothing ever followed it.
+ * `latest` is their newest membership, which is enough to separate them, because
+ * the free trial is assigned when a waiver is approved and is therefore always a
+ * person's OLDEST membership. A trial that is still their newest one means
+ * nothing ever followed it.
+ *
+ * Both of its fields are asked, not just the kind. `lapsed` is derived from
+ * `expired` OR `cancelled`, and a trial a manager cancelled was not used up: its
+ * classes may be sitting there untouched. Only `expired` on a credit plan means
+ * the last one was spent, since nothing else closes a plan that has no end date.
  */
-export function lifecycleLabel(status: string, latestPlanKind?: string | null): string {
-  if (status === "lapsed" && latestPlanKind === "trial") return "Trial used up";
+export function lifecycleLabel(
+  status: string,
+  latest?: { status: string | null; kind?: string | null } | null,
+): string {
+  if (status === "lapsed" && latest?.kind === "trial" && latest.status === "expired")
+    return TRIAL_USED_UP_LABEL;
   return LIFECYCLE[status as LifecycleStatus] ?? status;
 }

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -35,6 +35,7 @@ import {
   decodeDataUrlPng,
   deriveExpandedWaivers,
   deriveWaiverListStatuses,
+  endsWithCredits,
   interestSchema,
   isFutureSigningDate,
   isMinorOn,
@@ -1703,6 +1704,27 @@ describe("isUtsStudent", () => {
     expect(isUtsStudent("")).toBe(false);
     expect(isUtsStudent(null)).toBe(false);
     expect(isUtsStudent(undefined)).toBe(false);
+  });
+});
+
+describe("endsWithCredits", () => {
+  // Which plans are sold as a NUMBER of classes rather than a stretch of time.
+  // The naming of every ended membership on screen hangs off this answer.
+  it("is true for the plans that end when their classes run out", () => {
+    expect(endsWithCredits("trial")).toBe(true);
+    expect(endsWithCredits("session")).toBe(true);
+  });
+
+  it("is false for the plans that end on a date", () => {
+    expect(endsWithCredits("period")).toBe(false);
+    expect(endsWithCredits("insurance")).toBe(false);
+  });
+
+  it("is false for an unknown or missing kind, so nothing claims a class count", () => {
+    expect(endsWithCredits("something_new")).toBe(false);
+    expect(endsWithCredits(null)).toBe(false);
+    expect(endsWithCredits(undefined)).toBe(false);
+    expect(endsWithCredits("")).toBe(false);
   });
 });
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1760,6 +1760,24 @@ export const PLAN_TYPE_KINDS = Object.keys(PLAN_TYPES) as MembershipPlanKind[];
 export const planTypeOf = (kind: string): PlanTypeSpec =>
   PLAN_TYPES[kind as MembershipPlanKind] ?? PLAN_TYPES.period;
 
+/**
+ * Does a plan of this kind end by running out of classes rather than on a date?
+ *
+ * The free trial and a casual class or pack are sold as a NUMBER of classes:
+ * nothing about them can go out of date, and the only thing that closes one is
+ * spending the last credit. A training period and yearly insurance are the
+ * opposite, sold as a stretch of time. `creditsRequired` already draws exactly
+ * that line ("credits are the only thing that ends this kind"), so this reads it
+ * rather than re-listing the kinds and giving them somewhere to disagree.
+ *
+ * Unknown or missing kinds answer `false`, which is the safe way round: a row
+ * whose plan could not be resolved keeps the generic wording instead of claiming
+ * a class count it may not have.
+ */
+export function endsWithCredits(kind: string | null | undefined): boolean {
+  return kind ? (PLAN_TYPES[kind as MembershipPlanKind]?.creditsRequired ?? false) : false;
+}
+
 /** The fields whose meaning depends on the plan's kind. */
 export type PlanShapeFields = {
   kind: string;

--- a/src/routes/_authenticated/manager.memberships.tsx
+++ b/src/routes/_authenticated/manager.memberships.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Pill } from "@/components/site/StatusPill";
 import { MembershipRowActions } from "@/components/site/MembershipRowActions";
 import { membershipClass } from "@/lib/status-colours";
+import { membershipStatusLabel } from "@/lib/status-labels";
 import { formatCents } from "@/lib/validation";
 import { listMemberships } from "@/lib/membership.functions";
 import { useAuth, useRoles } from "@/hooks/useAuth";
@@ -110,7 +111,11 @@ function ManagerMembershipsPage() {
                     <td className="px-3 py-2">{r.uts_student_number ?? "—"}</td>
                     <td className="px-3 py-2 font-mono text-xs">{r.payment_reference}</td>
                     <td className="px-3 py-2">
-                      <Pill label={r.status} className={membershipClass(r.status)} />
+                      <Pill
+                        label={membershipStatusLabel(r)}
+                        preserveCase
+                        className={membershipClass(r.status)}
+                      />
                     </td>
                     <td className="px-3 py-2 text-right">
                       <MembershipRowActions membership={r} onChanged={refresh} />

--- a/src/routes/_authenticated/manager.users.tsx
+++ b/src/routes/_authenticated/manager.users.tsx
@@ -13,6 +13,7 @@ import {
   membershipClass,
   verificationClass,
 } from "@/lib/status-colours";
+import { lifecycleLabel, membershipStatusLabel } from "@/lib/status-labels";
 import { lifecycleStatuses, normalizeEmail } from "@/lib/validation";
 import { emailVerificationLabel } from "@/lib/email-verification";
 import { listClubUsers } from "@/lib/membership.functions";
@@ -312,7 +313,8 @@ function ManagerUsersPage() {
                       <td className="px-3 py-2">{r.phone ?? "—"}</td>
                       <td className="px-3 py-2">
                         <Pill
-                          label={r.lifecycle_status}
+                          label={lifecycleLabel(r.lifecycle_status, r.latest_plan_kind)}
+                          preserveCase
                           className={lifecycleClass(r.lifecycle_status)}
                         />
                       </td>
@@ -342,7 +344,11 @@ function ManagerUsersPage() {
                             <span>{r.latest_plan_name}</span>
                             {r.latest_membership_status ? (
                               <Pill
-                                label={r.latest_membership_status}
+                                label={membershipStatusLabel({
+                                  status: r.latest_membership_status,
+                                  kind: r.latest_plan_kind,
+                                })}
+                                preserveCase
                                 className={membershipClass(r.latest_membership_status)}
                               />
                             ) : null}

--- a/src/routes/_authenticated/manager.users.tsx
+++ b/src/routes/_authenticated/manager.users.tsx
@@ -313,7 +313,10 @@ function ManagerUsersPage() {
                       <td className="px-3 py-2">{r.phone ?? "—"}</td>
                       <td className="px-3 py-2">
                         <Pill
-                          label={lifecycleLabel(r.lifecycle_status, r.latest_plan_kind)}
+                          label={lifecycleLabel(r.lifecycle_status, {
+                            status: r.latest_membership_status,
+                            kind: r.latest_plan_kind,
+                          })}
                           preserveCase
                           className={lifecycleClass(r.lifecycle_status)}
                         />

--- a/src/routes/_authenticated/manager.users.tsx
+++ b/src/routes/_authenticated/manager.users.tsx
@@ -187,9 +187,11 @@ function ManagerUsersPage() {
             onChange={(e) => setLifecycle(e.target.value)}
           >
             <option value="all">All statuses</option>
+            {/* The value stays the stored enum (it is what the filter matches
+                on); only the text a manager reads is put through the label. */}
             {lifecycleStatuses.map((s) => (
               <option key={s} value={s}>
-                {s}
+                {lifecycleLabel(s)}
               </option>
             ))}
           </select>
@@ -314,8 +316,9 @@ function ManagerUsersPage() {
                       <td className="px-3 py-2">
                         <Pill
                           label={lifecycleLabel(r.lifecycle_status, {
-                            status: r.latest_membership_status,
+                            status: r.latest_membership_status ?? "",
                             kind: r.latest_plan_kind,
+                            sessions_remaining: r.latest_sessions_remaining,
                           })}
                           preserveCase
                           className={lifecycleClass(r.lifecycle_status)}
@@ -350,6 +353,7 @@ function ManagerUsersPage() {
                                 label={membershipStatusLabel({
                                   status: r.latest_membership_status,
                                   kind: r.latest_plan_kind,
+                                  sessions_remaining: r.latest_sessions_remaining,
                                 })}
                                 preserveCase
                                 className={membershipClass(r.latest_membership_status)}

--- a/src/routes/_authenticated/manager.users_.$userId.tsx
+++ b/src/routes/_authenticated/manager.users_.$userId.tsx
@@ -680,7 +680,10 @@ function ManagerUserPage() {
           <h1 className="text-3xl font-black">{summary.name ?? summary.email ?? "User"}</h1>
           <div className="flex flex-wrap items-center gap-2">
             <Pill
-              label={lifecycleLabel(summary.lifecycle_status, summary.latest_plan_kind)}
+              label={lifecycleLabel(summary.lifecycle_status, {
+                status: summary.latest_membership_status,
+                kind: summary.latest_plan_kind,
+              })}
               preserveCase
               className={lifecycleClass(summary.lifecycle_status)}
             />

--- a/src/routes/_authenticated/manager.users_.$userId.tsx
+++ b/src/routes/_authenticated/manager.users_.$userId.tsx
@@ -29,6 +29,7 @@ import {
   verificationClass,
   waiverClass,
 } from "@/lib/status-colours";
+import { lifecycleLabel, membershipStatusLabel } from "@/lib/status-labels";
 import { mediaConsentLabel } from "@/lib/waiver-acknowledgements";
 import { cn } from "@/lib/utils";
 import {
@@ -679,7 +680,8 @@ function ManagerUserPage() {
           <h1 className="text-3xl font-black">{summary.name ?? summary.email ?? "User"}</h1>
           <div className="flex flex-wrap items-center gap-2">
             <Pill
-              label={summary.lifecycle_status}
+              label={lifecycleLabel(summary.lifecycle_status, summary.latest_plan_kind)}
+              preserveCase
               className={lifecycleClass(summary.lifecycle_status)}
             />
             {summary.roles.map((role) => (
@@ -819,7 +821,11 @@ function ManagerUserPage() {
                   <tr key={m.id} className="border-t">
                     <td className="px-3 py-2 font-medium">{m.plan_name ?? "—"}</td>
                     <td className="px-3 py-2">
-                      <Pill label={m.status} className={membershipClass(m.status)} />
+                      <Pill
+                        label={membershipStatusLabel(m)}
+                        preserveCase
+                        className={membershipClass(m.status)}
+                      />
                     </td>
                     <td className="px-3 py-2">{formatCents(m.price_cents)}</td>
                     <td className="px-3 py-2">{m.payment_reference ?? "—"}</td>
@@ -893,7 +899,7 @@ function ManagerUserPage() {
                             <option value="">Whatever covers it now</option>
                             {memberships.map((m) => (
                               <option key={m.id} value={m.id}>
-                                {m.plan_name ?? "Membership"} ({m.status}
+                                {m.plan_name ?? "Membership"} ({membershipStatusLabel(m)}
                                 {m.sessions_remaining != null
                                   ? `, ${m.sessions_remaining} left`
                                   : ""}
@@ -928,7 +934,7 @@ function ManagerUserPage() {
                               <option value="">Move to...</option>
                               {otherMemberships(c.membership_id).map((m) => (
                                 <option key={m.id} value={m.id}>
-                                  {m.plan_name ?? "Membership"} ({m.status}
+                                  {m.plan_name ?? "Membership"} ({membershipStatusLabel(m)}
                                   {m.sessions_remaining != null
                                     ? `, ${m.sessions_remaining} left`
                                     : ""}

--- a/src/routes/_authenticated/manager.users_.$userId.tsx
+++ b/src/routes/_authenticated/manager.users_.$userId.tsx
@@ -681,8 +681,9 @@ function ManagerUserPage() {
           <div className="flex flex-wrap items-center gap-2">
             <Pill
               label={lifecycleLabel(summary.lifecycle_status, {
-                status: summary.latest_membership_status,
+                status: summary.latest_membership_status ?? "",
                 kind: summary.latest_plan_kind,
+                sessions_remaining: summary.latest_sessions_remaining,
               })}
               preserveCase
               className={lifecycleClass(summary.lifecycle_status)}

--- a/src/routes/_authenticated/membership.test.tsx
+++ b/src/routes/_authenticated/membership.test.tsx
@@ -281,3 +281,65 @@ describe("/membership: how to pay", () => {
     expect(within(card).queryByRole("button", { name: /copy BSB/i })).not.toBeInTheDocument();
   });
 });
+
+// A free trial is two classes, not a date. It cannot expire, and the person
+// holding one has no membership to renew, so neither "expired" nor "lapsed"
+// describes what happened to them.
+describe("/membership: what a finished trial is called", () => {
+  const usedUpTrial = {
+    ...pendingPlan,
+    id: "m9",
+    plan_code: "trial_2_session",
+    plan_name: "Free trial",
+    kind: "trial",
+    status: "expired",
+    price_cents: 0,
+    paid_at: "2026-07-01T00:00:00Z",
+    ends_at: null,
+    sessions_remaining: 0,
+  };
+  const endedSemester = {
+    ...pendingPlan,
+    id: "m10",
+    status: "expired",
+    paid_at: "2026-02-01T00:00:00Z",
+    ends_at: "2026-06-30T00:00:00Z",
+    created_at: "2026-02-01T00:00:00Z",
+  };
+
+  function lapsedWith(memberships: unknown[]) {
+    getMyMemberships.mockResolvedValue({
+      lifecycle: "lapsed",
+      memberships,
+      uts_student_number: null,
+      sessions_attended: 2,
+    });
+  }
+
+  it("says the trial is used up, not expired, and offers a plan instead of a renewal", async () => {
+    lapsedWith([usedUpTrial]);
+    await renderLoaded();
+    expect(screen.getByText("Used up")).toBeVisible();
+    expect(screen.queryByText("Expired")).not.toBeInTheDocument();
+    expect(screen.getByText("Trial used up")).toBeVisible();
+    expect(screen.getByText(/used your free trial classes/i)).toBeVisible();
+    expect(screen.queryByText(/membership has lapsed/i)).not.toBeInTheDocument();
+  });
+
+  it("counts the classes left rather than dating a plan that has no end date", async () => {
+    lapsedWith([usedUpTrial]);
+    await renderLoaded();
+    expect(screen.getByText("0 sessions left")).toBeVisible();
+  });
+
+  it("still says expired, and lapsed, for a training period that ran out of days", async () => {
+    // The stored status is the same word for both. Only the plan's kind tells
+    // them apart, so this is the case that would break if the label ignored it.
+    lapsedWith([endedSemester]);
+    await renderLoaded();
+    expect(screen.getByText("Expired")).toBeVisible();
+    expect(screen.queryByText("Used up")).not.toBeInTheDocument();
+    expect(screen.getByText("Lapsed")).toBeVisible();
+    expect(screen.getByText(/membership has lapsed/i)).toBeVisible();
+  });
+});

--- a/src/routes/_authenticated/membership.test.tsx
+++ b/src/routes/_authenticated/membership.test.tsx
@@ -332,6 +332,17 @@ describe("/membership: what a finished trial is called", () => {
     expect(screen.getByText("0 sessions left")).toBeVisible();
   });
 
+  it("does not tell somebody whose trial was cancelled that they used it", async () => {
+    // `lapsed` is derived from expired OR cancelled. Both this person's free
+    // classes may be sitting untouched, so "you've used your free trial
+    // classes" would be a plain falsehood about their own account.
+    lapsedWith([{ ...usedUpTrial, status: "cancelled", sessions_remaining: 2 }]);
+    await renderLoaded();
+    expect(screen.getByText("Cancelled")).toBeVisible();
+    expect(screen.queryByText("Trial used up")).not.toBeInTheDocument();
+    expect(screen.queryByText(/used your free trial classes/i)).not.toBeInTheDocument();
+  });
+
   it("still says expired, and lapsed, for a training period that ran out of days", async () => {
     // The stored status is the same word for both. Only the plan's kind tells
     // them apart, so this is the case that would break if the label ignored it.

--- a/src/routes/_authenticated/membership.test.tsx
+++ b/src/routes/_authenticated/membership.test.tsx
@@ -343,6 +343,19 @@ describe("/membership: what a finished trial is called", () => {
     expect(screen.queryByText(/used your free trial classes/i)).not.toBeInTheDocument();
   });
 
+  it("does not claim the classes are gone when one was given back", async () => {
+    // Reachable from the check-in screen: undoing a check-in refunds the credit
+    // but reopens the membership only when THAT check-in is the one that closed
+    // it, so undoing an earlier visit leaves `expired` with a class on the row.
+    // The row prints "1 session left" right beside the status.
+    lapsedWith([{ ...usedUpTrial, sessions_remaining: 1 }]);
+    await renderLoaded();
+    expect(screen.getByText("1 session left")).toBeVisible();
+    expect(screen.queryByText("Used up")).not.toBeInTheDocument();
+    expect(screen.queryByText("Trial used up")).not.toBeInTheDocument();
+    expect(screen.queryByText(/used your free trial classes/i)).not.toBeInTheDocument();
+  });
+
   it("still says expired, and lapsed, for a training period that ran out of days", async () => {
     // The stored status is the same word for both. Only the plan's kind tells
     // them apart, so this is the case that would break if the label ignored it.

--- a/src/routes/_authenticated/membership.tsx
+++ b/src/routes/_authenticated/membership.tsx
@@ -11,7 +11,7 @@ import { Pill } from "@/components/site/StatusPill";
 import { CopyButton } from "@/components/site/CopyButton";
 import { ClubAccountDetails } from "@/components/site/ClubAccountDetails";
 import { lifecycleClass } from "@/lib/status-colours";
-import { lifecycleLabel, membershipStatusLabel, TRIAL_USED_UP_LABEL } from "@/lib/status-labels";
+import { isTrialUsedUp, membershipStatusLabel, TRIAL_USED_UP_LABEL } from "@/lib/status-labels";
 import { cn } from "@/lib/utils";
 import {
   computeMembershipPrice,
@@ -78,16 +78,16 @@ const LIFECYCLE_COPY: Record<LifecycleStatus, { label: string; blurb: string }> 
  * `lapsed` is derived for two different people, and the copy above only fits one
  * of them. Somebody who came to their free classes and used them all has not
  * lapsed and has no membership to renew: nothing of theirs expired, they
- * finished the trial. Which of the two this is comes from `lifecycleLabel`
- * rather than being decided again here, so the member's card and the manager's
- * pill cannot end up disagreeing about the same person. Only the blurb is this
- * page's own. `memberships` arrives newest first.
+ * finished the trial. Which of the two this is comes from `isTrialUsedUp` rather
+ * than being decided again here, so the member's card and the manager's pill
+ * cannot end up disagreeing about the same person. Only the blurb is this page's
+ * own. `memberships` arrives newest first.
  */
 function lifecycleCopy(
   lifecycle: LifecycleStatus,
-  memberships: { status: string; kind: string | null }[],
+  memberships: { status: string; kind: string | null; sessions_remaining: number | null }[],
 ) {
-  if (lifecycleLabel(lifecycle, memberships[0]) === TRIAL_USED_UP_LABEL)
+  if (isTrialUsedUp(lifecycle, memberships[0]))
     return {
       label: TRIAL_USED_UP_LABEL,
       blurb: "You've used your free trial classes. Pick a plan below to keep training.",
@@ -420,7 +420,10 @@ function MembershipPage() {
                       <th className="px-3 py-2">Status</th>
                       <th className="px-3 py-2">Price</th>
                       <th className="px-3 py-2">Reference</th>
-                      <th className="px-3 py-2">Valid until</th>
+                      {/* Not "Valid until": a plan sold as a number of classes
+                          has no date to be valid until, and this cell counts
+                          for it instead. */}
+                      <th className="px-3 py-2">Ends</th>
                     </tr>
                   </thead>
                   <tbody>

--- a/src/routes/_authenticated/membership.tsx
+++ b/src/routes/_authenticated/membership.tsx
@@ -11,7 +11,7 @@ import { Pill } from "@/components/site/StatusPill";
 import { CopyButton } from "@/components/site/CopyButton";
 import { ClubAccountDetails } from "@/components/site/ClubAccountDetails";
 import { lifecycleClass } from "@/lib/status-colours";
-import { membershipStatusLabel } from "@/lib/status-labels";
+import { lifecycleLabel, membershipStatusLabel, TRIAL_USED_UP_LABEL } from "@/lib/status-labels";
 import { cn } from "@/lib/utils";
 import {
   computeMembershipPrice,
@@ -72,25 +72,26 @@ const LIFECYCLE_COPY: Record<LifecycleStatus, { label: string; blurb: string }> 
   },
 };
 
-// `lapsed` is derived for two different people, and the copy above only fits
-// one of them. Somebody who came to their free classes and used them all has
-// not lapsed and has no membership to renew: nothing of theirs expired, they
-// finished the trial. They are also the person most worth speaking to plainly,
-// so they get their own words.
-const TRIAL_USED_UP = {
-  label: "Trial used up",
-  blurb: "You've used your free trial classes. Pick a plan below to keep training.",
-};
-
 /**
  * The status card's words for this member.
  *
- * The trial is assigned when a waiver is approved, so it is always a person's
- * oldest membership: one that is still their NEWEST means they never bought
- * anything after it. `memberships` arrives newest first.
+ * `lapsed` is derived for two different people, and the copy above only fits one
+ * of them. Somebody who came to their free classes and used them all has not
+ * lapsed and has no membership to renew: nothing of theirs expired, they
+ * finished the trial. Which of the two this is comes from `lifecycleLabel`
+ * rather than being decided again here, so the member's card and the manager's
+ * pill cannot end up disagreeing about the same person. Only the blurb is this
+ * page's own. `memberships` arrives newest first.
  */
-function lifecycleCopy(lifecycle: LifecycleStatus, memberships: { kind: string | null }[]) {
-  if (lifecycle === "lapsed" && memberships[0]?.kind === "trial") return TRIAL_USED_UP;
+function lifecycleCopy(
+  lifecycle: LifecycleStatus,
+  memberships: { status: string; kind: string | null }[],
+) {
+  if (lifecycleLabel(lifecycle, memberships[0]) === TRIAL_USED_UP_LABEL)
+    return {
+      label: TRIAL_USED_UP_LABEL,
+      blurb: "You've used your free trial classes. Pick a plan below to keep training.",
+    };
   return LIFECYCLE_COPY[lifecycle];
 }
 

--- a/src/routes/_authenticated/membership.tsx
+++ b/src/routes/_authenticated/membership.tsx
@@ -11,6 +11,7 @@ import { Pill } from "@/components/site/StatusPill";
 import { CopyButton } from "@/components/site/CopyButton";
 import { ClubAccountDetails } from "@/components/site/ClubAccountDetails";
 import { lifecycleClass } from "@/lib/status-colours";
+import { membershipStatusLabel } from "@/lib/status-labels";
 import { cn } from "@/lib/utils";
 import {
   computeMembershipPrice,
@@ -70,6 +71,28 @@ const LIFECYCLE_COPY: Record<LifecycleStatus, { label: string; blurb: string }> 
     blurb: "Your membership has lapsed. Renew below to keep training.",
   },
 };
+
+// `lapsed` is derived for two different people, and the copy above only fits
+// one of them. Somebody who came to their free classes and used them all has
+// not lapsed and has no membership to renew: nothing of theirs expired, they
+// finished the trial. They are also the person most worth speaking to plainly,
+// so they get their own words.
+const TRIAL_USED_UP = {
+  label: "Trial used up",
+  blurb: "You've used your free trial classes. Pick a plan below to keep training.",
+};
+
+/**
+ * The status card's words for this member.
+ *
+ * The trial is assigned when a waiver is approved, so it is always a person's
+ * oldest membership: one that is still their NEWEST means they never bought
+ * anything after it. `memberships` arrives newest first.
+ */
+function lifecycleCopy(lifecycle: LifecycleStatus, memberships: { kind: string | null }[]) {
+  if (lifecycle === "lapsed" && memberships[0]?.kind === "trial") return TRIAL_USED_UP;
+  return LIFECYCLE_COPY[lifecycle];
+}
 
 /**
  * A one-line nudge to read the code of conduct, shown only to someone who has
@@ -336,7 +359,7 @@ function MembershipPage() {
   }
 
   const lifecycle = mine?.lifecycle ?? "lead";
-  const status = LIFECYCLE_COPY[lifecycle];
+  const status = lifecycleCopy(lifecycle, mine?.memberships ?? []);
   // What the member still owes, as transfers rather than as rows: a bundled
   // plan + insurance is two memberships behind one reference and one payment.
   const unpaid = unpaidInvoices(mine?.memberships ?? []);
@@ -403,7 +426,7 @@ function MembershipPage() {
                     {mine.memberships.map((m) => (
                       <tr key={m.id} className="border-t">
                         <td className="px-3 py-2 font-medium">{m.plan_name ?? "—"}</td>
-                        <td className="px-3 py-2 capitalize">{m.status}</td>
+                        <td className="px-3 py-2">{membershipStatusLabel(m)}</td>
                         <td className="px-3 py-2">{formatCents(m.price_cents)}</td>
                         <td className="px-3 py-2">
                           {isUnpaid(m) ? (
@@ -413,10 +436,12 @@ function MembershipPage() {
                           )}
                         </td>
                         <td className="px-3 py-2">
+                          {/* A plan sold as a number of classes has no date to
+                              run out on, so this column counts instead. */}
                           {m.ends_at
                             ? new Date(m.ends_at).toLocaleDateString("en-AU")
                             : m.sessions_remaining != null
-                              ? `${m.sessions_remaining} sessions`
+                              ? `${m.sessions_remaining} session${m.sessions_remaining === 1 ? "" : "s"} left`
                               : "—"}
                         </td>
                       </tr>

--- a/src/routes/api/manager/agent.ts
+++ b/src/routes/api/manager/agent.ts
@@ -342,6 +342,7 @@ async function handleListUsers(params: unknown) {
       price_cents: m.price_cents,
       is_student: m.is_student,
       uts_student_number: m.uts_student_number,
+      sessions_remaining: m.sessions_remaining,
       created_at: m.created_at,
     })),
     plans: (plans ?? []).map((p) => ({ id: p.id, name: p.name, kind: p.kind })),


### PR DESCRIPTION
## What people see

A free trial is **two classes**, not a date. Nothing about it can go out of date. But the club was telling people it had:

| Where | Before | After |
| --- | --- | --- |
| A member on `/membership` | "Expired" | **"Used up"** |
| Their status card on `/membership` | "Lapsed" / "Your membership has lapsed. Renew below to keep training." | **"Trial used up"** / "You've used your free trial classes. Pick a plan below to keep training." |
| `/manager/users` funnel column | "Lapsed" | **"Trial used up"** |
| `/manager/users` latest-membership pill | "Expired" | **"Used up"** |
| A person's manager page (pill + membership rows + the check-in attach/move pickers) | "Expired" | **"Used up"** |
| `/manager/memberships` | "Expired" | **"Used up"** |

A **training period** or **yearly insurance** genuinely does expire, and still says so. Only the plans sold as a number of classes (free trial, casual class or pack) change wording.

Two smaller things on `/membership` that were the same mistake:

- Someone who used up their trial was being offered a renewal for a membership they never had. Now they are pointed at a plan.
- The "Valid until" column showed a bare `0 sessions` for a plan that has no end date. It now reads `0 sessions left` (`1 session left` in the singular).

Nothing changes for a member who is training, and no email or notification is affected. A manager scanning the users list can now tell "they came twice and stopped" apart from "their semester finished" at a glance, which are two very different follow-ups.

## What is deliberately not in this change

**Nothing stored changes.** `expired` and `lapsed` are still what the database, the `/manager/users` filter and the manager agent API speak, so no migration, no API contract change, and every existing filter and integration keeps working. Only the words a human reads are different.

**The funnel is still missing a phase**, and this change works around it rather than fixing it. `lapsed` is derived for two different people, and someone who finished their free trial without buying anything really is a distinct phase (the club's warmest lead). Adding one is a product decision that changes the agent API's `status` filter values, so it is worth deciding on separately. Here the phase is only *labelled* correctly, using the fact that the free trial is assigned at waiver approval and is therefore always a person's oldest membership: a trial that is still their newest one means nothing followed it.

## How it is built

- `endsWithCredits` (`src/lib/validation.ts`) answers "is this plan sold as a number of classes?" by reading `creditsRequired` off `PLAN_TYPES`, rather than re-listing the kinds and giving them somewhere to disagree. An unknown or missing kind answers `false`, so a row whose plan could not be resolved keeps the generic wording instead of claiming a class count.
- `src/lib/status-labels.ts` is a new module: the naming counterpart to `src/lib/status-colours.ts`, with the same shape and the same maps keyed by the status unions, so adding a status fails the typecheck until it has been given a word as well as a colour. Labels come out sentence-cased and callers pass `preserveCase` to `<Pill>`, because CSS `capitalize` would title-case "Used Up".
- The only new data is `ClubUser.latest_plan_kind` and `kind` on the person page's membership rows: the two screens that name a status without already holding the plan behind it.
- Docs: a new "What an ended membership is called" section in `docs/memberships.md`, plus a pointer from the `memberships` table entry in `docs/database.md`.

## Tests

New `src/lib/status-labels.test.ts` (both endings, unresolved plans, unknown statuses, and that a trial's kind does not leak into any phase but the ended one), new `endsWithCredits` cases in `validation.test.ts`, a `latest_plan_kind` case in `club-users.test.ts`, and three cases in `membership.test.tsx` rendering the real page: a used-up trial, its session count, and the training-period control that would break if the label ignored the plan kind.

`bun run lint`, `bun run test` (1876 passing) and `bun run build` are green locally.

⚠️ **`bun run typecheck` is already failing on `main`** at bb06b24 ("Upgrade @tanstack/react-start to 1.168.42"), with 18 errors in `src/routes/api/*`, `src/routes/lovable/email/auth/*`, `robots[.]txt.ts` and `sitemap[.]xml.ts` (the `server:` route option no longer exists in that version). Those reproduce with this branch's changes stashed and are unrelated to this diff, which typechecks clean. Worth its own fix.