### PR TITLE
Copy link button on the manager blog list

### DIFF
--- a/docs/blog.md
+++ b/docs/blog.md
@@ -115,7 +115,14 @@ convention as every other public form.
 
 `/manager/blog` lists every post regardless of status; "New post" opens the
 composer (`/manager/blog/new`), an existing one opens for editing
-(`/manager/blog/:id`). The composer is a Markdown textarea with a small
+(`/manager/blog/:id`). A published post carries a **Copy link** button next to
+its title, which puts the post's canonical `https://jitsu.au/blog/<slug>`
+address on the clipboard (`canonicalUrl`, so it is the public address whatever
+host the manager is signed in on) ready to paste into a message or a social
+post. It sits with the title rather than with View/Delete because those are off
+the right edge of the table on a phone. A draft has no button: the public route
+serves published posts only, so a draft's URL is a 404 for everyone it is sent
+to. The composer is a Markdown textarea with a small
 formatting toolbar (bold/italic/heading/list/link), an "Insert image" button
 (uploads to `blog-media`, inserts a Markdown image), an "Insert video" dialog
 (YouTube links embed inline; anything else shows as a plain link), a separate

--- a/src/components/site/CopyButton.test.tsx
+++ b/src/components/site/CopyButton.test.tsx
@@ -1,0 +1,60 @@
+// Copying can be refused by the browser (no secure context, a dismissed
+// permission prompt), and when it is, the person still has to get the value
+// somehow. This pins that the failure carries the value itself: the button is
+// used in places where the string it copies is nowhere else on screen (the
+// blog list copies a post URL it never prints), so a bare "copy it manually"
+// would leave nothing to select.
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const toastError = vi.fn();
+
+vi.mock("sonner", () => ({
+  toast: { error: (...args: unknown[]) => toastError(...args) },
+}));
+
+const { CopyButton } = await import("./CopyButton");
+
+beforeEach(() => {
+  toastError.mockReset();
+});
+
+describe("CopyButton", () => {
+  it("copies the exact string it was given", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(<CopyButton text="https://jitsu.au/blog/hello" label="Copy link" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy link" }));
+
+    expect(writeText).toHaveBeenCalledWith("https://jitsu.au/blog/hello");
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("puts the value in the failure message, and keeps it on screen to be selected", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(<CopyButton text="https://jitsu.au/blog/hello" label="Copy link" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy link" }));
+
+    expect(toastError).toHaveBeenCalledTimes(1);
+    const [, options] = toastError.mock.calls[0] as [string, Record<string, unknown>];
+    expect(String(options.description)).toContain("https://jitsu.au/blog/hello");
+    // Auto-dismissing would take the value away mid-selection.
+    expect(options.duration).toBe(Infinity);
+    expect(options.closeButton).toBe(true);
+  });
+
+  it("uses ariaLabel as the accessible name while the visible label stays put", () => {
+    render(<CopyButton text="x" label="Copy link" ariaLabel="Copy link to Hello world" />);
+    const button = screen.getByRole("button", { name: "Copy link to Hello world" });
+    expect(button).toHaveTextContent("Copy link");
+  });
+
+  it("leaves the label as the accessible name when no ariaLabel is given", () => {
+    render(<CopyButton text="x" label="Copy reference" />);
+    expect(screen.getByRole("button", { name: "Copy reference" })).toBeInTheDocument();
+  });
+});

--- a/src/components/site/CopyButton.tsx
+++ b/src/components/site/CopyButton.tsx
@@ -6,8 +6,14 @@ import { Button } from "@/components/ui/button";
 interface CopyButtonProps {
   /** The exact string put on the clipboard. */
   text: string;
-  /** Button label, e.g. "Copy reference". Also the accessible name. */
+  /** Button label, e.g. "Copy reference". Also the accessible name by default. */
   label: string;
+  /**
+   * Accessible name, when the visible label is not enough on its own. A table
+   * of rows each with a "Copy link" button reads as a dozen identical buttons
+   * to a screen reader; this says which row it belongs to.
+   */
+  ariaLabel?: string;
   className?: string;
 }
 
@@ -19,13 +25,14 @@ interface CopyButtonProps {
  * caller keeps the value visible on screen, and the toast tells the person to
  * select it by hand rather than leaving a button that silently does nothing.
  */
-export function CopyButton({ text, label, className }: CopyButtonProps) {
+export function CopyButton({ text, label, ariaLabel, className }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
   return (
     <Button
       type="button"
       variant="outline"
       size="sm"
+      aria-label={ariaLabel}
       className={className}
       onClick={async () => {
         try {

--- a/src/components/site/CopyButton.tsx
+++ b/src/components/site/CopyButton.tsx
@@ -21,9 +21,12 @@ interface CopyButtonProps {
  * Copy one string to the clipboard, with a transient "copied" tick.
  *
  * Clipboard access can be refused outright (older browsers, no secure context,
- * a permission prompt the person dismissed), so the failure path matters: every
- * caller keeps the value visible on screen, and the toast tells the person to
- * select it by hand rather than leaving a button that silently does nothing.
+ * a permission prompt the person dismissed), so the failure path matters: the
+ * failure carries the value itself and stays on screen until dismissed, so the
+ * person can always select it by hand. It used to say "select it manually" and
+ * rely on every caller happening to print the value next to the button, which
+ * left anyone whose caller did not (a table row copying a URL it never shows)
+ * with nothing to select.
  */
 export function CopyButton({ text, label, ariaLabel, className }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
@@ -40,7 +43,11 @@ export function CopyButton({ text, label, ariaLabel, className }: CopyButtonProp
           setCopied(true);
           setTimeout(() => setCopied(false), 1500);
         } catch {
-          toast.error("Couldn't copy. Select and copy manually.");
+          toast.error("Couldn't copy that automatically.", {
+            description: `Select this and copy it by hand: ${text}`,
+            duration: Infinity,
+            closeButton: true,
+          });
         }
       }}
     >

--- a/src/routes/_authenticated/manager.blog.test.tsx
+++ b/src/routes/_authenticated/manager.blog.test.tsx
@@ -1,0 +1,98 @@
+// The point of the copy button is that a manager can hand out a post's real
+// public address without opening it and reading the browser bar, so what is
+// pinned here is the exact string it puts on the clipboard: the canonical
+// jitsu.au URL, whatever host the manager happens to be signed in on. Drafts
+// have no working URL (the public route filters to published), so they get no
+// button rather than a link that 404s for whoever it is sent to.
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const listAllBlogPosts = vi.fn();
+const deleteBlogPost = vi.fn();
+
+const published = {
+  id: "post-1",
+  slug: "2026-08-01-hello-world",
+  title: "Hello world",
+  status: "published" as const,
+  published_at: "2026-08-01T00:00:00.000Z",
+  created_at: "2026-08-01T00:00:00.000Z",
+  updated_at: "2026-08-01T00:00:00.000Z",
+};
+const draft = {
+  ...published,
+  id: "post-2",
+  slug: "2026-08-02-not-yet",
+  title: "Not yet",
+  status: "draft" as const,
+  published_at: null,
+};
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => opts,
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@tanstack/react-start", () => ({
+  useServerFn: (fn: unknown) => fn,
+}));
+
+vi.mock("@/lib/blog.functions", () => ({
+  listAllBlogPosts: (...args: unknown[]) => listAllBlogPosts(...args),
+  deleteBlogPost: (...args: unknown[]) => deleteBlogPost(...args),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "manager-1" }, session: null, loading: false }),
+  useRoles: () => ({ roles: ["manager"], loading: false, isManager: true }),
+}));
+
+const { Route } = await import("./manager.blog");
+const BlogPostsPage = (Route as unknown as { component: () => ReactNode }).component;
+
+async function renderLoaded() {
+  render(<BlogPostsPage />);
+  await screen.findByRole("table");
+}
+
+function rowFor(title: string) {
+  return within(screen.getByText(title).closest("tr")!);
+}
+
+beforeEach(() => {
+  listAllBlogPosts.mockReset().mockResolvedValue([published, draft]);
+  deleteBlogPost.mockReset();
+});
+
+describe("/manager/blog", () => {
+  it("copies the post's canonical public URL", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    await renderLoaded();
+
+    await userEvent.click(rowFor("Hello world").getByRole("button", { name: /copy link/i }));
+
+    expect(writeText).toHaveBeenCalledWith("https://jitsu.au/blog/2026-08-01-hello-world");
+  });
+
+  it("names each button after its own post, so a screen reader can tell them apart", async () => {
+    await renderLoaded();
+    expect(screen.getByRole("button", { name: "Copy link to Hello world" })).toBeInTheDocument();
+  });
+
+  it("offers no link for a draft, whose public URL is a 404", async () => {
+    await renderLoaded();
+    expect(rowFor("Not yet").queryByRole("button", { name: /copy link/i })).toBeNull();
+  });
+
+  it("puts the button in the title cell, which is reachable without scrolling the table", async () => {
+    await renderLoaded();
+    const cells = screen.getByText("Hello world").closest("tr")!.querySelectorAll("td");
+    expect(
+      within(cells[0] as HTMLElement).getByRole("button", { name: /copy link/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/routes/_authenticated/manager.blog.tsx
+++ b/src/routes/_authenticated/manager.blog.tsx
@@ -14,7 +14,9 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { CopyButton } from "@/components/site/CopyButton";
 import { blogPostClass } from "@/lib/status-colours";
+import { canonicalUrl } from "@/lib/seo";
 import { formatDateTime } from "@/lib/dates";
 import { deleteBlogPost, listAllBlogPosts } from "@/lib/blog.functions";
 import { useAuth, useRoles } from "@/hooks/useAuth";
@@ -110,13 +112,28 @@ function BlogPostsPage() {
               {rows.map((row) => (
                 <tr key={row.id} className="border-t">
                   <td className="p-3 font-medium">
-                    <Link
-                      to="/manager/blog/$id"
-                      params={{ id: row.id }}
-                      className="hover:underline"
-                    >
-                      {row.title}
-                    </Link>
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+                      <Link
+                        to="/manager/blog/$id"
+                        params={{ id: row.id }}
+                        className="hover:underline"
+                      >
+                        {row.title}
+                      </Link>
+                      {/* Next to the title, not with the row's other actions:
+                          those sit off the right edge of a table this wide, so
+                          on a phone they need a horizontal scroll to reach.
+                          Only published posts get one, because a draft's URL
+                          is a 404 for everyone who isn't a manager. */}
+                      {row.status === "published" && (
+                        <CopyButton
+                          text={canonicalUrl(`/blog/${row.slug}`)}
+                          label="Copy link"
+                          ariaLabel={`Copy link to ${row.title}`}
+                          className="shrink-0"
+                        />
+                      )}
+                    </div>
                   </td>
                   <td className="p-3">
                     <Pill label={row.status} className={blogPostClass(row.status)} />

--- a/src/routes/_authenticated/manager.blog.tsx
+++ b/src/routes/_authenticated/manager.blog.tsx
@@ -123,8 +123,9 @@ function BlogPostsPage() {
                       {/* Next to the title, not with the row's other actions:
                           those sit off the right edge of a table this wide, so
                           on a phone they need a horizontal scroll to reach.
-                          Only published posts get one, because a draft's URL
-                          is a 404 for everyone who isn't a manager. */}
+                          Only published posts get one: the public route reads
+                          through the anon client with no session, so a draft's
+                          URL is a 404 for everyone, managers included. */}
                       {row.status === "published" && (
                         <CopyButton
                           text={canonicalUrl(`/blog/${row.slug}`)}


### PR DESCRIPTION
## What changes for a manager

On `/manager/blog`, every published post now has a **Copy link** button sitting right next to its title. One tap puts the post's public address (`https://jitsu.au/blog/<slug>`) on the clipboard, ready to paste into a message, an email or a social post. No need to open the post and read it out of the browser bar.

It's next to the title on purpose. The table is wide, so on a phone the View and Delete buttons are off the right edge behind a horizontal scroll; the title is the part of the row you can actually reach without swiping. The button wraps under a long title on a narrow screen rather than pushing the title around.

Drafts get no button. The public blog serves published posts only, so a draft's URL is a 404 for whoever it's sent to. Better to have nothing to press than a link that looks fine and isn't.

Nothing else moves: View and Delete are where they were, and members and visitors see no change.

## Also in here: the copy-failure path

A review of the first commit found this change broke `CopyButton`'s own contract. Its failure message said "select and copy manually" and relied on every caller printing the value next to the button. The blog list doesn't: it copies a URL that appears nowhere on the page, so a browser refusing clipboard access left a manager with nothing to select. The row's View link is no substitute, since it resolves against whichever host they're on rather than `jitsu.au`.

The failure now carries the string itself and stays on screen until dismissed, instead of auto-dismissing mid-selection. That fixes it for every caller rather than asking the next one to remember the rule.

## Notes

- The copied address is always the `jitsu.au` one, whatever host the manager happens to be signed in on (a Lovable preview, a branch deploy), so a pasted link never points somewhere temporary.
- `CopyButton` grew an optional accessible-name prop so a table of otherwise identical "Copy link" buttons still tells a screen reader which post each one belongs to.
- Tests: `src/routes/_authenticated/manager.blog.test.tsx` pins the exact string copied, the per-row accessible name, that drafts have no button, and that the button lands in the title cell. New `src/components/site/CopyButton.test.tsx` pins the failure message carrying the value and staying up, plus the accessible-name behaviour. `docs/blog.md` updated in the same change.
- No migration, so nothing to apply to the live database.
- `bun run lint`, `bun run typecheck`, `bun run test` (1904 passing) and `bun run build` all pass locally; all three CI checks green.