### PR TITLE
Let a manager's agent edit and publish the waiver through the API

### DIFF
--- a/.claude/skills/uts-manager-agent/SKILL.md
+++ b/.claude/skills/uts-manager-agent/SKILL.md
@@ -457,8 +457,9 @@ too, and it is the thing to say out loud before you call it.
 
 ### `list_waiver_templates` — every version, and which is live
 
-Bodies are not included; `body_chars` and the acknowledgement count are, so you
-can tell versions apart without pulling the text of each.
+Bodies are not included; `body_chars` and `acknowledgement_count` are, so you
+can tell versions apart without pulling the text of each. (`get_waiver_template`
+is where `acknowledgements` holds the real list.)
 
 ```bash
 scripts/agent.sh list_waiver_templates '{}'
@@ -513,6 +514,13 @@ scripts/agent.sh save_waiver_template '{"title":"Training Waiver","body_md":"# T
 > - **Show the manager the exact wording before you save**, and say that it goes
 >   live immediately for everyone who signs after it. People who already signed
 >   are unaffected.
+> - **`503 waiver_template_not_published` is not a refusal.** The change did not
+>   reach the live waiver, usually because another manager was promoting at the
+>   same moment, and the club may have no live waiver until somebody lands one.
+>   Obey the `Retry-After` header. If `error.details.version` is there, that
+>   version WAS written and is simply not live: finish with
+>   `publish_waiver_template` on it rather than saving again, which would file a
+>   second numbered draft of the same wording.
 
 ### `publish_waiver_template` — roll back to an earlier version
 

--- a/.claude/skills/uts-manager-agent/SKILL.md
+++ b/.claude/skills/uts-manager-agent/SKILL.md
@@ -3,13 +3,16 @@ name: uts-manager-agent
 description: >-
   Perform UTS Jitsu manager actions (list members and their status, raise a
   membership for someone, cancel or delete an invoice, edit an invoice's
-  details, file a scanned paper waiver, manage the club's membership dates,
-  publish and reorder the club's knowledge base and read members' comments on
-  it) against the live site via its manager agent HTTP API. Use when a club
+  details, file a scanned paper waiver, edit and publish the waiver template
+  people sign, manage the club's membership dates, publish and reorder the
+  club's knowledge base and read members' comments on it) against the live site
+  via its manager agent HTTP API. Use when a club
   manager asks an agent to look up members/invoices, put a member on a plan or
   swap them onto a different one, cancel or delete a membership, correct invoice
   details (price, payment reference, notes, status), migrate/bulk-file waivers
-  the club holds on paper, add or edit a membership window's start/end dates, or edit a
+  the club holds on paper, reword the waiver or its tick-boxes and publish a new
+  version of it (or roll back to an earlier one), add or edit a membership
+  window's start/end dates, or edit a
   knowledge base article at /kb/<slug>, change the order members read them in,
   and review the feedback left on them. Requires the UTS_MANAGER_API_URL and
   UTS_MANAGER_API_KEY environment variables.
@@ -442,6 +445,85 @@ scripts/agent.sh file_waiver '{
 >   reach for `confirm_duplicate` to get past it: that disables the check rather
 >   than fixing it, and would let a genuine duplicate through.
 
+### The waiver everyone signs
+
+The document at `/waiver` is **versioned**, and each signed waiver names the
+version it was signed against — that link is the club's legal record, which is
+why old versions are kept forever and why editing never touches them. Exactly
+one version is **live** at a time.
+
+There is **no draft state**: saving publishes. That is true on the manager screen
+too, and it is the thing to say out loud before you call it.
+
+### `list_waiver_templates` — every version, and which is live
+
+Bodies are not included; `body_chars` and the acknowledgement count are, so you
+can tell versions apart without pulling the text of each.
+
+```bash
+scripts/agent.sh list_waiver_templates '{}'
+```
+
+### `get_waiver_template` — read one version's text
+
+The live version unless you pass `version`.
+
+```bash
+scripts/agent.sh get_waiver_template '{}'
+```
+
+The body is markdown carrying `{{placeholder}}` tokens (`full_name`,
+`date_of_birth`, `signature_name`, `club_name`, the health questions, ...) that
+are filled in per signer. Leave every token you are not deliberately changing
+exactly as it is: a dropped `{{signature_name}}` is a waiver with no signature
+line on it.
+
+### `save_waiver_template` — publish new wording
+
+Writes a **new version** and makes it the one everyone signs from that moment.
+Anything you omit is carried over from the version the edit starts from (the live
+one, unless `base_version` names another), so an acknowledgement can be reworded
+without resending the legal text:
+
+```bash
+scripts/agent.sh save_waiver_template '{
+  "acknowledgements": [
+    {"id":"media","label":"I consent to photos and video of me training being used by the club.","required":false},
+    {"id":"risk","label":"I understand jiu-jitsu carries a risk of injury.","required":true}
+  ]
+}'
+```
+
+Rewriting the text itself needs `title` and `body_md` together — a version is
+written as a whole:
+
+```bash
+scripts/agent.sh save_waiver_template '{"title":"Training Waiver","body_md":"# Training Waiver\n\n..."}'
+```
+
+> [!IMPORTANT]
+>
+> - **Read `get_waiver_template` first and edit what it gives you back.** The
+>   body is replaced wholesale, so a version built without reading first drops
+>   every clause it did not include — from a legal document.
+> - **`acknowledgements` replaces the whole list**, so send it complete. It must
+>   still carry the `media` item with real wording: that tick is what records who
+>   agreed to photos, so a version without it silently ends the club's consent
+>   record and is refused (`422 save_waiver_template_failed`).
+> - **Show the manager the exact wording before you save**, and say that it goes
+>   live immediately for everyone who signs after it. People who already signed
+>   are unaffected.
+
+### `publish_waiver_template` — roll back to an earlier version
+
+Makes a stored version live again. Nothing is rewritten and no new version is
+created; on the version that is already live it does nothing and reports
+`published: false`.
+
+```bash
+scripts/agent.sh publish_waiver_template '{"version": 4}'
+```
+
 ### The knowledge base
 
 Versioned markdown pages served at `/kb/<slug>` that members read and comment on,
@@ -583,6 +665,11 @@ scripts/agent.sh list_kb_comments '{"slug":"our-history"}'
   before writing it. An article with no `section` lands in "Everything else" at
   the bottom of the sidebar, which is visible but almost certainly not what they
   meant.
+- Never save a waiver version the manager has not read. Fetch
+  `get_waiver_template`, show them the exact wording you propose, and say plainly
+  that saving publishes it to everyone who signs from that moment. It is the
+  club's legal document, and rolling back (`publish_waiver_template`) restores
+  old wording but cannot unsign anybody.
 - Before a `file_waiver` batch, confirm scope with the manager: how many
   records, whether any should be flagged for review rather than filed
   automatically, and that leaving everything pending (not approved) is what
@@ -603,7 +690,7 @@ scripts/agent.sh list_kb_comments '{"slug":"our-history"}'
   correct to retry unchanged, and it carries a `Retry-After` header — obey it
   rather than retrying immediately. Nothing was filed. Retryable failures are 5xx;
   a 4xx means the request itself needs to change before it will ever succeed.
-- The manifest's `version` tells generations apart (currently `"10"`), and its
+- The manifest's `version` tells generations apart (currently `"11"`), and its
   `changes` array says what each version actually moved, newest first, with
   `breaking: true` on any version that turns calls which used to succeed into
   errors. **There is no way to pin an older version** — the contract is

--- a/docs/manager-agent-api.md
+++ b/docs/manager-agent-api.md
@@ -118,6 +118,37 @@ An "invoice" is a `memberships` row — its price/reference/status _are_ the inv
   check lives in `filePaperWaiver`, so the manager's own upload form gets the
   same speed bump.
 
+- `list_waiver_templates` / `get_waiver_template` / `save_waiver_template` /
+  `publish_waiver_template` — the waiver everyone signs, the agent's equivalent
+  of `/manager/waiver-template`. They go through `listWaiverTemplateRows`,
+  `loadWaiverTemplateVersion`, `saveWaiverTemplateVersion` and
+  `promoteWaiverTemplate` in `src/lib/waiver.functions.ts` — the same functions
+  the editor screen's server functions call, so an agent-published version and a
+  manager's own are the same row written the same way. Three things are worth
+  knowing before touching them:
+  - **They key on the version number, not the row id.** The screen holds the row
+    it just listed; an agent reads a list, decides, and calls back later. The
+    version is unique on the table and is the number a manager reads off the
+    screen and off a signed PDF.
+  - **Saving publishes.** There is no draft state (the screen has none either),
+    so `save_waiver_template` writes a new version and makes it live in one call.
+    Waivers already signed keep the version they were signed against, which is
+    what makes this safe to get wrong and then roll back with
+    `publish_waiver_template`.
+  - **An omitted field is carried over** from the version the edit starts from
+    (the live one, unless `base_version` names another), so rewording one
+    acknowledgement does not mean resending 30000 characters of legal text and
+    risking a body retyped from memory. `title` and `body_md` still travel
+    together, and a call naming neither text nor acknowledgements is refused
+    rather than republishing an identical copy under a new number. The result's
+    `based_on` names the version an omitted field came from.
+
+  Every version must carry the `media` acknowledgement with real wording
+  (`hasMediaAcknowledgement`), or the club stops recording who agreed to photos;
+  both the save and the publish refuse without it. That check now runs **before**
+  the insert rather than only inside `promoteWaiverTemplate`, so a refused save
+  no longer leaves an unwanted draft version behind in the editor's list.
+
 ### `file_waiver`: the parts that have bitten us
 
 - **The two surfaces present that one check differently on purpose, and
@@ -190,7 +221,7 @@ wrapper never needs hand-syncing beyond the human-readable docs above.
 changes**, not only when an action is added or removed. A guard that starts
 refusing a call that used to succeed, or a new field in a response, is exactly
 what a client needs the version to tell it about. The version is pinned by a
-test so the bump is a deliberate edit, and the current value is `"10"`.
+test so the bump is a deliberate edit, and the current value is `"11"`.
 
 **Responses carry `version` too**, not just the manifest, so a client that
 cached the manifest at the start of a long run can notice a bump per call

--- a/docs/manager-agent-api.md
+++ b/docs/manager-agent-api.md
@@ -143,6 +143,17 @@ An "invoice" is a `memberships` row — its price/reference/status _are_ the inv
     rather than republishing an identical copy under a new number. The result's
     `based_on` names the version an omitted field came from.
 
+  Failures are classified rather than flattened, because SKILL.md tells agents a
+  4xx means the request has to change: a change that did not reach the live
+  waiver (a concurrent promotion, a failed write) is `503
+waiver_template_not_published` with a `Retry-After`, and it carries
+  `error.details.version` when a version WAS written and is merely unpublished —
+  the case where saving again would file a second numbered draft and publishing
+  that version finishes the job. `WaiverTemplateError` in
+  `src/lib/waiver-template-editor.ts` carries the reason (`not_found` |
+  `invalid` | `not_published`) that decides this; the editor screen shows the
+  same message either way.
+
   Every version must carry the `media` acknowledgement with real wording
   (`hasMediaAcknowledgement`), or the club stops recording who agreed to photos;
   both the save and the publish refuse without it. That check now runs **before**

--- a/docs/waivers.md
+++ b/docs/waivers.md
@@ -463,6 +463,16 @@ There are two ways a version becomes live:
   publishes the **stored** text, so unsaved edits in the editor are not part of
   what goes live and the screen says so before it proceeds.
 
+**A manager's agent can do all of this too.** `list_waiver_templates`,
+`get_waiver_template`, `save_waiver_template` and `publish_waiver_template` on
+the manager agent API (`docs/manager-agent-api.md`) are the same two paths
+through the same functions, keyed on the version number instead of the row id.
+Saving publishes there as well, because it does here — the API cannot offer a
+draft state the screen does not have. The one thing an agent gets that the
+screen does not need is the carry-over: an omitted field keeps what the version
+it started from says, so an acknowledgement can be reworded without a caller
+resending the whole legal text from memory.
+
 Promoting never touches waivers already signed. Each one records the
 `template_version` it was signed against and its PDF carries that version's full
 text, so the evidence is fixed at signing time and does not depend on this table.

--- a/src/lib/kb-admin.ts
+++ b/src/lib/kb-admin.ts
@@ -16,6 +16,7 @@ import type {
   KbSectionRow,
 } from "@/lib/kb-types";
 import type { SaveKbArticleInput, SaveKbSectionInput } from "@/lib/validation";
+import { actorUserId } from "@/lib/manager-agent";
 
 /** An article together with the version being read. */
 export type LoadedArticle = {
@@ -233,7 +234,7 @@ export async function saveKbArticle(
   input: SaveKbArticleInput,
   actingAs: string | null,
 ): Promise<{ slug: string; version: number | null; article_id: string; created: boolean }> {
-  const createdBy = actingAs && isUuid(actingAs) ? actingAs : null;
+  const createdBy = actorUserId(actingAs);
   const sectionId = await resolveSectionId(db, input.section);
 
   const { data: existing, error: findErr } = await db
@@ -550,15 +551,4 @@ export function projectAnnotation(row: KbAnnotationRow, authorName: string | nul
     resolved_at: row.resolved_at,
     created_at: row.created_at,
   };
-}
-
-/**
- * Whether a string is a UUID, used to decide if an actor can be recorded as
- * `created_by`. The manager agent's break-glass env key authenticates as
- * `AGENT_ENV_KEY_UPLOADER`, which is deliberately not a UUID and has no auth
- * user behind it — writing it into a `references auth.users` column would fail
- * the insert outright. `filePaperWaiver` makes the same check for the same reason.
- */
-function isUuid(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
 }

--- a/src/lib/manager-agent.test.ts
+++ b/src/lib/manager-agent.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   AGENT_ENV_KEY_UPLOADER,
   AGENT_MANIFEST,
+  actorUserId,
   AgentError,
   bearerToken,
   buildInvoicePatch,
@@ -671,5 +672,24 @@ describe("projectAgentWaiverTemplate", () => {
       title: "Training Waiver",
       created_at: "2026-08-01T00:00:00Z",
     });
+  });
+});
+
+describe("actorUserId", () => {
+  // Every column this feeds `references auth.users`, so the sentinel the
+  // break-glass env key authenticates as must never reach one: the insert would
+  // fail outright, taking a waiver filing or a published article with it.
+  it("refuses the break-glass sentinel, which is no auth user", () => {
+    expect(actorUserId(AGENT_ENV_KEY_UPLOADER)).toBeNull();
+  });
+
+  it("records a real manager", () => {
+    const id = "63ab09b5-20e4-451a-ad8e-08caa0c299a2";
+    expect(actorUserId(id)).toBe(id);
+  });
+
+  it("treats no actor at all as no author", () => {
+    expect(actorUserId(null)).toBeNull();
+    expect(actorUserId("")).toBeNull();
   });
 });

--- a/src/lib/manager-agent.test.ts
+++ b/src/lib/manager-agent.test.ts
@@ -645,7 +645,10 @@ describe("projectAgentWaiverTemplate", () => {
     const row = projectAgentWaiverTemplate(version, 4);
     expect(row).not.toHaveProperty("body_md");
     expect(row.body_chars).toBe(version.body_md.length);
-    expect(row.acknowledgements).toBe(2);
+    expect(row.acknowledgement_count).toBe(2);
+    // Not `acknowledgements`: that name holds the real list on
+    // get_waiver_template, and a caller iterating a 2 is the bug this prevents.
+    expect(row).not.toHaveProperty("acknowledgements");
   });
 
   // Same word the manager reads off the editor screen for the same row: an

--- a/src/lib/manager-agent.test.ts
+++ b/src/lib/manager-agent.test.ts
@@ -10,6 +10,7 @@ import {
   INVOICE_EDITABLE_FIELDS,
   invoiceEditAudit,
   projectAgentKbArticle,
+  projectAgentWaiverTemplate,
   projectInvoice,
   RECONCILED_GUARDED_FIELDS,
   reconciledEditBlockers,
@@ -452,7 +453,7 @@ describe("AGENT_MANIFEST", () => {
   // Round 2 of the dev probes noted that the manifest still said "1" after the
   // behaviour changed, leaving a client no way to tell the generations apart.
   it("advertises a version a client can branch on", () => {
-    expect(AGENT_MANIFEST.version).toBe("10");
+    expect(AGENT_MANIFEST.version).toBe("11");
   });
 
   // The changelog is only worth having if it cannot fall behind the version it
@@ -621,5 +622,51 @@ describe("projectAgentKbArticle", () => {
     expect(
       projectAgentKbArticle({ ...article, section_id: null }, live, null, 1).section,
     ).toBeNull();
+  });
+});
+
+describe("projectAgentWaiverTemplate", () => {
+  const version = {
+    version: 4,
+    title: "Training Waiver",
+    body_md: "# Waiver\n\nSigned by {{full_name}}.",
+    acknowledgements: [
+      { id: "media", label: "I consent to being photographed.", required: false },
+      { id: "risk", label: "I accept the risks.", required: true },
+    ],
+    is_current: true,
+    created_at: "2026-08-01T00:00:00Z",
+  };
+
+  // The list is what a caller reads before deciding what to edit, and a club
+  // with a dozen versions of a 30000-character legal document would otherwise
+  // be sending a third of a megabyte to answer "which one is live".
+  it("leaves the body out but says how long it is", () => {
+    const row = projectAgentWaiverTemplate(version, 4);
+    expect(row).not.toHaveProperty("body_md");
+    expect(row.body_chars).toBe(version.body_md.length);
+    expect(row.acknowledgements).toBe(2);
+  });
+
+  // Same word the manager reads off the editor screen for the same row: an
+  // agent reporting "draft" for what the screen calls "previous" would have a
+  // manager approve a rollback to wording they think was never published.
+  it("labels a version the way the editor screen labels it", () => {
+    expect(projectAgentWaiverTemplate(version, 4).status).toBe("Live");
+    expect(
+      projectAgentWaiverTemplate({ ...version, version: 2, is_current: false }, 4).status,
+    ).toBe("Previous");
+    expect(
+      projectAgentWaiverTemplate({ ...version, version: 7, is_current: false }, 4).status,
+    ).toBe("Draft");
+  });
+
+  it("carries the version number and the live flag a caller branches on", () => {
+    expect(projectAgentWaiverTemplate({ ...version, is_current: false }, 9)).toMatchObject({
+      version: 4,
+      is_current: false,
+      title: "Training Waiver",
+      created_at: "2026-08-01T00:00:00Z",
+    });
   });
 });

--- a/src/lib/manager-agent.ts
+++ b/src/lib/manager-agent.ts
@@ -822,6 +822,27 @@ export const AGENT_MANIFEST: {
 export const AGENT_ENV_KEY_UPLOADER = "manager-agent-env-key";
 
 /**
+ * The actor to record as the author of a row, or null when there isn't one.
+ *
+ * Every write this API makes on somebody's behalf lands in a column that
+ * `references auth.users`, and the break-glass env key authenticates as
+ * `AGENT_ENV_KEY_UPLOADER` — deliberately not a UUID, with no auth user behind
+ * it. Writing that sentinel into such a column fails the insert outright, so
+ * each writer asks this instead: record the manager when the token resolved to
+ * one, null when it did not.
+ *
+ * Lives here, with the sentinel it exists because of, rather than as a private
+ * copy in each writer — this is the third caller, which is the point the repo's
+ * own rule says to stop duplicating.
+ */
+export function actorUserId(actingAs: string | null): string | null {
+  if (!actingAs) return null;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(actingAs)
+    ? actingAs
+    : null;
+}
+
+/**
  * Classify a raw request body's `action` field before dispatch, distinguishing
  * an absent field from a present-but-invalid one — otherwise both report
  * "unknown_action" and a caller who built the body wrong (forgot the field

--- a/src/lib/manager-agent.ts
+++ b/src/lib/manager-agent.ts
@@ -10,6 +10,7 @@
 import { formatCents } from "@/lib/validation";
 import type { EditInvoiceInput } from "@/lib/validation";
 import type { MembershipPlanRow, MembershipRow } from "@/lib/membership-types";
+import { versionLabel } from "@/lib/waiver-template-editor";
 
 /** The columns `list_kb_articles` projects from. */
 export type AgentKbArticle = {
@@ -67,6 +68,52 @@ export function projectAgentKbArticle(
   };
 }
 
+/**
+ * One stored waiver version, as `list_waiver_templates` reports it.
+ *
+ * Deliberately structural rather than importing `WaiverTemplateVersion` from
+ * `waiver.functions.ts`: this module is pure and server-import-free (see the
+ * header), and that one pulls in `createServerFn` and a Supabase client.
+ */
+export type AgentWaiverTemplate = {
+  version: number;
+  title: string;
+  body_md: string;
+  acknowledgements: { id: string; label: string; required: boolean }[];
+  is_current: boolean;
+  created_at: string;
+};
+
+/**
+ * A version as the LIST reports it: no body, and the same Live/Previous/Draft
+ * label the editor screen shows.
+ *
+ * The body is left out because a club with a dozen versions of a 30000-character
+ * legal document would otherwise send a third of a megabyte to answer "which one
+ * is live" — `get_waiver_template` is one call away when the text is wanted.
+ * `body_chars` stays so a caller can tell a real version from a stub without
+ * fetching it.
+ *
+ * `status` reuses `versionLabel`, so an agent and a manager reading the same
+ * version see the same word for it. "Draft" there means "never been live", not
+ * "unpublished work in progress" — saving always publishes, so the only drafts
+ * are versions seeded outside the editor and versions superseded by a rollback.
+ */
+export function projectAgentWaiverTemplate(
+  template: AgentWaiverTemplate,
+  liveVersion: number | null,
+) {
+  return {
+    version: template.version,
+    title: template.title,
+    is_current: template.is_current,
+    status: versionLabel(template, liveVersion),
+    acknowledgements: template.acknowledgements.length,
+    body_chars: template.body_md.length,
+    created_at: template.created_at,
+  };
+}
+
 /** One action's shape, returned verbatim by the GET manifest endpoint. */
 export type AgentActionSpec = {
   name: string;
@@ -90,7 +137,7 @@ export const AGENT_MANIFEST: {
   service: "uts-jitsu-manager-agent",
   // Bumped when the behaviour a client can rely on changes, not just the action
   // list. See `changes` for what each version actually moved.
-  version: "10",
+  version: "11",
   // What changed in each version, newest first.
   //
   // A bare version number tells a client THAT something moved, never what — and
@@ -103,6 +150,17 @@ export const AGENT_MANIFEST: {
   // moves between versions is the behaviour INSIDE an action — a new refusal, a
   // new response field — which is what these notes name.
   changes: [
+    {
+      version: "11",
+      // Purely additive: four new actions, no existing one changed shape.
+      breaking: false,
+      notes: [
+        "New actions list_waiver_templates, get_waiver_template, save_waiver_template and publish_waiver_template: the waiver everyone signs is now editable through this API, the same way /manager/waiver-template edits it. They key on the VERSION NUMBER, not a row id.",
+        "save_waiver_template writes a new version and PUBLISHES it in the same call, because that is what saving means on the manager screen: there is no draft state. Waivers already signed keep the version they were signed against.",
+        "save_waiver_template carries over anything you omit from the version the edit starts from, so acknowledgements can be reworded without resending the body. title and body_md must arrive together, and a call naming neither text nor acknowledgements is refused rather than republishing an identical copy.",
+        "Every version must carry the `media` acknowledgement with real wording: it is what records who agreed to photos, and a save or publish without it is refused with 422 rather than quietly ending the club's consent record.",
+      ],
+    },
     {
       version: "10",
       // Authorising a membership and paying for one used to be the same act.
@@ -443,6 +501,71 @@ export const AGENT_MANIFEST: {
           required: false,
           description:
             "Your own UUID for this filing attempt, minted once per record and RESENT UNCHANGED on every retry of it. This is what makes retrying safe: the same id always resolves to the same waiver, so a call whose reply you never saw can be repeated without filing twice. The duplicate check alone cannot catch two retries racing each other; this can. Send one per record in any bulk import. A new id means a new waiver, and an id already used for a different record is refused (409 submission_id_conflict). NOTE: sending an id means you own finishing that record — a filing that fails with 503 waiver_filing_incomplete leaves a waiver with no document, which only your retry completes.",
+        },
+      ],
+    },
+    {
+      name: "list_waiver_templates",
+      method: "POST",
+      summary:
+        "List every stored version of the waiver members sign, newest first, saying which one is LIVE. Versions are the club's legal record: each signed waiver names the version it was signed against, and old versions are kept forever for that reason. Bodies are not included here — read one with get_waiver_template.",
+      params: [],
+    },
+    {
+      name: "get_waiver_template",
+      method: "POST",
+      summary:
+        "Read one version's full markdown and its acknowledgements. Returns the LIVE version unless you name one. Read this before saving an edit: save_waiver_template writes the body as a whole, so an edit built without reading first silently drops every clause it did not include. The body carries {{placeholder}} tokens (full_name, date_of_birth, signature_name, ...) filled in per signer — leave the ones you are not deliberately changing exactly as they are.",
+      params: [
+        {
+          name: "version",
+          required: false,
+          description: "Read a specific version instead of the live one.",
+        },
+      ],
+    },
+    {
+      name: "save_waiver_template",
+      method: "POST",
+      summary:
+        "Write a NEW version of the waiver and make it the one everyone signs, from that moment. Saving IS publishing here — there is no draft state, exactly as on the manager screen — so this changes the legal document the club puts in front of people: show a manager what you are changing before you call it. Waivers already signed keep the version they were signed against and are unaffected. Anything you omit is carried over from the version the edit starts from (the live one unless base_version names another), so an acknowledgement can be reworded without resending the body; title and body_md must arrive together.",
+      params: [
+        {
+          name: "title",
+          required: false,
+          description:
+            "The document's heading. Required with body_md when writing text; omit both to change only the acknowledgements.",
+        },
+        {
+          name: "body_md",
+          required: false,
+          description:
+            "The whole waiver as markdown, up to 30000 characters. This REPLACES the previous body; {{placeholder}} tokens in it are filled in per signer.",
+        },
+        {
+          name: "acknowledgements",
+          required: false,
+          description:
+            "The tick-boxes the signer accepts, as a list of { id, label, required }. REPLACES the previous list, so send it whole. It must still contain the `media` item with real wording: that one also records who agreed to photos, and a version without it is refused. Omit to keep the list as it is.",
+        },
+        {
+          name: "base_version",
+          required: false,
+          description:
+            "Which stored version this edit starts from, and therefore what an omitted field is carried over from. Defaults to the live one. Name an older version to bring back its wording with your edit on top.",
+        },
+      ],
+    },
+    {
+      name: "publish_waiver_template",
+      method: "POST",
+      summary:
+        "Make an existing stored version the live one, for rolling back to wording the club already agreed. Nothing is rewritten and no new version is created. Waivers already signed keep the version they were signed against, so this changes what the NEXT person signs and nothing else. Calling it on the version that is already live does nothing and reports published: false.",
+      params: [
+        {
+          name: "version",
+          required: true,
+          description: "The version number to make live, as reported by list_waiver_templates.",
         },
       ],
     },

--- a/src/lib/manager-agent.ts
+++ b/src/lib/manager-agent.ts
@@ -108,7 +108,11 @@ export function projectAgentWaiverTemplate(
     title: template.title,
     is_current: template.is_current,
     status: versionLabel(template, liveVersion),
-    acknowledgements: template.acknowledgements.length,
+    // Named for what it is, not `acknowledgements`: `get_waiver_template`
+    // returns that name holding the actual list, and one field meaning a count
+    // on one action and an array on another is how a caller ends up iterating a
+    // number. Same reason `projectAgentKbArticle` calls its count `versions`.
+    acknowledgement_count: template.acknowledgements.length,
     body_chars: template.body_md.length,
     created_at: template.created_at,
   };
@@ -159,6 +163,7 @@ export const AGENT_MANIFEST: {
         "save_waiver_template writes a new version and PUBLISHES it in the same call, because that is what saving means on the manager screen: there is no draft state. Waivers already signed keep the version they were signed against.",
         "save_waiver_template carries over anything you omit from the version the edit starts from, so acknowledgements can be reworded without resending the body. title and body_md must arrive together, and a call naming neither text nor acknowledgements is refused rather than republishing an identical copy.",
         "Every version must carry the `media` acknowledgement with real wording: it is what records who agreed to photos, and a save or publish without it is refused with 422 rather than quietly ending the club's consent record.",
+        "save_waiver_template and publish_waiver_template answer 503 waiver_template_not_published with a Retry-After when the change did not reach the live waiver (a concurrent promotion, most often). Retry it. When error.details.version is present, that version WAS written and is only unpublished — finish with publish_waiver_template on it rather than saving again, which would file a second draft.",
       ],
     },
     {
@@ -528,7 +533,7 @@ export const AGENT_MANIFEST: {
       name: "save_waiver_template",
       method: "POST",
       summary:
-        "Write a NEW version of the waiver and make it the one everyone signs, from that moment. Saving IS publishing here — there is no draft state, exactly as on the manager screen — so this changes the legal document the club puts in front of people: show a manager what you are changing before you call it. Waivers already signed keep the version they were signed against and are unaffected. Anything you omit is carried over from the version the edit starts from (the live one unless base_version names another), so an acknowledgement can be reworded without resending the body; title and body_md must arrive together.",
+        "Write a NEW version of the waiver and make it the one everyone signs, from that moment. Saving IS publishing here — there is no draft state, exactly as on the manager screen — so this changes the legal document the club puts in front of people: show a manager what you are changing before you call it. Waivers already signed keep the version they were signed against and are unaffected. Anything you omit is carried over from the version the edit starts from (the live one unless base_version names another), so an acknowledgement can be reworded without resending the body; title and body_md must arrive together. A 503 waiver_template_not_published means the version may exist without being live: retry, and if error.details.version names one, publish THAT rather than saving again.",
       params: [
         {
           name: "title",

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  agentGetWaiverTemplateSchema,
+  agentPublishWaiverTemplateSchema,
+  agentSaveWaiverTemplateSchema,
   attachCheckInSchema,
   blockCommenterSchema,
   blogCommentSchema,
@@ -2412,5 +2415,67 @@ describe("knowledge base schemas", () => {
     const id = crypto.randomUUID();
     expect(resolveAnnotationSchema.safeParse({ id, resolved: false }).success).toBe(true);
     expect(resolveAnnotationSchema.safeParse({ id }).success).toBe(false);
+  });
+});
+
+describe("manager agent waiver-template schemas", () => {
+  const MEDIA = { id: "media", label: "I consent to being photographed.", required: false };
+
+  it("keys on the version number, not a row id", () => {
+    expect(agentGetWaiverTemplateSchema.parse({ version: 4 })).toEqual({ version: 4 });
+    expect(agentPublishWaiverTemplateSchema.safeParse({ version: 4 }).success).toBe(true);
+    // An agent reads a list and calls back later, so a UUID it happened to hold
+    // is not an identifier this API knows.
+    expect(agentPublishWaiverTemplateSchema.safeParse({ id: crypto.randomUUID() }).success).toBe(
+      false,
+    );
+  });
+
+  it("reads the live version when none is named", () => {
+    expect(agentGetWaiverTemplateSchema.parse({})).toEqual({});
+  });
+
+  it("lets acknowledgements be changed on their own, body carried over", () => {
+    const parsed = agentSaveWaiverTemplateSchema.parse({ acknowledgements: [MEDIA] });
+    expect(parsed.acknowledgements).toEqual([MEDIA]);
+    expect(parsed.title).toBeUndefined();
+    expect(parsed.body_md).toBeUndefined();
+  });
+
+  // A version is written as a whole: a new body under the previous heading is
+  // nobody's intent, and the same rule holds for save_kb_article.
+  it("refuses text arriving half at a time", () => {
+    expect(agentSaveWaiverTemplateSchema.safeParse({ body_md: "New body" }).success).toBe(false);
+    expect(agentSaveWaiverTemplateSchema.safeParse({ title: "New title" }).success).toBe(false);
+    expect(
+      agentSaveWaiverTemplateSchema.safeParse({ title: "New title", body_md: "New body" }).success,
+    ).toBe(true);
+  });
+
+  // Saving publishes, so an empty call would put a byte-identical copy of the
+  // live wording live under a new number and report a change that was not one.
+  it("refuses a save that would change nothing", () => {
+    const result = agentSaveWaiverTemplateSchema.safeParse({ base_version: 2 });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toContain("publish_waiver_template");
+  });
+
+  // Strict, like paperWaiverUploadSchema: a stripped `base_version` typo would
+  // silently publish an edit made against the wrong wording.
+  it("rejects an unknown param rather than dropping it", () => {
+    expect(
+      agentSaveWaiverTemplateSchema.safeParse({ acknowledgements: [MEDIA], base_verison: 2 })
+        .success,
+    ).toBe(false);
+    expect(agentGetWaiverTemplateSchema.safeParse({ versoin: 2 }).success).toBe(false);
+  });
+
+  it("holds acknowledgements to the same shape the editor screen writes", () => {
+    // No id, so it could never be ticked off against a submission.
+    expect(
+      agentSaveWaiverTemplateSchema.safeParse({
+        acknowledgements: [{ label: "I accept the risks.", required: true }],
+      }).success,
+    ).toBe(false);
   });
 });

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -600,6 +600,77 @@ export const setCurrentTemplateSchema = z.object({
 });
 export type SetCurrentTemplateInput = z.infer<typeof setCurrentTemplateSchema>;
 
+// ---- Manager agent API: the same three template actions, keyed by version ----
+//
+// The editor screen keys on the row id because it is holding the row it just
+// listed. An agent is not: it reads a list, decides, and calls back later, so it
+// keys on the VERSION NUMBER — unique on the table, stable, and the same number
+// a manager reads off the screen and off a signed PDF. That is the only
+// difference between these and the two schemas above; every rule about what a
+// version may contain is shared.
+//
+// All three are `.strict()`, like `paperWaiverUploadSchema` and
+// `editInvoiceSchema`: a misspelled `base_version` that Zod quietly stripped
+// would publish an edit against the wrong wording and report success.
+
+/** Read one stored version, or the live one when no version is named. */
+export const agentGetWaiverTemplateSchema = z
+  .object({ version: z.number().int().positive().optional() })
+  .strict();
+export type AgentGetWaiverTemplateInput = z.infer<typeof agentGetWaiverTemplateSchema>;
+
+/**
+ * Write a new version of the waiver and publish it.
+ *
+ * Every field is optional because an omitted one is CARRIED OVER from the
+ * version the edit starts from (the live one, unless `base_version` names
+ * another). That is what the screen does: a manager opens a version, changes one
+ * clause or reworders one acknowledgement, and saves. Without the carry-over,
+ * changing an acknowledgement would mean resending the whole legal text, and the
+ * likeliest outcome of that is a body retyped from memory.
+ *
+ * Two refusals, both about not writing a version nobody meant:
+ *
+ *   * `title` and `body_md` travel together, as in `saveKbArticleSchema` — a
+ *     version is written as a whole, and a body under last version's heading is
+ *     nobody's intent.
+ *   * A call naming no text and no acknowledgements is refused rather than
+ *     publishing a byte-identical copy of the live version under a new number.
+ */
+export const agentSaveWaiverTemplateSchema = z
+  .object({
+    title: z.string().trim().min(1).max(200).optional(),
+    body_md: z.string().trim().min(1).max(30000).optional(),
+    acknowledgements: templateAcknowledgementsSchema.optional(),
+    /** Which stored version this edit starts from. Defaults to the live one. */
+    base_version: z.number().int().positive().optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (Boolean(value.title) !== Boolean(value.body_md)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [value.title ? "body_md" : "title"],
+        message: "Saving new text needs both title and body_md: a version is written as a whole.",
+      });
+    }
+    if (!value.title && !value.body_md && !value.acknowledgements) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["body_md"],
+        message:
+          "Nothing to save: send title and body_md, acknowledgements, or both. To make an existing version live again, use publish_waiver_template.",
+      });
+    }
+  });
+export type AgentSaveWaiverTemplateInput = z.infer<typeof agentSaveWaiverTemplateSchema>;
+
+/** Make an existing stored version the live one. */
+export const agentPublishWaiverTemplateSchema = z
+  .object({ version: z.number().int().positive() })
+  .strict();
+export type AgentPublishWaiverTemplateInput = z.infer<typeof agentPublishWaiverTemplateSchema>;
+
 // ---- Manager: approve / unapprove a signed waiver ----
 
 /** The member-facing status a manager can set on a signed waiver. */
@@ -1992,6 +2063,10 @@ export const managerAgentActions = [
   "mark_invoice_paid",
   "delete_invoice",
   "file_waiver",
+  "list_waiver_templates",
+  "get_waiver_template",
+  "save_waiver_template",
+  "publish_waiver_template",
   "list_membership_plans",
   "save_membership_plan",
   "list_kb_sections",

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -587,6 +587,7 @@ export const saveTemplateSchema = z.object({
   body_md: z.string().trim().min(1).max(30000),
   acknowledgements: templateAcknowledgementsSchema.default([]),
 });
+export type SaveTemplateInput = z.infer<typeof saveTemplateSchema>;
 
 // ---- Manager: promote an existing template version to the live one ----
 //

--- a/src/lib/waiver-template-editor.ts
+++ b/src/lib/waiver-template-editor.ts
@@ -1,8 +1,40 @@
 // Decisions the waiver-template editor makes, kept out of the component so they
 // are unit-testable — same reason `waiver-approval.ts` exists. No React, no
-// toasts, no server calls.
+// toasts, no server calls. The refusal type lives here too, so the screen and
+// the manager agent API describe a rejected template change the same way.
 import type { AcknowledgementDef } from "./validation";
 import { MEDIA_ACK_ID } from "./waiver-acknowledgements";
+
+/**
+ * Why a template change could not be made.
+ *
+ * One class carrying a reason rather than three classes, because the callers
+ * that care all branch on the same three cases: the editor screen shows the
+ * message either way, and the agent API turns the reason into a status code an
+ * agent can act on (change the request / it is gone / try again).
+ *
+ * `not_published` is the one a message alone cannot carry. It means the club's
+ * live waiver is not what the caller asked for, and when `version` is set it
+ * means that version WAS written and is simply not live — so repeating the save
+ * files a second numbered draft, while publishing that version finishes the job.
+ * Getting that distinction wrong is how an outage (`/waiver` refusing to render
+ * for everyone) gets reported as "your request was invalid" and abandoned.
+ */
+export class WaiverTemplateError extends Error {
+  constructor(
+    message: string,
+    readonly reason: "not_found" | "invalid" | "not_published",
+    /**
+     * The version that exists but is not live. Undefined when nothing was
+     * written at all, which is the difference between "retry this call" and
+     * "publish the version you already have".
+     */
+    readonly version?: number,
+  ) {
+    super(message);
+    this.name = "WaiverTemplateError";
+  }
+}
 
 /** What the editor holds right now, and what a stored version holds. */
 export type TemplateDraft = {

--- a/src/lib/waiver-template.functions.test.ts
+++ b/src/lib/waiver-template.functions.test.ts
@@ -10,7 +10,12 @@
 // The rules below are the ones that keep that gap from becoming an outage
 // nobody notices — never open it needlessly, and never leave it silently.
 import { describe, expect, it, vi } from "vitest";
-import { promoteWaiverTemplate } from "./waiver.functions";
+import {
+  listWaiverTemplateRows,
+  loadWaiverTemplateVersion,
+  promoteWaiverTemplate,
+  saveWaiverTemplateVersion,
+} from "./waiver.functions";
 
 type Result = { data: unknown; error: { message: string } | null };
 const ok = (data: unknown): Result => ({ data, error: null });
@@ -198,5 +203,194 @@ describe("promoteWaiverTemplate", () => {
     await expect(promoteWaiverTemplate(admin, "v2")).rejects.toThrow(/no live waiver/);
     expect(err).toHaveBeenCalled();
     err.mockRestore();
+  });
+});
+
+// ---- The rest of the template surface, extracted so the manager agent API
+// saves and reads through exactly the code the editor screen does. These run
+// against a fake that actually holds rows, because what is worth pinning is the
+// SEQUENCE (refuse before writing, insert as a draft, then promote) and a fake
+// that answered every read the same way would pass with the order reversed.
+
+type StoredRow = {
+  id: string;
+  version: number;
+  title: string;
+  body_md: string;
+  acknowledgements: unknown;
+  is_current: boolean;
+  created_at: string;
+};
+
+const MEDIA_ACK = { id: "media", label: "I consent to being photographed.", required: false };
+
+function row(over: Partial<StoredRow> & { version: number }): StoredRow {
+  return {
+    id: `v${over.version}`,
+    title: `Training Waiver v${over.version}`,
+    body_md: "Body",
+    acknowledgements: [MEDIA_ACK],
+    is_current: false,
+    created_at: "2026-08-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+/** A store-backed fake covering the chains these three functions walk. */
+function fakeStore(rows: StoredRow[]) {
+  const inserts: Record<string, unknown>[] = [];
+  const writes: string[] = [];
+
+  type Opts = { descending?: boolean; limit?: number };
+  function read(filters: [string, unknown][], opts: Opts) {
+    let out = rows.filter((r) =>
+      filters.every(([col, val]) => (r as unknown as Record<string, unknown>)[col] === val),
+    );
+    if (opts.descending) out = [...out].sort((a, b) => b.version - a.version);
+    if (opts.limit !== undefined) out = out.slice(0, opts.limit);
+    return out;
+  }
+
+  function selectBuilder(filters: [string, unknown][], opts: Opts) {
+    const builder: Record<string, unknown> = {
+      eq: (col: string, val: unknown) => selectBuilder([...filters, [col, val]], opts),
+      order: () => selectBuilder(filters, { ...opts, descending: true }),
+      limit: (n: number) => selectBuilder(filters, { ...opts, limit: n }),
+      maybeSingle: () => Promise.resolve({ data: read(filters, opts)[0] ?? null, error: null }),
+      then: (resolve: (r: { data: StoredRow[]; error: null }) => unknown) =>
+        Promise.resolve(resolve({ data: read(filters, opts), error: null })),
+    };
+    return builder;
+  }
+
+  function updateBuilder(patch: Record<string, unknown>, filters: [string, unknown][]) {
+    const apply = () => {
+      writes.push(`update ${JSON.stringify(patch)}`);
+      for (const r of read(filters, {})) Object.assign(r, patch);
+      return Promise.resolve({ data: null, error: null });
+    };
+    const builder: Record<string, unknown> = {
+      eq: (col: string, val: unknown) => updateBuilder(patch, [...filters, [col, val]]),
+      then: (resolve: (r: { data: null; error: null }) => unknown) => apply().then(resolve),
+    };
+    return builder;
+  }
+
+  const admin = {
+    from: () => ({
+      select: () => selectBuilder([], {}),
+      update: (patch: Record<string, unknown>) => updateBuilder(patch, []),
+      insert: (patch: Record<string, unknown>) => {
+        inserts.push(patch);
+        writes.push("insert");
+        const created = row({ ...(patch as unknown as StoredRow), id: "new" });
+        rows.push(created);
+        return {
+          select: () => ({ single: () => Promise.resolve({ data: created, error: null }) }),
+        };
+      },
+    }),
+  };
+  return { admin: admin as never, rows, inserts, writes };
+}
+
+describe("listWaiverTemplateRows", () => {
+  it("parses the acknowledgements JSONB rather than handing it back raw", async () => {
+    // The column is JSONB and the generated types call it `Json`, so anything
+    // reading it without `parseTemplateAcks` is trusting whatever is in there.
+    const { admin } = fakeStore([
+      row({ version: 2, acknowledgements: [MEDIA_ACK, { id: "bad" }, "nonsense"] }),
+    ]);
+    const [first] = await listWaiverTemplateRows(admin);
+    expect(first.acknowledgements).toEqual([MEDIA_ACK]);
+  });
+});
+
+describe("loadWaiverTemplateVersion", () => {
+  // The one that would go unnoticed: "live" is the flagged row, not the newest.
+  // Answering with the newest has a caller edit and republish a version the club
+  // deliberately rolled back from.
+  it("reads the flagged live version, not the highest-numbered one", async () => {
+    const { admin } = fakeStore([row({ version: 2, is_current: true }), row({ version: 5 })]);
+    await expect(loadWaiverTemplateVersion(admin)).resolves.toMatchObject({ version: 2 });
+  });
+
+  it("reads a named version, live or not", async () => {
+    const { admin } = fakeStore([row({ version: 2, is_current: true }), row({ version: 5 })]);
+    await expect(loadWaiverTemplateVersion(admin, 5)).resolves.toMatchObject({
+      version: 5,
+      is_current: false,
+    });
+  });
+
+  it("returns null for a version that does not exist", async () => {
+    const { admin } = fakeStore([row({ version: 2, is_current: true })]);
+    await expect(loadWaiverTemplateVersion(admin, 9)).resolves.toBeNull();
+  });
+});
+
+describe("saveWaiverTemplateVersion", () => {
+  const draft = { title: "Training Waiver", body_md: "Body", acknowledgements: [MEDIA_ACK] };
+
+  it("numbers the next version and publishes it, previous version first", async () => {
+    const store = fakeStore([row({ version: 3, is_current: true })]);
+    await expect(saveWaiverTemplateVersion(store.admin, draft, "user-1")).resolves.toMatchObject({
+      version: 4,
+    });
+    expect(store.inserts[0]).toMatchObject({ version: 4, is_current: false, created_by: "user-1" });
+    // Insert first, THEN the clear/set pair: the other order leaves the club
+    // with no live waiver if the insert fails.
+    expect(store.writes).toEqual([
+      "insert",
+      'update {"is_current":false}',
+      'update {"is_current":true}',
+    ]);
+    expect(store.rows.find((r) => r.version === 4)?.is_current).toBe(true);
+    expect(store.rows.find((r) => r.version === 3)?.is_current).toBe(false);
+  });
+
+  it("records no author when the caller resolves to no auth user", async () => {
+    // `created_by` is a real FK to auth.users, and the agent API's break-glass
+    // key has no user behind it.
+    const store = fakeStore([row({ version: 1, is_current: true })]);
+    await saveWaiverTemplateVersion(store.admin, draft, null);
+    expect(store.inserts[0]).toMatchObject({ created_by: null });
+  });
+
+  it("numbers the first version 1 on an empty table", async () => {
+    const store = fakeStore([]);
+    await expect(saveWaiverTemplateVersion(store.admin, draft, null)).resolves.toMatchObject({
+      version: 1,
+    });
+  });
+
+  // The check the promote guard already made, moved ahead of the insert. It
+  // fired after the row existed before, which left an unwanted draft in the
+  // version list every time somebody saved a template missing the media item.
+  it("refuses a version with no media consent acknowledgement, writing nothing", async () => {
+    const store = fakeStore([row({ version: 3, is_current: true })]);
+    await expect(
+      saveWaiverTemplateVersion(
+        store.admin,
+        {
+          ...draft,
+          acknowledgements: [{ id: "risk", label: "I accept the risks.", required: true }],
+        },
+        null,
+      ),
+    ).rejects.toThrow("no media consent acknowledgement");
+    expect(store.writes).toEqual([]);
+  });
+
+  it("refuses one whose media item has been emptied rather than removed", async () => {
+    const store = fakeStore([row({ version: 3, is_current: true })]);
+    await expect(
+      saveWaiverTemplateVersion(
+        store.admin,
+        { ...draft, acknowledgements: [{ id: "media", label: "   ", required: false }] },
+        null,
+      ),
+    ).rejects.toThrow("no media consent acknowledgement");
+    expect(store.writes).toEqual([]);
   });
 });

--- a/src/lib/waiver-template.functions.test.ts
+++ b/src/lib/waiver-template.functions.test.ts
@@ -10,6 +10,7 @@
 // The rules below are the ones that keep that gap from becoming an outage
 // nobody notices — never open it needlessly, and never leave it silently.
 import { describe, expect, it, vi } from "vitest";
+import { WaiverTemplateError } from "./waiver-template-editor";
 import {
   listWaiverTemplateRows,
   loadWaiverTemplateVersion,
@@ -392,5 +393,110 @@ describe("saveWaiverTemplateVersion", () => {
       ),
     ).rejects.toThrow("no media consent acknowledgement");
     expect(store.writes).toEqual([]);
+  });
+});
+
+// The reason on a refusal is what the agent API turns into a status code, and
+// getting it wrong is not cosmetic: SKILL.md tells agents a 4xx means the
+// request has to change, so an outage reported as one is an outage nobody
+// retries. `version` separates "nothing was written" from "version N exists and
+// is simply not live", which is the difference between retrying the save and
+// finishing with a publish.
+describe("WaiverTemplateError reasons", () => {
+  async function reasonOf(run: () => Promise<unknown>) {
+    try {
+      await run();
+    } catch (e) {
+      expect(e).toBeInstanceOf(WaiverTemplateError);
+      const err = e as WaiverTemplateError;
+      return { reason: err.reason, version: err.version };
+    }
+    throw new Error("expected a refusal");
+  }
+
+  it("calls a missing version not_found rather than invalid", async () => {
+    const { admin } = fakeClient(() => ok(null));
+    expect(await reasonOf(() => promoteWaiverTemplate(admin, "gone"))).toEqual({
+      reason: "not_found",
+      version: undefined,
+    });
+  });
+
+  it("calls a version missing its media acknowledgement invalid", async () => {
+    const { admin } = fakeClient(() =>
+      ok({ id: "v2", version: 2, is_current: false, acknowledgements: [] }),
+    );
+    expect(await reasonOf(() => promoteWaiverTemplate(admin, "v2"))).toEqual({
+      reason: "invalid",
+      version: 2,
+    });
+  });
+
+  it("calls a lost promotion race not_published, naming the version left unlive", async () => {
+    const { admin } = fakeClient((op, all) => {
+      const selects = all.filter((c) => c.verb === "select").length;
+      if (op.verb === "select" && selects === 1)
+        return ok({
+          id: "v2",
+          version: 2,
+          is_current: false,
+          acknowledgements: [{ id: "media", label: "Photos are fine.", required: false }],
+        });
+      if (op.verb === "select" && selects === 2) return ok({ id: "v1" });
+      if (op.verb === "select") return ok({ id: "v3" });
+      if (op.patch?.is_current === true) return { data: null, error: { message: "conflict" } };
+      return ok(null);
+    });
+    expect(await reasonOf(() => promoteWaiverTemplate(admin, "v2"))).toEqual({
+      reason: "not_published",
+      version: 2,
+    });
+  });
+
+  it("calls a refused save invalid, with no version, because nothing was written", async () => {
+    const store = fakeStore([row({ version: 3, is_current: true })]);
+    expect(
+      await reasonOf(() =>
+        saveWaiverTemplateVersion(
+          store.admin,
+          { title: "T", body_md: "B", acknowledgements: [] },
+          null,
+        ),
+      ),
+    ).toEqual({ reason: "invalid", version: undefined });
+  });
+
+  // The one worth the whole class: the row IS there, so a caller repeating the
+  // save files a second copy of the same wording under a new number.
+  it("names the version a save wrote but could not publish", async () => {
+    const store = fakeStore([row({ version: 3, is_current: true })]);
+    const admin = store.admin as unknown as {
+      from: (t: string) => { update: (p: Record<string, unknown>) => unknown };
+    };
+    const realFrom = admin.from;
+    admin.from = (table: string) => {
+      const built = realFrom(table) as Record<string, unknown>;
+      return {
+        ...built,
+        update: (patch: Record<string, unknown>) =>
+          patch.is_current === true
+            ? {
+                eq: () => ({
+                  then: (resolve: (r: { data: null; error: { message: string } }) => unknown) =>
+                    Promise.resolve(resolve({ data: null, error: { message: "storage blip" } })),
+                }),
+              }
+            : (built.update as (p: Record<string, unknown>) => unknown)(patch),
+      } as never;
+    };
+    expect(
+      await reasonOf(() =>
+        saveWaiverTemplateVersion(
+          store.admin,
+          { title: "T", body_md: "B", acknowledgements: [MEDIA_ACK] },
+          null,
+        ),
+      ),
+    ).toEqual({ reason: "not_published", version: 4 });
   });
 });

--- a/src/lib/waiver.functions.ts
+++ b/src/lib/waiver.functions.ts
@@ -44,7 +44,7 @@ import {
   toDuplicateRefs,
 } from "@/lib/waiver-duplicates";
 import { supersedesMediaConsent } from "@/lib/waiver-approval";
-import { hasMediaAcknowledgement } from "@/lib/waiver-template-editor";
+import { hasMediaAcknowledgement, WaiverTemplateError } from "@/lib/waiver-template-editor";
 import type { DuplicateWaiverRef } from "@/lib/waiver-duplicates";
 import { userIdByEmail } from "@/lib/supabase-rpc";
 
@@ -1038,10 +1038,10 @@ export async function promoteWaiverTemplate(
     .select("id, version, is_current, acknowledgements")
     .eq("id", id)
     .maybeSingle();
-  if (tErr) throw new Error(tErr.message);
+  if (tErr) throw new WaiverTemplateError(tErr.message, "not_published");
   // Both checks happen BEFORE anything is cleared: a bad id or an already-live
   // target must never cost the club its live waiver.
-  if (!target) throw new Error("That waiver version no longer exists.");
+  if (!target) throw new WaiverTemplateError("That waiver version no longer exists.", "not_found");
   if (target.is_current) return { version: target.version };
   // A template can only go live carrying the media-consent acknowledgement.
   // This is the one place every promotion passes through -- `saveWaiverTemplate`
@@ -1050,8 +1050,10 @@ export async function promoteWaiverTemplate(
   // not just a direct promote of an old stored one. See
   // `hasMediaAcknowledgement` for what counts as still carrying it.
   if (!hasMediaAcknowledgement(parseTemplateAcks(target.acknowledgements))) {
-    throw new Error(
+    throw new WaiverTemplateError(
       "This version has no media consent acknowledgement (or its wording is blank), so making it live would stop the club recording who agreed to photos. Add it back before making this version live.",
+      "invalid",
+      target.version,
     );
   }
 
@@ -1060,13 +1062,13 @@ export async function promoteWaiverTemplate(
     .select("id")
     .eq("is_current", true)
     .maybeSingle();
-  if (pErr) throw new Error(pErr.message);
+  if (pErr) throw new WaiverTemplateError(pErr.message, "not_published", target.version);
 
   const { error: clearErr } = await admin
     .from("waiver_templates")
     .update({ is_current: false })
     .eq("is_current", true);
-  if (clearErr) throw new Error(clearErr.message);
+  if (clearErr) throw new WaiverTemplateError(clearErr.message, "not_published", target.version);
 
   const { error: setErr } = await admin
     .from("waiver_templates")
@@ -1086,8 +1088,10 @@ export async function promoteWaiverTemplate(
     .eq("is_current", true)
     .maybeSingle();
   if (nowCurrent) {
-    throw new Error(
+    throw new WaiverTemplateError(
       "Someone else changed the live waiver a moment ago, so this change was not applied. Reload the page to see the current version.",
+      "not_published",
+      target.version,
     );
   }
 
@@ -1101,12 +1105,14 @@ export async function promoteWaiverTemplate(
       // gets a server-side log AND a message that tells the manager the signing
       // page is down rather than a generic failure they would shrug at.
       console.error("[promoteWaiverTemplate] could not restore the live template:", restoreErr);
-      throw new Error(
+      throw new WaiverTemplateError(
         "The waiver version could not be changed, and the club is now left with no live waiver, so nobody can sign. Try again now to fix it.",
+        "not_published",
+        target.version,
       );
     }
   }
-  throw new Error(setErr.message);
+  throw new WaiverTemplateError(setErr.message, "not_published", target.version);
 }
 
 export const setCurrentWaiverTemplate = createServerFn({ method: "POST" })
@@ -1144,8 +1150,9 @@ export async function saveWaiverTemplateVersion(
   createdBy: string | null,
 ): Promise<{ id: string; version: number }> {
   if (!hasMediaAcknowledgement(input.acknowledgements)) {
-    throw new Error(
+    throw new WaiverTemplateError(
       "This version has no media consent acknowledgement (or its wording is blank), so saving it would stop the club recording who agreed to photos. Add it back before saving.",
+      "invalid",
     );
   }
 
@@ -1158,7 +1165,7 @@ export async function saveWaiverTemplateVersion(
     .order("version", { ascending: false })
     .limit(1)
     .maybeSingle();
-  if (maxErr) throw new Error(maxErr.message);
+  if (maxErr) throw new WaiverTemplateError(maxErr.message, "not_published");
   const nextVersion = (maxRow?.version ?? 0) + 1;
 
   // Write the new version as a draft, THEN promote it.
@@ -1181,8 +1188,12 @@ export async function saveWaiverTemplateVersion(
     })
     .select("id, version")
     .single();
-  if (error) throw new Error(error.message);
+  if (error) throw new WaiverTemplateError(error.message, "not_published");
 
+  // The version now exists. Whatever the promotion does from here, the caller
+  // has to hear about THAT rather than about a save it should repeat: saving
+  // again would file a second numbered draft, where publishing this one
+  // finishes what this call started.
   await promoteWaiverTemplate(admin, created.id);
   return { id: created.id, version: created.version };
 }

--- a/src/lib/waiver.functions.ts
+++ b/src/lib/waiver.functions.ts
@@ -47,6 +47,7 @@ import { supersedesMediaConsent } from "@/lib/waiver-approval";
 import { hasMediaAcknowledgement, WaiverTemplateError } from "@/lib/waiver-template-editor";
 import type { DuplicateWaiverRef } from "@/lib/waiver-duplicates";
 import { userIdByEmail } from "@/lib/supabase-rpc";
+import { actorUserId } from "@/lib/manager-agent";
 
 const BUCKET = "waivers";
 const CLUB_NAME = "UTS Jitsu";
@@ -1324,8 +1325,6 @@ export async function countWaiversAwaitingApproval(admin: SupabaseClient<Databas
 // it cannot go through requireSupabaseAuth. Both entry points call the same
 // function after their own auth check, so a scripted migration and a manager's
 // own upload produce identical waivers.
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 export async function filePaperWaiver(
   admin: SupabaseClient<Database>,
   data: PaperWaiverUploadInput,
@@ -1514,7 +1513,7 @@ export async function filePaperWaiver(
   // Not every caller resolves to a real auth user: the manager agent API's
   // break-glass env-key fallback (docs/manager-agent-api.md) has no owner to look up, so
   // skip the lookup rather than log a spurious not-found error every call.
-  if (UUID_RE.test(uploadedByUserId)) {
+  if (actorUserId(uploadedByUserId)) {
     try {
       const { data: manager } = await admin.auth.admin.getUserById(uploadedByUserId);
       if (manager.user?.email) signer_meta.uploaded_by_email = manager.user.email;

--- a/src/lib/waiver.functions.ts
+++ b/src/lib/waiver.functions.ts
@@ -23,7 +23,12 @@ import {
   waiverSubmitSchema,
   waiverToProfileFields,
 } from "@/lib/validation";
-import type { PaperWaiverUploadInput, SignerMeta } from "@/lib/validation";
+import type {
+  AcknowledgementDef,
+  PaperWaiverUploadInput,
+  SaveTemplateInput,
+  SignerMeta,
+} from "@/lib/validation";
 import { beltSizeForGiSize, type GiSize } from "@/lib/kit-sizes";
 import {
   mediaConsentFromAnswers,
@@ -918,25 +923,93 @@ export const checkWaiverSubmission = createServerFn({ method: "POST" })
 // read back) was invisible in the UI even though the table had always held the
 // full history. Managers can read every row by RLS; this goes through the
 // service role like the rest of the manager reads.
+/**
+ * One stored version of the waiver, as every manager surface reads it.
+ *
+ * The editor screen and the manager agent API project the same row through the
+ * same functions below, so a version an agent reads back is the version a
+ * manager sees on screen — including the acknowledgements, which live in a JSONB
+ * column and are only trustworthy once `parseTemplateAcks` has been over them.
+ */
+export type WaiverTemplateVersion = {
+  id: string;
+  version: number;
+  title: string;
+  body_md: string;
+  acknowledgements: AcknowledgementDef[];
+  is_current: boolean;
+  created_at: string;
+};
+
+type WaiverTemplateRow = {
+  id: string;
+  version: number;
+  title: string;
+  body_md: string;
+  acknowledgements: unknown;
+  is_current: boolean;
+  created_at: string;
+};
+
+function projectWaiverTemplate(row: WaiverTemplateRow): WaiverTemplateVersion {
+  return {
+    id: row.id,
+    version: row.version,
+    title: row.title,
+    body_md: row.body_md,
+    acknowledgements: parseTemplateAcks(row.acknowledgements),
+    is_current: row.is_current,
+    created_at: row.created_at,
+  };
+}
+
+/**
+ * Every stored version, newest first.
+ *
+ * Exported and taking its client as a parameter for the same reason
+ * `promoteWaiverTemplate` is: a `createServerFn` handler only runs inside a Start
+ * request context, and the manager agent API has to reach the same list the
+ * editor screen shows rather than growing a second query of its own.
+ */
+export async function listWaiverTemplateRows(
+  admin: SupabaseClient<Database>,
+): Promise<WaiverTemplateVersion[]> {
+  const { data, error } = await admin
+    .from("waiver_templates")
+    .select("id, version, title, body_md, acknowledgements, is_current, created_at")
+    .order("version", { ascending: false });
+  if (error) throw new Error(error.message);
+  return (data ?? []).map(projectWaiverTemplate);
+}
+
+/**
+ * One stored version, or the live one when no version is named.
+ *
+ * "The live one" is the row flagged `is_current`, never the highest-numbered
+ * one. Those differ the moment a manager rolls back to earlier wording, and
+ * answering with the newest would have a caller read version 9, edit it, and
+ * publish it over the version 4 the club deliberately went back to.
+ */
+export async function loadWaiverTemplateVersion(
+  admin: SupabaseClient<Database>,
+  version?: number,
+): Promise<WaiverTemplateVersion | null> {
+  const query = admin
+    .from("waiver_templates")
+    .select("id, version, title, body_md, acknowledgements, is_current, created_at");
+  const { data, error } = await (
+    version === undefined ? query.eq("is_current", true) : query.eq("version", version)
+  ).maybeSingle();
+  if (error) throw new Error(error.message);
+  return data ? projectWaiverTemplate(data) : null;
+}
+
 export const listWaiverTemplates = createServerFn({ method: "GET" })
   .middleware([requireSupabaseAuth])
   .handler(async ({ context }) => {
     await requireManager(context);
     const { supabaseAdmin } = await import("@/integrations/supabase/client.server");
-    const { data, error } = await supabaseAdmin
-      .from("waiver_templates")
-      .select("id, version, title, body_md, acknowledgements, is_current, created_at")
-      .order("version", { ascending: false });
-    if (error) throw new Error(error.message);
-    return (data ?? []).map((t) => ({
-      id: t.id,
-      version: t.version,
-      title: t.title,
-      body_md: t.body_md,
-      acknowledgements: parseTemplateAcks(t.acknowledgements),
-      is_current: t.is_current,
-      created_at: t.created_at,
-    }));
+    return listWaiverTemplateRows(supabaseAdmin);
   });
 
 // ---- Manager: promote an existing version to the live one ----
@@ -1047,50 +1120,81 @@ export const setCurrentWaiverTemplate = createServerFn({ method: "POST" })
   });
 
 // ---- Manager: save new template version ----
+
+/**
+ * Write a new version of the waiver and make it the one people sign.
+ *
+ * That is the whole of "save" as the editor screen means it: there is no draft
+ * state, saving publishes, and waivers already signed keep the version they were
+ * signed against. Exported and client-parameterised like `promoteWaiverTemplate`
+ * so the manager agent API saves through exactly this path instead of a second
+ * one that could drift from it.
+ *
+ * `createdBy` is null for a caller that resolves to no auth user (the agent
+ * API's break-glass env key), because the column is a real FK to `auth.users`.
+ *
+ * The media-consent check runs BEFORE the insert. `promoteWaiverTemplate` would
+ * refuse the publish anyway, but only after the row existed, leaving a draft
+ * version nobody asked for sitting in the editor's version list. Refusing first
+ * means a rejected save changes nothing at all.
+ */
+export async function saveWaiverTemplateVersion(
+  admin: SupabaseClient<Database>,
+  input: SaveTemplateInput,
+  createdBy: string | null,
+): Promise<{ id: string; version: number }> {
+  if (!hasMediaAcknowledgement(input.acknowledgements)) {
+    throw new Error(
+      "This version has no media consent acknowledgement (or its wording is blank), so saving it would stop the club recording who agreed to photos. Add it back before saving.",
+    );
+  }
+
+  // A failed read here would number the new template 1 and collide with the
+  // existing version 1, so the manager's save would fail on a duplicate-key
+  // message that says nothing about what actually went wrong.
+  const { data: maxRow, error: maxErr } = await admin
+    .from("waiver_templates")
+    .select("version")
+    .order("version", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (maxErr) throw new Error(maxErr.message);
+  const nextVersion = (maxRow?.version ?? 0) + 1;
+
+  // Write the new version as a draft, THEN promote it.
+  //
+  // The obvious order (clear `is_current`, then insert the row with
+  // `is_current = true`) leaves the club with no live waiver if the insert
+  // fails, and there is nothing to roll back to by then. This way a failed
+  // insert changes nothing at all, and a failed promotion leaves the previous
+  // version live with an unused draft behind it — a manager can retry, and
+  // nobody's signing page went down in the meantime.
+  const { data: created, error } = await admin
+    .from("waiver_templates")
+    .insert({
+      version: nextVersion,
+      title: input.title,
+      body_md: input.body_md,
+      acknowledgements: input.acknowledgements,
+      is_current: false,
+      created_by: createdBy,
+    })
+    .select("id, version")
+    .single();
+  if (error) throw new Error(error.message);
+
+  await promoteWaiverTemplate(admin, created.id);
+  return { id: created.id, version: created.version };
+}
+
 export const saveWaiverTemplate = createServerFn({ method: "POST" })
   .middleware([requireSupabaseAuth])
   .inputValidator((d: unknown) => saveTemplateSchema.parse(d))
   .handler(async ({ data, context }) => {
     await requireManager(context);
-
     const { supabaseAdmin } = await import("@/integrations/supabase/client.server");
-
-    // A failed read here would number the new template 1 and collide with the
-    // existing version 1, so the manager's save would fail on a duplicate-key
-    // message that says nothing about what actually went wrong.
-    const { data: maxRow, error: maxErr } = await supabaseAdmin
-      .from("waiver_templates")
-      .select("version")
-      .order("version", { ascending: false })
-      .limit(1)
-      .maybeSingle();
-    if (maxErr) throw new Error(maxErr.message);
-    const nextVersion = (maxRow?.version ?? 0) + 1;
-
-    // Write the new version as a draft, THEN promote it.
-    //
-    // The obvious order (clear `is_current`, then insert the row with
-    // `is_current = true`) leaves the club with no live waiver if the insert
-    // fails, and there is nothing to roll back to by then. This way a failed
-    // insert changes nothing at all, and a failed promotion leaves the previous
-    // version live with an unused draft behind it — a manager can retry, and
-    // nobody's signing page went down in the meantime.
-    const { data: created, error } = await supabaseAdmin
-      .from("waiver_templates")
-      .insert({
-        version: nextVersion,
-        title: data.title,
-        body_md: data.body_md,
-        acknowledgements: data.acknowledgements,
-        is_current: false,
-        created_by: context.userId,
-      })
-      .select("id, version")
-      .single();
-    if (error) throw new Error(error.message);
-
-    await promoteWaiverTemplate(supabaseAdmin, created.id);
-    return { ok: true as const, version: created.version };
+    const { version } = await saveWaiverTemplateVersion(supabaseAdmin, data, context.userId);
+    return { ok: true as const, version };
   });
 
 // ---- Manager: list waivers ----

--- a/src/routes/api/manager/agent.test.ts
+++ b/src/routes/api/manager/agent.test.ts
@@ -489,6 +489,24 @@ describe("manager agent route: the waiver template", () => {
     delete process.env.MANAGER_AGENT_API_KEY;
   });
 
+  /**
+   * Build a refusal from the SAME module registry the route will import from.
+   *
+   * `vi.resetModules()` in beforeEach gives each test a fresh registry, so an
+   * error built from a top-level import is an instance of a different class
+   * than the route's `instanceof` check sees, and every mapping would silently
+   * fall through to the 500 branch — the test would pass on a broken mapper
+   * only if the mapper were broken in the same direction.
+   */
+  async function refusal(
+    message: string,
+    reason: "not_found" | "invalid" | "not_published",
+    version?: number,
+  ) {
+    const { WaiverTemplateError } = await import("@/lib/waiver-template-editor");
+    return new WaiverTemplateError(message, reason, version);
+  }
+
   it("lists versions without their bodies, naming the live one", async () => {
     listWaiverTemplateRowsMock.mockResolvedValue([
       { ...LIVE, version: 5, is_current: false, id: "b" },
@@ -565,10 +583,13 @@ describe("manager agent route: the waiver template", () => {
     expect((await res.json()).result.based_on).toBeNull();
   });
 
-  it("reports a refused save in the endpoint's error envelope", async () => {
+  it("reports a refused save as the caller's to fix", async () => {
     loadWaiverTemplateVersionMock.mockResolvedValue(LIVE);
     saveWaiverTemplateVersionMock.mockRejectedValue(
-      new Error("This version has no media consent acknowledgement (or its wording is blank)."),
+      await refusal(
+        "This version has no media consent acknowledgement (or its wording is blank).",
+        "invalid",
+      ),
     );
     const res = await post({
       action: "save_waiver_template",
@@ -578,6 +599,36 @@ describe("manager agent route: the waiver template", () => {
     const body = await res.json();
     expect(body.error.code).toBe("save_waiver_template_failed");
     expect(body.error.message).toContain("media consent");
+  });
+
+  // The one that must not be a 4xx: the skill tells agents a 4xx means the
+  // request has to change, so an unpublished version reported as one leaves
+  // /waiver possibly down with nobody retrying — and a caller that DOES retry
+  // the save files a second draft of wording that is already written.
+  it("reports a version written but not published as a retryable 503", async () => {
+    loadWaiverTemplateVersionMock.mockResolvedValue(LIVE);
+    saveWaiverTemplateVersionMock.mockRejectedValue(
+      await refusal("Someone else changed the live waiver a moment ago.", "not_published", 5),
+    );
+    const res = await post({
+      action: "save_waiver_template",
+      params: { acknowledgements: [MEDIA] },
+    });
+    expect(res.status).toBe(503);
+    expect(res.headers.get("retry-after")).toBe("5");
+    const body = await res.json();
+    expect(body.error.code).toBe("waiver_template_not_published");
+    expect(body.error.details).toEqual({ version: 5, published: false });
+  });
+
+  it("404s a version that vanished between the read and the publish", async () => {
+    loadWaiverTemplateVersionMock.mockResolvedValue({ ...LIVE, version: 2, is_current: false });
+    promoteWaiverTemplateMock.mockRejectedValue(
+      await refusal("That waiver version no longer exists.", "not_found"),
+    );
+    const res = await post({ action: "publish_waiver_template", params: { version: 2 } });
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe("not_found");
   });
 
   it("publishes a stored version", async () => {

--- a/src/routes/api/manager/agent.test.ts
+++ b/src/routes/api/manager/agent.test.ts
@@ -134,8 +134,21 @@ vi.mock("@/integrations/supabase/client.server", () => ({
 // the skill tells agents to branch on — 503 retry, 409 stop and confirm — so a
 // silent collapse to 422 turns a transient outage into an abandoned record.
 const filePaperWaiverMock = vi.fn();
+// The waiver-template functions are mocked for the same reason: their own
+// behaviour (refuse before writing, insert then promote) is pinned in
+// waiver-template.functions.test.ts against a store-backed fake. What the route
+// owns, and what these tests pin, is which version an omitted field is carried
+// over FROM, and whether a call that changed nothing says so.
+const listWaiverTemplateRowsMock = vi.fn();
+const loadWaiverTemplateVersionMock = vi.fn();
+const saveWaiverTemplateVersionMock = vi.fn();
+const promoteWaiverTemplateMock = vi.fn();
 vi.mock("@/lib/waiver.functions", () => ({
   filePaperWaiver: (...args: unknown[]) => filePaperWaiverMock(...args),
+  listWaiverTemplateRows: (...args: unknown[]) => listWaiverTemplateRowsMock(...args),
+  loadWaiverTemplateVersion: (...args: unknown[]) => loadWaiverTemplateVersionMock(...args),
+  saveWaiverTemplateVersion: (...args: unknown[]) => saveWaiverTemplateVersionMock(...args),
+  promoteWaiverTemplate: (...args: unknown[]) => promoteWaiverTemplateMock(...args),
 }));
 
 const BREAK_GLASS_KEY = "test-break-glass-key";
@@ -448,5 +461,140 @@ describe("manager agent route", () => {
       const body = await (await post({ action: "file_waiver", params })).json();
       expect(body.result.created).toBe(false);
     });
+  });
+});
+
+describe("manager agent route: the waiver template", () => {
+  const MEDIA = { id: "media", label: "I consent to being photographed.", required: false };
+  const LIVE = {
+    id: "11111111-1111-4111-8111-111111111111",
+    version: 4,
+    title: "Training Waiver",
+    body_md: "The whole legal text, {{full_name}}.",
+    acknowledgements: [MEDIA],
+    is_current: true,
+    created_at: "2026-08-01T00:00:00.000Z",
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.MANAGER_AGENT_API_KEY = BREAK_GLASS_KEY;
+    currentAdmin = {};
+    listWaiverTemplateRowsMock.mockReset();
+    loadWaiverTemplateVersionMock.mockReset();
+    saveWaiverTemplateVersionMock.mockReset();
+    promoteWaiverTemplateMock.mockReset();
+  });
+  afterEach(() => {
+    delete process.env.MANAGER_AGENT_API_KEY;
+  });
+
+  it("lists versions without their bodies, naming the live one", async () => {
+    listWaiverTemplateRowsMock.mockResolvedValue([
+      { ...LIVE, version: 5, is_current: false, id: "b" },
+      LIVE,
+    ]);
+    const res = await post({ action: "list_waiver_templates", params: {} });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result.live_version).toBe(4);
+    expect(body.result.count).toBe(2);
+    expect(body.result.templates[0]).not.toHaveProperty("body_md");
+  });
+
+  it("404s a version that does not exist", async () => {
+    loadWaiverTemplateVersionMock.mockResolvedValue(null);
+    const res = await post({ action: "get_waiver_template", params: { version: 99 } });
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.message).toContain("99");
+  });
+
+  // The outage, not a tidy empty state: /waiver refuses to render without a live
+  // template, so the reply has to say what to do about it.
+  it("says nobody can sign when nothing is live", async () => {
+    loadWaiverTemplateVersionMock.mockResolvedValue(null);
+    const res = await post({ action: "get_waiver_template", params: {} });
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.message).toMatch(/nobody can sign/);
+  });
+
+  // The carry-over is the whole point of the optional fields: rewording one
+  // acknowledgement must not mean resending 30000 characters of legal text, and
+  // the text it keeps has to come from the version named, not the newest.
+  it("carries the body over from the live version when only acknowledgements change", async () => {
+    loadWaiverTemplateVersionMock.mockResolvedValue(LIVE);
+    saveWaiverTemplateVersionMock.mockResolvedValue({ id: "new", version: 5 });
+    const reworded = [{ ...MEDIA, label: "I consent to photos and video." }];
+    const res = await post({
+      action: "save_waiver_template",
+      params: { acknowledgements: reworded },
+    });
+    expect(res.status).toBe(200);
+    expect(loadWaiverTemplateVersionMock).toHaveBeenCalledWith(expect.anything(), undefined);
+    expect(saveWaiverTemplateVersionMock.mock.calls[0][1]).toEqual({
+      title: LIVE.title,
+      body_md: LIVE.body_md,
+      acknowledgements: reworded,
+    });
+    const body = await res.json();
+    expect(body.result).toMatchObject({ version: 5, based_on: 4, is_current: true });
+  });
+
+  it("starts from the version named by base_version, not the live one", async () => {
+    loadWaiverTemplateVersionMock.mockResolvedValue({ ...LIVE, version: 2, is_current: false });
+    saveWaiverTemplateVersionMock.mockResolvedValue({ id: "new", version: 6 });
+    const res = await post({
+      action: "save_waiver_template",
+      params: { acknowledgements: [MEDIA], base_version: 2 },
+    });
+    expect(res.status).toBe(200);
+    expect(loadWaiverTemplateVersionMock).toHaveBeenCalledWith(expect.anything(), 2);
+    expect((await res.json()).result.based_on).toBe(2);
+  });
+
+  // A caller that described a whole version needs nothing to copy from, and a
+  // club whose live template has gone missing must still be able to write one.
+  it("writes a complete version without reading a base", async () => {
+    saveWaiverTemplateVersionMock.mockResolvedValue({ id: "new", version: 1 });
+    const res = await post({
+      action: "save_waiver_template",
+      params: { title: "Training Waiver", body_md: "Text", acknowledgements: [MEDIA] },
+    });
+    expect(res.status).toBe(200);
+    expect(loadWaiverTemplateVersionMock).not.toHaveBeenCalled();
+    expect((await res.json()).result.based_on).toBeNull();
+  });
+
+  it("reports a refused save in the endpoint's error envelope", async () => {
+    loadWaiverTemplateVersionMock.mockResolvedValue(LIVE);
+    saveWaiverTemplateVersionMock.mockRejectedValue(
+      new Error("This version has no media consent acknowledgement (or its wording is blank)."),
+    );
+    const res = await post({
+      action: "save_waiver_template",
+      params: { acknowledgements: [{ id: "risk", label: "I accept the risks.", required: true }] },
+    });
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error.code).toBe("save_waiver_template_failed");
+    expect(body.error.message).toContain("media consent");
+  });
+
+  it("publishes a stored version", async () => {
+    loadWaiverTemplateVersionMock.mockResolvedValue({ ...LIVE, version: 2, is_current: false });
+    promoteWaiverTemplateMock.mockResolvedValue({ version: 2 });
+    const res = await post({ action: "publish_waiver_template", params: { version: 2 } });
+    expect(res.status).toBe(200);
+    expect((await res.json()).result).toEqual({ version: 2, published: true });
+  });
+
+  // Promoting is idempotent, so a retry would otherwise report a second change
+  // to the club's legal document that never happened.
+  it("changes nothing, and says so, for the version already live", async () => {
+    loadWaiverTemplateVersionMock.mockResolvedValue(LIVE);
+    const res = await post({ action: "publish_waiver_template", params: { version: 4 } });
+    expect(res.status).toBe(200);
+    expect((await res.json()).result).toEqual({ version: 4, published: false });
+    expect(promoteWaiverTemplateMock).not.toHaveBeenCalled();
   });
 });

--- a/src/routes/api/manager/agent.ts
+++ b/src/routes/api/manager/agent.ts
@@ -38,6 +38,7 @@ import type { ManagerAgentAction } from "@/lib/validation";
 import {
   AGENT_ENV_KEY_UPLOADER,
   AGENT_MANIFEST,
+  actorUserId,
   AgentError,
   bearerToken,
   buildInvoicePatch,
@@ -791,14 +792,6 @@ async function handleSaveMembershipPlan(params: unknown) {
   }
 }
 
-/**
- * A waiver version's `created_by` is a real FK to `auth.users`, and the
- * break-glass env key resolves to a sentinel rather than a user. Same rule as
- * `kb-admin`'s own `isUuid`: record the manager when there is one, null when
- * there is not, never a string the FK will reject.
- */
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 // ---- action: list_waiver_templates ----
 async function handleListWaiverTemplates() {
   const db = await adminClient();
@@ -908,7 +901,7 @@ async function handleSaveWaiverTemplate(params: unknown, actingAs: string) {
         body_md: input.body_md ?? base!.body_md,
         acknowledgements: input.acknowledgements ?? base!.acknowledgements,
       },
-      UUID_RE.test(actingAs) ? actingAs : null,
+      actorUserId(actingAs),
     );
     // `based_on` is what makes a carry-over auditable: it names the version the
     // fields this call did not send actually came from.

--- a/src/routes/api/manager/agent.ts
+++ b/src/routes/api/manager/agent.ts
@@ -18,6 +18,9 @@ import {
   deleteInvoiceSchema,
   markInvoicePaidSchema,
   editInvoiceSchema,
+  agentGetWaiverTemplateSchema,
+  agentPublishWaiverTemplateSchema,
+  agentSaveWaiverTemplateSchema,
   deleteKbSectionSchema,
   getKbArticleSchema,
   listAgentInvoicesSchema,
@@ -42,6 +45,7 @@ import {
   diffInvoicePatch,
   invoiceEditAudit,
   projectAgentKbArticle,
+  projectAgentWaiverTemplate,
   projectInvoice,
   reconciledEditBlockers,
   reconciledEditMessage,
@@ -72,7 +76,13 @@ import {
   saveKbSection,
 } from "@/lib/kb-admin";
 import type { KbAnnotationRow, KbArticleRow } from "@/lib/kb-types";
-import { filePaperWaiver } from "@/lib/waiver.functions";
+import {
+  filePaperWaiver,
+  listWaiverTemplateRows,
+  loadWaiverTemplateVersion,
+  promoteWaiverTemplate,
+  saveWaiverTemplateVersion,
+} from "@/lib/waiver.functions";
 import {
   createMembershipForUser,
   deleteMembershipRow,
@@ -781,6 +791,136 @@ async function handleSaveMembershipPlan(params: unknown) {
 }
 
 /**
+ * A waiver version's `created_by` is a real FK to `auth.users`, and the
+ * break-glass env key resolves to a sentinel rather than a user. Same rule as
+ * `kb-admin`'s own `isUuid`: record the manager when there is one, null when
+ * there is not, never a string the FK will reject.
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ---- action: list_waiver_templates ----
+async function handleListWaiverTemplates() {
+  const db = await adminClient();
+  const templates = await listWaiverTemplateRows(db);
+  const live = templates.find((t) => t.is_current)?.version ?? null;
+  return {
+    count: templates.length,
+    // Null here is not a tidy empty state: it means nobody can sign right now,
+    // and it is the first thing a caller should look at.
+    live_version: live,
+    templates: templates.map((t) => projectAgentWaiverTemplate(t, live)),
+  };
+}
+
+/** The "there is nothing live" outage, in words a manager can act on. */
+const NO_LIVE_TEMPLATE =
+  "There is no live waiver template, so nobody can sign. Make one live with publish_waiver_template.";
+
+// ---- action: get_waiver_template ----
+async function handleGetWaiverTemplate(params: unknown) {
+  const input = agentGetWaiverTemplateSchema.parse(params);
+  const db = await adminClient();
+  const template = await loadWaiverTemplateVersion(db, input.version);
+  if (!template) {
+    throw new AgentError(
+      404,
+      "not_found",
+      input.version === undefined ? NO_LIVE_TEMPLATE : `No waiver version ${input.version}.`,
+    );
+  }
+  return {
+    template: {
+      version: template.version,
+      title: template.title,
+      body_md: template.body_md,
+      acknowledgements: template.acknowledgements,
+      is_current: template.is_current,
+      created_at: template.created_at,
+    },
+  };
+}
+
+// ---- action: save_waiver_template ----
+async function handleSaveWaiverTemplate(params: unknown, actingAs: string) {
+  const input = agentSaveWaiverTemplateSchema.parse(params);
+  const db = await adminClient();
+
+  // The base is read only when it is actually needed: a caller that sends the
+  // title, the body AND the acknowledgements has described a whole version, and
+  // refusing that for want of a live one to copy from would leave a club with no
+  // live template unable to publish its way out through this API.
+  const needsBase =
+    input.title === undefined ||
+    input.body_md === undefined ||
+    input.acknowledgements === undefined;
+  let base: Awaited<ReturnType<typeof loadWaiverTemplateVersion>> = null;
+  if (needsBase || input.base_version !== undefined) {
+    base = await loadWaiverTemplateVersion(db, input.base_version);
+    if (!base) {
+      throw new AgentError(
+        404,
+        "not_found",
+        input.base_version === undefined
+          ? `${NO_LIVE_TEMPLATE} To write one from scratch instead, send title, body_md and acknowledgements together.`
+          : `No waiver version ${input.base_version}.`,
+      );
+    }
+  }
+
+  try {
+    const saved = await saveWaiverTemplateVersion(
+      db,
+      {
+        title: input.title ?? base!.title,
+        body_md: input.body_md ?? base!.body_md,
+        acknowledgements: input.acknowledgements ?? base!.acknowledgements,
+      },
+      UUID_RE.test(actingAs) ? actingAs : null,
+    );
+    // `based_on` is what makes a carry-over auditable: it names the version the
+    // fields this call did not send actually came from.
+    return {
+      version: saved.version,
+      based_on: base?.version ?? null,
+      is_current: true as const,
+      url: "/waiver",
+    };
+  } catch (e) {
+    // saveWaiverTemplateVersion throws plain Errors carrying manager-facing text
+    // (the media-consent refusal, a failed insert, a lost promotion race). Wrap
+    // so the agent gets that wording inside the endpoint's error envelope.
+    throw new AgentError(
+      422,
+      "save_waiver_template_failed",
+      e instanceof Error ? e.message : "Could not save the waiver template.",
+    );
+  }
+}
+
+// ---- action: publish_waiver_template ----
+async function handlePublishWaiverTemplate(params: unknown) {
+  const input = agentPublishWaiverTemplateSchema.parse(params);
+  const db = await adminClient();
+  const target = await loadWaiverTemplateVersion(db, input.version);
+  if (!target) throw new AgentError(404, "not_found", `No waiver version ${input.version}.`);
+  // Read before promoting so the reply can say whether this call changed
+  // anything: `promoteWaiverTemplate` is idempotent and returns the same success
+  // either way, and a retry reporting "published" for a no-op reads as a second
+  // change to the club's legal document.
+  if (target.is_current) return { version: target.version, published: false as const };
+  try {
+    const { version } = await promoteWaiverTemplate(db, target.id);
+    return { version, published: true as const };
+  } catch (e) {
+    throw new AgentError(
+      422,
+      "publish_waiver_template_failed",
+      e instanceof Error ? e.message : "Could not change the live waiver version.",
+    );
+  }
+}
+
+/**
  * Cap on articles returned by `list_kb_articles`. Generous: a club with more
  * pages than this has outgrown a flat list, and the handler warns rather than
  * truncating in silence.
@@ -987,6 +1127,14 @@ async function dispatch(action: ManagerAgentAction, params: unknown, actingAs: s
       return handleDeleteInvoice(params, actingAs);
     case "file_waiver":
       return handleFileWaiver(params, actingAs);
+    case "list_waiver_templates":
+      return handleListWaiverTemplates();
+    case "get_waiver_template":
+      return handleGetWaiverTemplate(params);
+    case "save_waiver_template":
+      return handleSaveWaiverTemplate(params, actingAs);
+    case "publish_waiver_template":
+      return handlePublishWaiverTemplate(params);
     case "list_membership_plans":
       return handleListMembershipPlans();
     case "save_membership_plan":

--- a/src/routes/api/manager/agent.ts
+++ b/src/routes/api/manager/agent.ts
@@ -76,6 +76,7 @@ import {
   saveKbSection,
 } from "@/lib/kb-admin";
 import type { KbAnnotationRow, KbArticleRow } from "@/lib/kb-types";
+import { WaiverTemplateError } from "@/lib/waiver-template-editor";
 import {
   filePaperWaiver,
   listWaiverTemplateRows,
@@ -812,6 +813,38 @@ async function handleListWaiverTemplates() {
   };
 }
 
+/**
+ * How long to wait before repeating a template call that could not publish.
+ * Short: the likeliest cause is another manager promoting at the same moment,
+ * and until one of them lands the club may have no live waiver at all.
+ */
+const TEMPLATE_RETRY_AFTER_SECONDS = 5;
+
+/**
+ * Turn a refused template change into the right status code.
+ *
+ * The distinction that matters is retryable vs not. SKILL.md tells agents that a
+ * 4xx means the request itself has to change, so reporting "nobody can sign
+ * right now, try again" as a 422 is how `/waiver` stays down: the agent stops.
+ * `not_published` is therefore a 503 with a Retry-After, and it carries the
+ * version when one was written — repeating the save would file a second draft,
+ * where publishing that version finishes the job.
+ */
+function templateFailure(e: unknown, refusedCode: string): AgentError {
+  if (e instanceof WaiverTemplateError) {
+    if (e.reason === "not_found") return new AgentError(404, "not_found", e.message);
+    if (e.reason === "invalid") return new AgentError(422, refusedCode, e.message);
+    return new AgentError(
+      503,
+      "waiver_template_not_published",
+      e.message,
+      e.version === undefined ? undefined : { version: e.version, published: false },
+      TEMPLATE_RETRY_AFTER_SECONDS,
+    );
+  }
+  return new AgentError(500, "db_error", e instanceof Error ? e.message : "Could not reach it.");
+}
+
 /** The "there is nothing live" outage, in words a manager can act on. */
 const NO_LIVE_TEMPLATE =
   "There is no live waiver template, so nobody can sign. Make one live with publish_waiver_template.";
@@ -886,14 +919,11 @@ async function handleSaveWaiverTemplate(params: unknown, actingAs: string) {
       url: "/waiver",
     };
   } catch (e) {
-    // saveWaiverTemplateVersion throws plain Errors carrying manager-facing text
-    // (the media-consent refusal, a failed insert, a lost promotion race). Wrap
-    // so the agent gets that wording inside the endpoint's error envelope.
-    throw new AgentError(
-      422,
-      "save_waiver_template_failed",
-      e instanceof Error ? e.message : "Could not save the waiver template.",
-    );
+    // The wording comes from `saveWaiverTemplateVersion`, which speaks to
+    // managers; what is added here is the status code, and it is not one code.
+    // A version that was written but could not be made live is a retry, not a
+    // bad request — see `templateFailure`.
+    throw templateFailure(e, "save_waiver_template_failed");
   }
 }
 
@@ -912,11 +942,7 @@ async function handlePublishWaiverTemplate(params: unknown) {
     const { version } = await promoteWaiverTemplate(db, target.id);
     return { version, published: true as const };
   } catch (e) {
-    throw new AgentError(
-      422,
-      "publish_waiver_template_failed",
-      e instanceof Error ? e.message : "Could not change the live waiver version.",
-    );
+    throw templateFailure(e, "publish_waiver_template_failed");
   }
 }
 


### PR DESCRIPTION
## What changes for people

**For a manager.** Everything the waiver-template screen does can now be asked of
an agent: "read me the current waiver", "reword the photo consent tick-box",
"put last month's version back". Until now the agent could file a scanned paper
waiver but could not touch the document being signed, so anything about the
waiver text meant opening `/manager/waiver-template` yourself.

**For everyone else.** Nothing changes unless a manager asks for it. The screen
is untouched, the waiver at `/waiver` is untouched, and a waiver somebody has
already signed is untouched: each one keeps the version it was signed against,
which is what makes a bad edit recoverable by publishing the old version again.

**The one thing to feel.** Saving publishes, immediately, to everyone who signs
from that moment. That is already true of the screen's Save button, and the API
deliberately does not invent a draft state the screen does not have. So the skill
now tells an agent to read the current wording back, show the manager exactly
what it proposes, and say out loud that it goes live on save.

## The four actions

| Action | What it does |
| --- | --- |
| `list_waiver_templates` | Every version, newest first, and which one is live |
| `get_waiver_template` | One version's full markdown and its tick-boxes |
| `save_waiver_template` | Write a new version and make it the one people sign |
| `publish_waiver_template` | Make a stored version live again (rollback) |

They key on the **version number**, not the row id: the screen holds the row it
just listed, while an agent reads a list, decides, and calls back later, and the
version is the number a manager reads off the screen and off a signed PDF.

Anything omitted from a save is **carried over** from the version the edit starts
from (the live one, unless `base_version` names another), so rewording one
acknowledgement does not mean resending 30000 characters of legal text and
risking a body retyped from memory. `title` and `body_md` still travel together,
and a call naming neither text nor acknowledgements is refused rather than
republishing an identical copy under a new number.

Every version must still carry the media acknowledgement with real wording, or
the club silently stops recording who agreed to photos. Both the save and the
publish refuse without it, exactly as the screen does.

## How it is built

Four commits, on purpose:

1. **Preparatory refactor** — the reads and the save come out of their
   `createServerFn` handlers as plain functions taking their client as a
   parameter, the shape `promoteWaiverTemplate` already had. The API and the
   screen now run the same code rather than two copies of it. One deliberate
   behaviour change rides along: the media-consent check runs *before* the
   insert instead of only inside the promotion, so a refused save no longer
   leaves an unwanted draft version in the editor's list.
2. **The four actions** — schemas, manifest, dispatch, docs.
3. **Review follow-up** — the failure classification below.
4. **A second refactor** — this diff created a *third* verbatim copy of the same
   UUID regex, alongside `filePaperWaiver` and `saveKbArticle`, which is the
   point CLAUDE.md's own rule says to stop duplicating. It is now `actorUserId`
   in `manager-agent.ts`, next to the sentinel it exists because of: the
   break-glass env key authenticates as `AGENT_ENV_KEY_UPLOADER`, which is not a
   UUID and has no auth user behind it, so writing it into any column that
   references `auth.users` fails the insert outright.

The manifest is version **11** (additive) with a changelog entry, and all four
sync points named in `docs/manager-agent-api.md` move together: the Zod schemas,
the manifest, the route dispatch and the skill (including its frontmatter, so
the skill is offered when a manager asks about waiver wording).

### Which failures an agent should retry

The first cut wrapped every failure in a 422. The skill tells agents a 4xx means
the request itself has to change, so the two failures that are neither the
caller's fault nor permanent were the worst served: a concurrent promotion, and
the outage where the club is left with no live waiver and `/waiver` refuses to
render for everyone. Reported as 422 they read as "your request was invalid" and
nobody retries — and a caller that *does* retry a save whose promotion failed
files a second numbered draft of wording already stored.

A refused change now carries a reason (`WaiverTemplateError`, next to the other
template rules the screen and the API share) and the endpoint maps it:
`not_found` → 404, `invalid` → 422, `not_published` → **503 with a `Retry-After`**,
carrying `error.details.version` when a version exists but is not live — the case
where `publish_waiver_template` finishes the job and saving again duplicates it.
The wording a manager reads is unchanged, on the screen and through the API.

## Tests

New coverage for the extracted functions against a store-backed fake ("live"
means the flagged row and not the highest-numbered one; insert-then-promote
order; both media-consent refusals write nothing), for the refusal reasons
(including the one that names a version written but not published), for the new
schemas (strictness, text-arrives-whole, the no-op refusal), for the list
projection, for `actorUserId` refusing the break-glass sentinel, and for the
route handlers (which version a carry-over comes from, the 503 + `Retry-After`
mapping, and that publishing something already live reports `published: false`
and changes nothing).

`bun run lint`, `bun run typecheck`, `bun run test` (1934 passing) and
`bun run build` all pass locally, on top of the current `main`. **No database
change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148c6LV1F3XaJo3EmVhbowX