### PR TITLE
Public-repo readiness: guard the committed .env, close two live auth holes

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Refuse a commit that would put a secret in the tracked `.env`.
+#
+# CI checks the same thing (.github/workflows/ci.yml), but by then the commit
+# object exists and, if it was pushed, the credential is out and has to be
+# rotated. This catches it while there is still nothing to rotate.
+#
+# Installed by `bash scripts/install-git-hooks.sh`, which `bun run deps` runs
+# for you. It points core.hooksPath at this directory, so hooks are versioned
+# with the repo rather than living unversioned in .git/hooks.
+#
+# This is a convenience, NOT the enforcement: `--no-verify` skips it, it only
+# runs for people who installed it, and it does not exist on Lovable's side.
+# CI is the backstop. See CLAUDE.md > Environment variables.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+CHECK="scripts/check-committed-env.mjs"
+[[ -f "$CHECK" ]] || exit 0
+
+# Bun is this project's runtime, but a GUI git client may not have it on PATH.
+# The checker is plain ESM with no dependencies, so node runs it identically.
+if command -v bun >/dev/null 2>&1; then
+  exec bun "$CHECK" --staged
+elif command -v node >/dev/null 2>&1; then
+  exec node "$CHECK" --staged
+fi
+
+# Neither runtime: warn rather than block. Refusing every commit because a GUI
+# client has a bare PATH would get the hook uninstalled, and CI still catches
+# the leak before it can merge.
+echo "[env-check] skipped: neither bun nor node is on PATH. CI will still check." >&2
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,15 @@ jobs:
         with:
           bun-version: latest
 
+      # This repo is public and `.env` is tracked (Lovable Cloud generates it and
+      # re-commits it, so it cannot just be gitignored). That makes it the easiest
+      # file in the tree to leak a credential through, and nothing else here would
+      # notice. Checked before the install so a leak fails in seconds, and against
+      # what git has rather than the working copy — a local service-role key is
+      # fine, committing one is not. See CLAUDE.md > Environment variables.
+      - name: Check the committed .env holds only publishable values
+        run: bun scripts/check-committed-env.mjs
+
       # Lovable pins tarball URLs to its private mirror (unreachable in CI), so
       # a plain `bun install` 403s here. This helper rewrites the pinned base
       # URL to public npm and installs Lovable's exact locked versions, then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           bun-version: latest
 
-      # This repo is public and `.env` is tracked (Lovable Cloud generates it and
+      # This repo is going public and `.env` is tracked (Lovable generates it and
       # re-commits it, so it cannot just be gitignored). That makes it the easiest
       # file in the tree to leak a credential through, and nothing else here would
       # notice. Checked before the install so a leak fails in seconds, and against

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -18,10 +18,10 @@ name: PR screenshots
 # the calendar show the SEEDED content, not what is on jitsu.au today. That is
 # the trade for screenshots that are the same on every run and on every fork.
 #
-# The repository is private, so GitHub will not render images pulled from
-# `raw.githubusercontent.com` inside a comment (they need an authenticated
-# request). The screenshots therefore ship as a build artifact and the comment
-# links to it: download, unzip, open `index.html`.
+# The screenshots ship as a build artifact and the comment links to it, rather
+# than being embedded inline: an Actions artifact is a zip you download, not a
+# URL a comment can render an image from. So: download, unzip, open
+# `index.html`.
 
 on:
   pull_request:

--- a/.github/workflows/supabase-lint.yml
+++ b/.github/workflows/supabase-lint.yml
@@ -24,6 +24,13 @@ concurrency:
   group: supabase-lint-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: this workflow only reads the repo. Without this block the
+# job inherits the repository default token scope (often read/write) — and this
+# job runs migrations and linters straight from a pull request's own tree, so
+# there is no reason for that tree to have a write-capable token in scope.
+permissions:
+  contents: read
+
 jobs:
   db-lint:
     name: Advisors + plpgsql_check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,31 @@ review submissions.
 The repo's package name is `tanstack_start_ts` — it was scaffolded from
 Lovable's TanStack Start template.
 
+## This repository is public — read first
+
+Everything you write here is world-readable: the code, the commit history, the
+issues and pull requests, the CI logs, and the screenshot artifacts. Work
+accordingly.
+
+- **Never commit a credential.** A pushed secret is public immediately and is
+  scraped within minutes, so the fix is always to **rotate** it, never to
+  revert the commit — git history keeps it forever. The file most likely to
+  catch you out is `.env`, which is tracked; see "Environment variables".
+- **Write commits, PR bodies and code comments for strangers.** No member names
+  or emails, no tokens, no internal hostnames, no pasted database rows. Real
+  people's data belongs in the database, never in the repo or a PR thread.
+- **RLS and table grants are the entire security boundary**, and now a public
+  one: anyone can read `supabase/migrations/*.sql`, reason precisely about
+  every policy, and probe it with the published `anon` key. Treat a weak policy
+  as a live vulnerability rather than a theoretical one, and see
+  `supabase/lint/client-grants-expected.txt` before granting anything to `anon`
+  or `authenticated`.
+- **Fixture data must stay synthetic** — `@example.com`, `0400 000 xxx`. It is
+  published in the seed script and photographed into screenshot artifacts.
+- CI holds one production credential (`SUPABASE_DB_URL`, used only by
+  `migration-drift.yml`). It is a GitHub secret and that workflow deliberately
+  never runs on `pull_request`; keep it that way. Forks get no secrets.
+
 ## Lovable-managed project — read first
 
 This project is connected to [Lovable](https://lovable.dev).
@@ -406,14 +431,16 @@ owner/manager policies (`20260727120000_waiver_storage_policies.sql`).
 - **CI:** `.github/workflows/ci.yml` runs lint → typecheck → test → build on
   Linux with Bun for every PR and pushes to `main`. It installs via
   `bash scripts/bun-install.sh` (see Lock file strategy below), not a plain
-  `bun install`. `.github/workflows/e2e.yml` runs the end-to-end suite
+  `bun install`. Before the install it runs `scripts/check-committed-env.mjs`,
+  which fails if the committed `.env` holds anything but publishable values
+  (see "Environment variables"). `.github/workflows/e2e.yml` runs the end-to-end suite
   alongside it (no repository secrets, same local-stack recipe as the
   screenshots job).
 - **PR screenshots:** `.github/workflows/pr-screenshots.yml` photographs **every
   page** on the branch at desktop and phone widths, uploads the PNGs plus an
   `index.html` contact sheet as an artifact, and posts one sticky PR comment
-  linking to it. The repo is private, so images cannot be embedded in the
-  comment — reviewers download the artifact.
+  linking to it. An Actions artifact is a zip you download, not something a
+  comment can embed, so reviewers download it and open `index.html`.
   - It runs the whole site against a **throwaway local Supabase stack**:
     `supabase start` (Postgres + Auth + PostgREST + Storage) with every
     migration in `supabase/migrations` applied, then
@@ -606,8 +633,40 @@ Non-production hosts (Lovable previews, branch deploys) are served a blanket
 
 ## Environment variables
 
-Configured via Lovable Cloud (`.env` locally; values are secrets, not committed
-meaningfully). The app reads:
+Secrets are configured in **Lovable Cloud project secrets** and injected into
+the server runtime. They are never written to a file in this repo.
+
+> [!IMPORTANT]
+> **`.env` is committed, on purpose, and it points at the live club.** Both
+> halves of that matter, and they cut in opposite directions.
+>
+> **It is Lovable's file.** Every version was written by `gpt-engineer-app[bot]`
+> when Cloud was enabled, and Lovable re-creates it on the next Cloud sync. So
+> do **not** gitignore it or `git rm --cached` it: you get churn commits rather
+> than a removal, and a build that reads the file rather than injected vars
+> fails the "Connect Supabase in Lovable Cloud" check while it is missing. It
+> holds only publishable values — the `anon` key, the Lovable Cloud API URL, the
+> project ref, the Google OAuth **client id** — all of which are baked into the
+> browser bundle anyway and readable from `jitsu.au` with devtools.
+>
+> **Never add a secret to it.** The repo is public, so a committed credential is
+> public the moment it is pushed and has to be rotated, not just reverted.
+> Keeping a service-role key in your **own local** `.env` to run scripts is
+> fine and expected; committing one is not.
+> `scripts/check-committed-env.mjs` enforces this in CI — it audits what git
+> has (not your working copy) against an allowlist of key names and a deny-list
+> of value shapes. A **new key from Lovable fails it by design**: that is the
+> review gate. If the value really is publishable, add it to
+> `PUBLISHABLE_ENV_KEYS` in that script and say why in the commit message.
+>
+> **bun auto-loads `.env`**, so any `bun run …` here talks to the **live club**
+> unless something overrides it. That is why `e2e/support/fixture.ts` and
+> `scripts/seed-local-club.mjs` both refuse a non-loopback Supabase URL, and why
+> `scripts/e2e.sh` stamps the build with the project it was built against —
+> `VITE_SUPABASE_URL` is baked in at build time, so no runtime guard would catch
+> a production-flavoured build. Never point a seeding or e2e script at it.
+
+The app reads:
 
 - Client (Vite, build-time): `VITE_SUPABASE_URL`, `VITE_SUPABASE_PUBLISHABLE_KEY`,
   `VITE_SUPABASE_PROJECT_ID`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,12 @@ review submissions.
 The repo's package name is `tanstack_start_ts` — it was scaffolded from
 Lovable's TanStack Start template.
 
-## This repository is public — read first
+## This repository is going public — read first
 
-Everything you write here is world-readable: the code, the commit history, the
-issues and pull requests, the CI logs, and the screenshot artifacts. Work
-accordingly.
+It is private today and is being opened up. Nothing already committed gets a
+second review when that happens, so work **now** as though everything here is
+already world-readable: the code, the full commit history, the issues and pull
+requests, the CI logs, and the screenshot artifacts.
 
 - **Never commit a credential.** A pushed secret is public immediately and is
   scraped within minutes, so the fix is always to **rotate** it, never to
@@ -649,8 +650,9 @@ the server runtime. They are never written to a file in this repo.
 > project ref, the Google OAuth **client id** — all of which are baked into the
 > browser bundle anyway and readable from `jitsu.au` with devtools.
 >
-> **Never add a secret to it.** The repo is public, so a committed credential is
-> public the moment it is pushed and has to be rotated, not just reverted.
+> **Never add a secret to it.** This repo is going public, so treat a committed
+> credential as public the moment it is pushed: it has to be rotated, not just
+> reverted, because history keeps it.
 > Keeping a service-role key in your **own local** `.env` to run scripts is
 > fine and expected; committing one is not.
 > `scripts/check-committed-env.mjs` enforces this in CI — it audits what git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,17 @@ requests, the CI logs, and the screenshot artifacts.
   or `authenticated`.
 - **Fixture data must stay synthetic** — `@example.com`, `0400 000 xxx`. It is
   published in the seed script and photographed into screenshot artifacts.
-- CI holds one production credential (`SUPABASE_DB_URL`, used only by
-  `migration-drift.yml`). It is a GitHub secret and that workflow deliberately
-  never runs on `pull_request`; keep it that way. Forks get no secrets.
+- CI is designed to hold exactly one production credential (`SUPABASE_DB_URL`,
+  used only by `migration-drift.yml`), as a GitHub secret, and that workflow
+  deliberately never runs on `pull_request`; keep it that way. Forks get no
+  secrets. **But the secret is not actually configured today** — every drift run
+  since the repo began has logged `SUPABASE_DB_URL:` empty and
+  `##[warning]SUPABASE_DB_URL is not set — the ... check did NOT run`, while
+  still reporting green. So nothing is currently at risk of leaking there, and
+  equally **neither live check has ever run**: no migration-ledger comparison
+  and no live client-grants comparison. Treat `supabase/lint/client-grants-expected.txt`
+  as a statement of intent verified against the migration files only, never
+  against the live database, until that secret is set.
 
 ## Lovable-managed project — read first
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ Use **Bun** (this is a Bun project — `bun install`, not npm/pnpm).
 | Command                 | Purpose                                |
 | ----------------------- | -------------------------------------- |
 | `bun install`           | Install dependencies                   |
+| `bun run hooks`         | Install the repo's git hooks           |
 | `bun run dev`           | Start the Vite dev server              |
 | `bun run build`         | Production build (Nitro)               |
 | `bun run build:dev`     | Build in development mode              |
@@ -158,6 +159,8 @@ public/                   Served at the site root
 supabase/
   config.toml             Supabase project ref + the local stack CI boots
   migrations/*.sql        Schema + RLS (timestamped, applied in order)
+.githooks/                Versioned git hooks (core.hooksPath; `bun run hooks`)
+  pre-commit              Refuses a commit that puts a secret in .env
 ```
 
 ## Routing conventions (TanStack Start — NOT Next.js/Remix)
@@ -545,7 +548,10 @@ Claude or CI produced.
 public npm — the path structure and integrity hashes are identical and every
 package (including `@lovable.dev/*`) is on public npm — installs Lovable's
 **exact locked versions**, then **restores `bun.lock`** so the rewrite is never
-committed. The 24h supply-chain guard in `bunfig.toml` still applies.
+committed. The 24h supply-chain guard in `bunfig.toml` still applies. It also
+runs `scripts/install-git-hooks.sh`, which points `core.hooksPath` at the
+versioned `.githooks/` (see "Environment variables"); that is a local git config
+change, idempotent, and a no-op outside a git checkout.
 
 **Never commit `bun.lock`.** If a stray `bun install` left it modified, restore
 it before committing: `git checkout bun.lock`. Add/remove dependencies by
@@ -655,11 +661,16 @@ the server runtime. They are never written to a file in this repo.
 > reverted, because history keeps it.
 > Keeping a service-role key in your **own local** `.env` to run scripts is
 > fine and expected; committing one is not.
-> `scripts/check-committed-env.mjs` enforces this in CI — it audits what git
-> has (not your working copy) against an allowlist of key names and a deny-list
-> of value shapes. A **new key from Lovable fails it by design**: that is the
-> review gate. If the value really is publishable, add it to
-> `PUBLISHABLE_ENV_KEYS` in that script and say why in the commit message.
+> `scripts/check-committed-env.mjs` enforces this. It audits what git has (not
+> your working copy) against an allowlist of key names and a deny-list of value
+> shapes, and runs in **two places**: a **pre-commit hook** reading the index,
+> so a secret is refused while there is still nothing to rotate, and **CI**
+> reading HEAD. Keep both — the hook is skipped by `--no-verify`, only runs for
+> people who installed it, and does not exist on Lovable's side, which is where
+> this file is actually written. CI is the only one none of that bypasses.
+> A **new key from Lovable fails it by design**: that is the review gate. If the
+> value really is publishable, add it to `PUBLISHABLE_ENV_KEYS` in that script
+> and say why in the commit message.
 >
 > **bun auto-loads `.env`**, so any `bun run …` here talks to the **live club**
 > unless something overrides it. That is why `e2e/support/fixture.ts` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,21 @@ requests, the CI logs, and the screenshot artifacts.
   since the repo began has logged `SUPABASE_DB_URL:` empty and
   `##[warning]SUPABASE_DB_URL is not set — the ... check did NOT run`, while
   still reporting green. So nothing is currently at risk of leaking there, and
-  equally **neither live check has ever run**: no migration-ledger comparison
-  and no live client-grants comparison. Treat `supabase/lint/client-grants-expected.txt`
-  as a statement of intent verified against the migration files only, never
-  against the live database, until that secret is set.
+  equally **the workflow has never checked anything**. Until that secret is set,
+  a green tick on Migration drift means only that the job ran.
+  - Both checks were run **by hand on 2026-08-20**, against the live database
+    through Lovable's SQL access rather than the workflow, and both came back
+    clean: **18 client grants live, 18 expected, 0 unexpected**, and every
+    migration in the repo present in the live ledger. So
+    `supabase/lint/client-grants-expected.txt` is, as of that date, verified
+    against production and not just against the migration files. It goes stale
+    the moment anyone changes a grant by hand, which is exactly what the
+    workflow is for — the by-hand run is a snapshot, not a substitute.
+  - The live ledger also carries one row with no file here
+    (`20260722131544_3de60949-…`, recorded as version `20260722131547`). Its SQL
+    is byte-identical to `20260722000000_memberships.sql`, so it is the
+    duplicate-re-emission case described in `docs/database-changes.md`, not
+    missing schema.
 
 ## Lovable-managed project — read first
 

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -51,8 +51,29 @@ Two ways, and the first wins whenever both are present:
   the waiver, and at that moment the person is an **applicant**: their login is
   banned until a manager approves them, so they cannot sign in at all. The link
   therefore carries an unguessable token (`?t=`), which is how the page knows who
-  is signing. Opening it also proves their address, like every other emailed link
-  in the product.
+  is signing.
+
+> [!IMPORTANT]
+> **This token identifies a signer. It does NOT verify their email**, and it is
+> the one token in the product that does not — every other one is proof of the
+> mailbox it was sent to.
+>
+> The reason is the success screen above: `submitWaiverWithPdf` returns this
+> token **in its HTTP response** so the button works before any email arrives.
+> Waiver signing is public and unauthenticated, so anyone can post any address
+> and be handed a live token for it without reading a single email. A value we
+> give to whoever asked proves nothing about who reads that inbox.
+>
+> So the token is scoped: `mailboxProvingPurposes` in `src/lib/email-verification.ts`
+> excludes `code_of_conduct`, and the three paths that stamp
+> `auth.users.email_confirmed_at` — the public `/api/verify-email/<token>`
+> redemption, the waiver's own `?vt=` proof, and this page's acceptance — all ask
+> that question first. Signing the code of conduct therefore records the
+> agreement and nothing else.
+>
+> Nothing is lost: the waiver confirmation email carries its own "confirm your
+> email address" button, which only ever exists inside that email. See
+> `docs/waivers.md` > Email verification.
 
 A visitor with neither can still **read** the whole document. They are shown how
 to sign (open the link from the email, or sign in) and nothing about whether any

--- a/docs/database.md
+++ b/docs/database.md
@@ -161,6 +161,25 @@ So the schema a helper lives in follows from who calls it:
 | `has_role`, `has_active_paid_membership`, the `user_emails` family | `public`  | the app calls them over PostgREST (`.rpc(...)`), so they have to stay routable |
 | `event_is_invite_only`, `is_event_invitee`, `is_commenter_blocked` | `private` | only an RLS policy ever calls them, so nothing needs them routable             |
 
+> [!IMPORTANT]
+> **Staying routable is not the same as answering anyone.** A function
+> `authenticated` may execute is reachable as `POST /rest/v1/rpc/<name>` with the
+> anon key and any session, so a `_user_id` parameter it does not check is an
+> oracle about other people. `has_role` and `has_active_paid_membership` both
+> had exactly that: given a uuid — and `blog_comments` publishes `user_id` beside
+> the commenter's name, while `calendar_events` publishes `created_by` — anyone
+> signed in could ask whether a named person was a manager or a paying member.
+>
+> `20260820000000_scope_role_helpers_to_caller.sql` closed it: each now answers
+> only when `_user_id = auth.uid()`, or when there is no `auth.uid()` at all
+> (the service role, which legitimately asks about anybody). RLS policies pass
+> `auth.uid()` and caller-scoped server functions pass their own `context.userId`,
+> so nothing legitimate changed. Both still return FALSE rather than NULL when
+> they refuse — see the RPC-nullability note in `CLAUDE.md`.
+>
+> A new `public` SECURITY DEFINER helper that takes a user id needs the same
+> guard, or it needs to live in `private`.
+
 PostgREST routes `/rest/v1/rpc/*` only to the schemas in its `db-schemas` list
 (`public, graphql_public`), so a function in `private` is unreachable from the
 API while RLS can still call it. `anon`/`authenticated` hold `USAGE` on the
@@ -601,6 +620,8 @@ person has an `active` membership whose plan `kind <> 'trial'` and whose
 PUBLIC/anon and granted to `authenticated` (it is evaluated inside RLS as the
 querying role) + `service_role`. It is acknowledged in
 `supabase/lint/advisors-allowlist.txt` for the same reason as `has_role`.
+Like `has_role`, it answers only about `auth.uid()` unless the caller is the
+service role — see the routable-is-not-answerable note under "Client grants".
 
 ### `calendar_series` — the repeat rule for an event
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "deps": "bash scripts/bun-install.sh",
+    "hooks": "bash scripts/install-git-hooks.sh",
     "dev": "vite dev",
     "build": "vite build",
     "build:dev": "vite build --mode development",

--- a/scripts/bun-install.sh
+++ b/scripts/bun-install.sh
@@ -37,6 +37,11 @@ if [[ $# -gt 0 ]]; then
   exit 2
 fi
 
+# Versioned git hooks (pre-commit guards the tracked `.env`). Cheap, idempotent,
+# and a no-op outside a git checkout, so it rides along with the normal install
+# rather than needing a separate step people forget. See scripts/install-git-hooks.sh.
+bash scripts/install-git-hooks.sh
+
 LOCK="bun.lock"
 
 if [[ ! -f "$LOCK" ]]; then

--- a/scripts/check-committed-env.mjs
+++ b/scripts/check-committed-env.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env bun
+//
+// Fail if the COMMITTED `.env` ever holds something that is not publishable.
+//
+// `.env` is tracked in this repo on purpose: Lovable Cloud generates it
+// (gpt-engineer-app[bot] wrote every version of it) and re-creates it on the
+// next Cloud sync, so removing it or adding it to .gitignore just starts a
+// churn fight with the platform. See CLAUDE.md > Environment variables.
+//
+// The catch is that a tracked `.env` is a loaded gun once the repo is public:
+// the file a person naturally reaches for when they need a service-role key
+// locally is the one already under version control, and `git add -A` commits
+// it without comment. Nothing else in the pipeline would notice — the value is
+// syntactically ordinary and the build stays green. So this checker is the
+// thing that notices.
+//
+// It reads what git has, NOT the working copy. A developer keeping a local
+// SUPABASE_SERVICE_ROLE_KEY in their own `.env` to run scripts against a local
+// stack is fine and expected; only committing it is the problem. Checking the
+// working copy would punish the safe case and miss nothing extra.
+//
+// Two independent rules, because either alone has a blind spot:
+//
+//   * an allowlist of KEY NAMES — catches a secret whose value shape we do not
+//     recognise (a bare hex token, an opaque vendor string);
+//   * a deny-list of VALUE SHAPES — catches a secret smuggled in under a
+//     harmless-looking or VITE_-prefixed name, which the allowlist would only
+//     flag as "unknown" and a reviewer might wave through.
+//
+// A new key from Lovable fails this check by design: that is the review gate.
+// If the new value really is publishable (the Google Picker API key discussed
+// for the Drive folder picker would be), add it to PUBLISHABLE_ENV_KEYS below
+// in the same commit, and say in the message why it is safe to publish.
+//
+// Run:  bun scripts/check-committed-env.mjs
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Env var names allowed to appear in the committed `.env`.
+ *
+ * Every one of these is public by design: the `VITE_*` values are baked into
+ * the browser bundle at build time and can be read out of jitsu.au with
+ * devtools, and their unprefixed twins are the same values for SSR. The
+ * publishable key is the Supabase `anon` key, which is safe because RLS and
+ * table grants are the boundary, not the key's secrecy.
+ */
+export const PUBLISHABLE_ENV_KEYS = new Set([
+  "SUPABASE_PROJECT_ID",
+  "SUPABASE_PUBLISHABLE_KEY",
+  "SUPABASE_URL",
+  "VITE_SUPABASE_PROJECT_ID",
+  "VITE_SUPABASE_PUBLISHABLE_KEY",
+  "VITE_SUPABASE_URL",
+  "VITE_GOOGLE_OAUTH_CLIENT_ID",
+]);
+
+/**
+ * Names we know are secrets, so the failure can say so outright rather than
+ * calling them merely unrecognised. Everything the server reads from
+ * `process.env` that is not in PUBLISHABLE_ENV_KEYS belongs here.
+ */
+const KNOWN_SECRET_KEYS = new Set([
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "LOVABLE_API_KEY",
+  "LOVABLE_SEND_URL",
+  "MANAGER_AGENT_API_KEY",
+  "NOTIFICATION_DIGEST_KEY",
+  "APP_USER_CONNECTION_KEY_SECRET",
+  "GOOGLE_DRIVE_APP_USER_CONNECTOR_CLIENT_API_KEY",
+]);
+
+/** Value shapes that are a credential whatever key they are hiding behind. */
+const SECRET_VALUE_SHAPES = [
+  [/^sb_secret_/, "a Supabase secret key"],
+  [/^sbp_/, "a Supabase personal access token"],
+  [/^sk-ant-/, "an Anthropic API key"],
+  [/^gh[pousr]_[A-Za-z0-9]{20,}/, "a GitHub token"],
+  [/^github_pat_/, "a GitHub fine-grained token"],
+  [/^AKIA[0-9A-Z]{16}$/, "an AWS access key id"],
+  [/^xox[baprs]-/, "a Slack token"],
+  [/-----BEGIN [A-Z ]*PRIVATE KEY/, "a private key"],
+  [/^postgres(ql)?:\/\/[^@]*:[^@]+@/, "a Postgres connection string with a password"],
+];
+
+/** Decode a JWT payload, or null if `value` is not a readable JWT. */
+export function jwtPayload(value) {
+  const parts = value.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+    return JSON.parse(Buffer.from(padded, "base64").toString("utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/** Strip one layer of matching surrounding quotes. */
+function unquote(raw) {
+  const trimmed = raw.trim();
+  const quoted = /^"(.*)"$/s.exec(trimmed) ?? /^'(.*)'$/s.exec(trimmed);
+  return quoted ? quoted[1] : trimmed;
+}
+
+/**
+ * Parse `.env` text into `{ key, value, line }` records, skipping blanks and
+ * comments. Deliberately permissive about `export KEY=` and unquoted values:
+ * this is a security check, so anything a shell or bun would load has to be
+ * seen, not just the exact shape Lovable writes today.
+ */
+export function parseEnv(text) {
+  const entries = [];
+  text.split(/\r?\n/).forEach((raw, index) => {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) return;
+    const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$/s.exec(line);
+    if (!match) return;
+    entries.push({ key: match[1], value: unquote(match[2]), line: index + 1 });
+  });
+  return entries;
+}
+
+/**
+ * Audit parsed `.env` text. Returns one finding per problem, each naming the
+ * key, the line, and what to do about it. An empty array means the file holds
+ * only publishable values.
+ */
+export function auditEnv(text) {
+  const findings = [];
+
+  for (const { key, value, line } of parseEnv(text)) {
+    if (KNOWN_SECRET_KEYS.has(key)) {
+      findings.push({
+        key,
+        line,
+        reason: `${key} is a secret and must never be committed. Keep it in Lovable Cloud project secrets (server runtime only).`,
+      });
+    } else if (!PUBLISHABLE_ENV_KEYS.has(key)) {
+      findings.push({
+        key,
+        line,
+        reason: `${key} is not in the publishable allowlist. If it really is public (a VITE_ value is baked into the browser bundle either way), add it to PUBLISHABLE_ENV_KEYS in scripts/check-committed-env.mjs and say why in the commit. If it is a secret, remove it and move it to Lovable Cloud project secrets.`,
+      });
+    }
+
+    // Value-shape rules run for every key, including allowlisted ones: the
+    // point is to catch a real credential pasted over a name we trust.
+    for (const [pattern, description] of SECRET_VALUE_SHAPES) {
+      if (pattern.test(value)) {
+        findings.push({
+          key,
+          line,
+          reason: `${key} holds what looks like ${description}. Remove it and rotate the credential.`,
+        });
+      }
+    }
+
+    const payload = jwtPayload(value);
+    if (payload && typeof payload.role === "string" && payload.role !== "anon") {
+      findings.push({
+        key,
+        line,
+        reason: `${key} is a JWT with role "${payload.role}". Only the "anon" key is publishable. Remove it and rotate the credential.`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * The committed `.env`, or null when git tracks no such file (nothing to
+ * check, which is a pass).
+ */
+function committedEnv() {
+  try {
+    return execFileSync("git", ["show", "HEAD:.env"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+function main() {
+  const text = committedEnv();
+  if (text === null) {
+    console.log("[env-check] no .env is committed — nothing to check.");
+    return;
+  }
+
+  const findings = auditEnv(text);
+  if (findings.length === 0) {
+    console.log("[env-check] committed .env holds only publishable values.");
+    return;
+  }
+
+  console.error("The committed .env holds something that must not be public.\n");
+  for (const { line, reason } of findings) {
+    console.error(`  .env:${line}  ${reason}`);
+  }
+  console.error(
+    "\nThis repo's .env is tracked because Lovable Cloud generates it. That makes it\n" +
+      "the easiest file to leak a secret through. See CLAUDE.md > Environment variables.",
+  );
+  process.exitCode = 1;
+}
+
+// Run as a script (`bun scripts/check-committed-env.mjs`) rather than imported.
+// Compared against argv rather than `import.meta.main`, which node only grew
+// recently and which this file has to behave the same under.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/check-committed-env.mjs
+++ b/scripts/check-committed-env.mjs
@@ -19,6 +19,20 @@
 // stack is fine and expected; only committing it is the problem. Checking the
 // working copy would punish the safe case and miss nothing extra.
 //
+// Which "what git has" depends on who is asking, hence the two modes:
+//
+//   --staged   the index (`:.env`) — what THIS commit is about to contain.
+//              Used by the pre-commit hook in `.githooks/`, so a secret is
+//              caught before the commit object exists and there is nothing to
+//              rotate. `git commit -a` stages tracked edits before hooks run,
+//              so the index is the right thing to read there too.
+//   (default)  HEAD (`HEAD:.env`) — what is already committed. Used by CI.
+//
+// The hook is the fast feedback and CI is the enforcement; keep both. A hook
+// only runs for people who installed it, is skipped by `--no-verify`, and does
+// not exist at all on Lovable's side — and Lovable is the one committing this
+// file. CI is the only check none of that can bypass.
+//
 // Two independent rules, because either alone has a blind spot:
 //
 //   * an allowlist of KEY NAMES — catches a secret whose value shape we do not
@@ -172,12 +186,21 @@ export function auditEnv(text) {
 }
 
 /**
- * The committed `.env`, or null when git tracks no such file (nothing to
- * check, which is a pass).
+ * Which `.env` to audit, as a git revision. `--staged` reads the index (what
+ * this commit will contain), anything else reads HEAD (what is already
+ * committed). Pure, so the mode selection is testable without running git.
  */
-function committedEnv() {
+export function gitRevisionFor(argv) {
+  return argv.includes("--staged") ? ":.env" : "HEAD:.env";
+}
+
+/**
+ * `.env` at `revision`, or null when git has no such file there (nothing to
+ * check, which is a pass — a fresh clone before the first commit, say).
+ */
+function envAt(revision) {
   try {
-    return execFileSync("git", ["show", "HEAD:.env"], {
+    return execFileSync("git", ["show", revision], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     });
@@ -187,19 +210,27 @@ function committedEnv() {
 }
 
 function main() {
-  const text = committedEnv();
+  const revision = gitRevisionFor(process.argv.slice(2));
+  const staged = revision === ":.env";
+  const subject = staged ? "staged" : "committed";
+
+  const text = envAt(revision);
   if (text === null) {
-    console.log("[env-check] no .env is committed — nothing to check.");
+    console.log(`[env-check] no ${subject} .env — nothing to check.`);
     return;
   }
 
   const findings = auditEnv(text);
   if (findings.length === 0) {
-    console.log("[env-check] committed .env holds only publishable values.");
+    console.log(`[env-check] ${subject} .env holds only publishable values.`);
     return;
   }
 
-  console.error("The committed .env holds something that must not be public.\n");
+  console.error(
+    staged
+      ? "This commit would put something in .env that must not be public.\n"
+      : "The committed .env holds something that must not be public.\n",
+  );
   for (const { line, reason } of findings) {
     console.error(`  .env:${line}  ${reason}`);
   }
@@ -207,6 +238,12 @@ function main() {
     "\nThis repo's .env is tracked because Lovable Cloud generates it. That makes it\n" +
       "the easiest file to leak a secret through. See CLAUDE.md > Environment variables.",
   );
+  if (staged) {
+    console.error(
+      "\nTo unstage it:  git restore --staged .env\n" +
+        "Your working copy is untouched — a local secret is fine, a committed one is not.",
+    );
+  }
   process.exitCode = 1;
 }
 

--- a/scripts/check-committed-env.test.mjs
+++ b/scripts/check-committed-env.test.mjs
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { PUBLISHABLE_ENV_KEYS, auditEnv, jwtPayload, parseEnv } from "./check-committed-env.mjs";
+
+/** Build an unsigned JWT carrying `payload`, the shape Supabase keys have. */
+function jwt(payload) {
+  const encode = (value) =>
+    Buffer.from(JSON.stringify(value)).toString("base64url").replace(/=+$/, "");
+  return `${encode({ alg: "HS256", typ: "JWT" })}.${encode(payload)}.SIGNATURE`;
+}
+
+const ANON_KEY = jwt({ iss: "supabase", ref: "abc", role: "anon" });
+const SERVICE_ROLE_KEY = jwt({ iss: "supabase", ref: "abc", role: "service_role" });
+
+/** The committed `.env` as Lovable writes it today: the case that must pass. */
+const PUBLISHABLE_ENV = [
+  'SUPABASE_PROJECT_ID="abcdefghijklmnopqrst"',
+  `SUPABASE_PUBLISHABLE_KEY="${ANON_KEY}"`,
+  'SUPABASE_URL="https://c--0000-prod.lovable.cloud"',
+  'VITE_SUPABASE_PROJECT_ID="abcdefghijklmnopqrst"',
+  `VITE_SUPABASE_PUBLISHABLE_KEY="${ANON_KEY}"`,
+  'VITE_SUPABASE_URL="https://c--0000-prod.lovable.cloud"',
+  'VITE_GOOGLE_OAUTH_CLIENT_ID="626329413356-abc.apps.googleusercontent.com"',
+].join("\n");
+
+describe("parseEnv", () => {
+  it("reads quoted, unquoted and export-prefixed assignments", () => {
+    const entries = parseEnv(['A="one"', "B=two", "export C='three'"].join("\n"));
+    expect(entries).toEqual([
+      { key: "A", value: "one", line: 1 },
+      { key: "B", value: "two", line: 2 },
+      { key: "C", value: "three", line: 3 },
+    ]);
+  });
+
+  it("skips blanks and comments, and reports 1-indexed line numbers", () => {
+    const entries = parseEnv(["# a comment", "", 'REAL="x"'].join("\n"));
+    expect(entries).toEqual([{ key: "REAL", value: "x", line: 3 }]);
+  });
+});
+
+describe("jwtPayload", () => {
+  it("decodes a JWT payload", () => {
+    expect(jwtPayload(ANON_KEY)).toMatchObject({ role: "anon" });
+  });
+
+  it("returns null for anything that is not a JWT", () => {
+    expect(jwtPayload("https://example.com")).toBeNull();
+    expect(jwtPayload("a.b")).toBeNull();
+  });
+});
+
+describe("auditEnv", () => {
+  it("passes the publishable set Lovable commits today", () => {
+    expect(auditEnv(PUBLISHABLE_ENV)).toEqual([]);
+  });
+
+  it("keeps every allowlisted key in step with that file", () => {
+    // If Lovable adds a key and someone allowlists it without updating this
+    // fixture, the fixture stops proving the real file passes.
+    const keys = parseEnv(PUBLISHABLE_ENV).map((entry) => entry.key);
+    expect(new Set(keys)).toEqual(PUBLISHABLE_ENV_KEYS);
+  });
+
+  it("rejects a service-role key by name", () => {
+    const findings = auditEnv(
+      `${PUBLISHABLE_ENV}\nSUPABASE_SERVICE_ROLE_KEY="${SERVICE_ROLE_KEY}"`,
+    );
+    expect(findings).toHaveLength(2); // the name rule and the JWT-role rule
+    expect(findings.every((f) => f.key === "SUPABASE_SERVICE_ROLE_KEY")).toBe(true);
+    expect(findings[0].reason).toContain("must never be committed");
+  });
+
+  it("rejects a service-role JWT hiding behind an allowlisted name", () => {
+    // The allowlist alone would wave this through: the key name is one we
+    // expect. Only the value-shape rule catches it.
+    const findings = auditEnv(
+      PUBLISHABLE_ENV.replace(
+        `VITE_SUPABASE_PUBLISHABLE_KEY="${ANON_KEY}"`,
+        `VITE_SUPABASE_PUBLISHABLE_KEY="${SERVICE_ROLE_KEY}"`,
+      ),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].key).toBe("VITE_SUPABASE_PUBLISHABLE_KEY");
+    expect(findings[0].reason).toContain('role "service_role"');
+  });
+
+  it("rejects an unrecognised key so a new one gets a human look", () => {
+    const findings = auditEnv(`${PUBLISHABLE_ENV}\nVITE_SOMETHING_NEW="whatever"`);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].key).toBe("VITE_SOMETHING_NEW");
+    expect(findings[0].reason).toContain("not in the publishable allowlist");
+  });
+
+  it.each([
+    ["a Supabase secret key", "sb_secret_abcdefghijklmnop"],
+    ["a Supabase access token", "sbp_0123456789abcdef0123456789abcdef01234567"],
+    ["a GitHub token", "ghp_0123456789abcdefghijklmnopqrstuvwxyz"],
+    ["an AWS access key id", "AKIAIOSFODNN7EXAMPLE"],
+    ["a Slack token", "xoxb-000000-000000-abcdefghijklmnop"],
+    ["a private key", "-----BEGIN RSA PRIVATE KEY-----"],
+    [
+      "a Postgres URL with a password",
+      "postgresql://postgres:hunter2@db.example.com:5432/postgres",
+    ],
+  ])("rejects %s whatever key it is under", (_label, value) => {
+    const findings = auditEnv(`${PUBLISHABLE_ENV}\nVITE_SUPABASE_URL="${value}"`);
+    expect(findings.some((f) => f.key === "VITE_SUPABASE_URL")).toBe(true);
+  });
+
+  it("reports the line number so the failure points at the offending row", () => {
+    const findings = auditEnv(`${PUBLISHABLE_ENV}\nLOVABLE_API_KEY="anything"`);
+    expect(findings[0].line).toBe(8);
+  });
+
+  it("passes when nothing is committed", () => {
+    expect(auditEnv("")).toEqual([]);
+  });
+});

--- a/scripts/check-committed-env.test.mjs
+++ b/scripts/check-committed-env.test.mjs
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { PUBLISHABLE_ENV_KEYS, auditEnv, jwtPayload, parseEnv } from "./check-committed-env.mjs";
+import {
+  PUBLISHABLE_ENV_KEYS,
+  auditEnv,
+  gitRevisionFor,
+  jwtPayload,
+  parseEnv,
+} from "./check-committed-env.mjs";
 
 /** Build an unsigned JWT carrying `payload`, the shape Supabase keys have. */
 function jwt(payload) {
@@ -47,6 +53,18 @@ describe("jwtPayload", () => {
   it("returns null for anything that is not a JWT", () => {
     expect(jwtPayload("https://example.com")).toBeNull();
     expect(jwtPayload("a.b")).toBeNull();
+  });
+});
+
+describe("gitRevisionFor", () => {
+  it("reads the index under --staged, which is what a commit will contain", () => {
+    // The pre-commit hook depends on this: HEAD would be the PREVIOUS commit,
+    // so a hook reading it would pass the very commit introducing the secret.
+    expect(gitRevisionFor(["--staged"])).toBe(":.env");
+  });
+
+  it("reads HEAD by default, which is what CI checks", () => {
+    expect(gitRevisionFor([])).toBe("HEAD:.env");
   });
 });
 

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Point git at the repo's versioned hooks (`.githooks/`).
+#
+# Git's own hook directory (`.git/hooks`) is not versioned, so a hook written
+# there reaches exactly one machine. `core.hooksPath` moves the whole directory
+# into the repo, which is why the hooks live in `.githooks/` and this one-liner
+# exists to switch it on. It is a local git config change: per-clone, reversible
+# with `git config --unset core.hooksPath`, and invisible to everyone else.
+#
+# `bun run deps` runs this, so a normal install sets it up. Safe to re-run.
+#
+# Deliberately not husky: that would mean a new dependency, and adding one here
+# means editing package.json and waiting for Lovable to re-resolve the lockfile
+# (CLAUDE.md > Lock file strategy). Two git config lines do not justify that.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# No-op outside a git checkout (a tarball export, some CI images).
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+chmod +x .githooks/* 2>/dev/null || true
+
+if [[ "$(git config --get core.hooksPath || true)" == ".githooks" ]]; then
+  exit 0
+fi
+
+git config core.hooksPath .githooks
+echo "[hooks] core.hooksPath -> .githooks (pre-commit now guards .env)"

--- a/src/lib/code-of-conduct.functions.ts
+++ b/src/lib/code-of-conduct.functions.ts
@@ -64,8 +64,6 @@ export type CodeOfConductSigner = {
   email: string;
   /** True when a session identified them (rather than an emailed token). */
   signedIn: boolean;
-  /** True when an emailed token identified them, so the click proves the address. */
-  fromToken: boolean;
 };
 
 /**
@@ -86,7 +84,6 @@ async function resolveSigner(
   let userId: string | null = null;
   let email: string | null = null;
   let signedIn = false;
-  let fromToken = false;
 
   if (bearer) {
     try {
@@ -105,7 +102,11 @@ async function resolveSigner(
   if (!userId && raw) {
     const { lookupVerificationToken } = await import("@/lib/email-verification.server");
     const { tokenProvesEmail } = await import("@/lib/email-verification");
-    const found = await lookupVerificationToken(admin, raw);
+    // The only token this page is ever linked with. Scoped so an interest or
+    // waiver token cannot be spent here either.
+    const found = await lookupVerificationToken(admin, raw, {
+      purposes: ["code_of_conduct"],
+    });
     if (found) {
       // A lead's token carries no user id, so re-resolve the address. Signing
       // the code of conduct never CREATES a person: someone whose address the
@@ -124,7 +125,6 @@ async function resolveSigner(
         if (got?.user?.email && tokenProvesEmail(found.email, got.user.email)) {
           userId = tokenUserId;
           email = got.user.email;
-          fromToken = true;
           // Best-effort, like every other redemption stamp on this table: a
           // PostgrestBuilder is a lazy thenable, so the .then() is what issues
           // the request and a failure here must not block signing.
@@ -160,7 +160,6 @@ async function resolveSigner(
     greetingName: greetingName(profile) || email,
     email,
     signedIn,
-    fromToken,
   };
 }
 
@@ -296,17 +295,13 @@ export const acceptCodeOfConduct = createServerFn({ method: "POST" })
     });
     if (error) throw new Error(error.message);
 
-    // Arriving from the emailed link is itself proof the address is real, so
-    // record it. Best-effort: the agreement is already saved, and a hiccup in a
-    // side benefit must not surface as a failed signature.
-    if (signer.fromToken) {
-      const { error: confirmErr } = await admin.auth.admin.updateUserById(signer.userId, {
-        email_confirm: true,
-      });
-      if (confirmErr) {
-        console.error("[acceptCodeOfConduct] could not record email verification:", confirmErr);
-      }
-    }
+    // Signing does NOT confirm the email address, even though arriving here from
+    // a link looks like proof. The code-of-conduct token is handed back by
+    // `submitWaiverWithPdf` in its HTTP response so the button works straight
+    // after signing a waiver, and waiver signing is public — so anyone could
+    // mint one for any address and spend it here. See `mailboxProvingPurposes`.
+    // The waiver confirmation email carries its own "confirm your email address"
+    // button, which only ever exists inside that email, and that one does.
 
     return { ok: true as const, accepted_at };
   });

--- a/src/lib/email-verification.server.test.ts
+++ b/src/lib/email-verification.server.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/integrations/supabase/types";
-import { redeemVerificationToken } from "./email-verification.server";
-import { verificationExpiry } from "./email-verification";
+import { lookupVerificationToken, redeemVerificationToken } from "./email-verification.server";
+import { mailboxProvingPurposes, verificationExpiry } from "./email-verification";
 
 type TokenRow = {
   id: string;
   user_id: string | null;
   email: string;
+  purpose: string;
   expires_at: string;
   revoked_at: string | null;
 };
@@ -17,6 +18,9 @@ function token(over: Partial<TokenRow> = {}): TokenRow {
     id: "tok-1",
     user_id: null,
     email: "ada@example.com",
+    // A mailbox-proving purpose: this is the "confirm your email address"
+    // button, which only ever exists inside an email we sent.
+    purpose: "waiver",
     expires_at: verificationExpiry(),
     revoked_at: null,
     ...over,
@@ -169,5 +173,89 @@ describe("redeemVerificationToken", () => {
     await redeemVerificationToken(admin, "utsj_raw");
     await redeemVerificationToken(admin, "utsj_raw");
     expect(confirmed).toEqual(["u1", "u1"]);
+  });
+
+  /**
+   * The bug this guards: `submitWaiverWithPdf` returns a live `code_of_conduct`
+   * token in its HTTP response, and waiver signing is public. Before the purpose
+   * check, posting a waiver with somebody else's address and then GETting
+   * /api/verify-email/<that token> stamped their address confirmed — no mailbox
+   * involved. A confirmed address is also what the manager-bootstrap trigger
+   * keys on, so this reached further than a wrong badge.
+   */
+  it("refuses to confirm from a code-of-conduct token, which is handed out in-band", async () => {
+    const { admin, confirmed } = fakeAdmin({
+      row: token({ user_id: "u1", purpose: "code_of_conduct" }),
+      users: { u1: { email: "ada@example.com" } },
+    });
+    await expect(redeemVerificationToken(admin, "utsj_raw")).resolves.toEqual({
+      result: "not_proof",
+      email: "ada@example.com",
+    });
+    expect(confirmed).toEqual([]);
+  });
+
+  it("fails closed on a purpose it does not recognise", async () => {
+    const { admin, confirmed } = fakeAdmin({
+      row: token({ user_id: "u1", purpose: "something_new" }),
+      users: { u1: { email: "ada@example.com" } },
+    });
+    await expect(redeemVerificationToken(admin, "utsj_raw")).resolves.toMatchObject({
+      result: "not_proof",
+    });
+    expect(confirmed).toEqual([]);
+  });
+
+  it.each(["interest", "waiver", "manager_resend", "self_resend", "email_change"])(
+    "still confirms from an emailed %s token",
+    async (purpose) => {
+      const { admin, confirmed } = fakeAdmin({
+        row: token({ user_id: "u1", purpose }),
+        users: { u1: { email: "ada@example.com" } },
+      });
+      await expect(redeemVerificationToken(admin, "utsj_raw")).resolves.toMatchObject({
+        result: "verified",
+      });
+      expect(confirmed).toEqual(["u1"]);
+    },
+  );
+});
+
+/**
+ * The scoping that keeps one flow's token out of another's hands. Both callers
+ * go through here, so this is the seam worth pinning rather than either handler.
+ */
+describe("lookupVerificationToken", () => {
+  it("returns the row when the purpose is one the caller accepts", async () => {
+    const { admin } = fakeAdmin({ row: token({ user_id: "u1", purpose: "waiver" }) });
+    await expect(
+      lookupVerificationToken(admin, "utsj_raw", { purposes: ["interest", "waiver"] }),
+    ).resolves.toMatchObject({ id: "tok-1", email: "ada@example.com", purpose: "waiver" });
+  });
+
+  it("returns null for a live token minted for a different flow", async () => {
+    // The waiver's `vt` proof asks for mailbox-proving purposes only. A
+    // code-of-conduct token is live and well-formed, but it was handed to the
+    // submitter in an HTTP response, so it must not answer this question.
+    const { admin } = fakeAdmin({ row: token({ user_id: "u1", purpose: "code_of_conduct" }) });
+    await expect(
+      lookupVerificationToken(admin, "utsj_raw", { purposes: mailboxProvingPurposes }),
+    ).resolves.toBeNull();
+  });
+
+  it("refuses an interest token offered to the code-of-conduct page", async () => {
+    const { admin } = fakeAdmin({ row: token({ user_id: "u1", purpose: "interest" }) });
+    await expect(
+      lookupVerificationToken(admin, "utsj_raw", { purposes: ["code_of_conduct"] }),
+    ).resolves.toBeNull();
+  });
+
+  it("still rejects an expired token whose purpose is accepted", async () => {
+    const { admin } = fakeAdmin({
+      row: token({ user_id: "u1", purpose: "waiver", expires_at: "2020-01-01T00:00:00.000Z" }),
+    });
+    await expect(
+      lookupVerificationToken(admin, "utsj_raw", { purposes: ["waiver"] }),
+    ).resolves.toBeNull();
   });
 });

--- a/src/lib/email-verification.server.ts
+++ b/src/lib/email-verification.server.ts
@@ -18,6 +18,7 @@ import { normalizeEmail } from "@/lib/validation";
 import {
   buildVerifyUrl,
   isVerificationTokenLive,
+  purposeProvesMailbox,
   tokenProvesEmail,
   verificationExpiry,
   type VerificationPurpose,
@@ -88,15 +89,23 @@ export async function revokeVerificationTokensForEmail(
  * ask "was this address proven?" WITHOUT confirming anything yet: at that point
  * the person may not exist, and the answer decides whether they are created
  * confirmed. Returns null for anything expired, revoked, or unknown.
+ *
+ * **Always pass `purposes`.** A token is a capability, and until this argument
+ * existed the lookup matched on hash alone — so a token minted for one flow
+ * authenticated a completely different one. The code-of-conduct token, which
+ * `submitWaiverWithPdf` hands back in its HTTP response, was therefore a valid
+ * `vt` for the next waiver submission. Naming the purposes a call site accepts
+ * keeps each flow to the tokens it actually issues.
  */
 export async function lookupVerificationToken(
   admin: AdminClient,
   rawToken: string,
-): Promise<{ id: string; user_id: string | null; email: string } | null> {
+  opts: { purposes: readonly VerificationPurpose[] },
+): Promise<{ id: string; user_id: string | null; email: string; purpose: string } | null> {
   const token_hash = await hashToken(rawToken);
   const { data: row, error } = await admin
     .from("email_verification_tokens")
-    .select("id, user_id, email, expires_at, revoked_at")
+    .select("id, user_id, email, purpose, expires_at, revoked_at")
     .eq("token_hash", token_hash)
     .is("revoked_at", null)
     .maybeSingle();
@@ -105,7 +114,9 @@ export async function lookupVerificationToken(
   // present as "nobody is arriving from their email any more".
   if (error) console.error("[email-verification] token lookup failed:", error);
   if (!row || !isVerificationTokenLive(row)) return null;
-  return { id: row.id, user_id: row.user_id, email: row.email };
+  // A token for another flow is as good as no token here.
+  if (!(opts.purposes as readonly string[]).includes(row.purpose)) return null;
+  return { id: row.id, user_id: row.user_id, email: row.email, purpose: row.purpose };
 }
 
 /** What a redemption did, for the caller to log or act on. Never shown to a visitor. */
@@ -116,6 +127,11 @@ export type RedemptionOutcome =
   | { result: "no_person"; email: string }
   /** Live token whose address no longer matches the account's. Deliberately inert. */
   | { result: "stale"; email: string; userId: string }
+  /**
+   * Live token, but minted for a purpose that does not prove the mailbox (see
+   * `mailboxProvingPurposes`). Redeeming it confirms nothing.
+   */
+  | { result: "not_proof"; email: string }
   /** The address is now confirmed (or already was). */
   | { result: "verified"; email: string; userId: string };
 
@@ -135,7 +151,7 @@ export async function redeemVerificationToken(
   const token_hash = await hashToken(rawToken);
   const { data: row, error: lookupErr } = await admin
     .from("email_verification_tokens")
-    .select("id, user_id, email, expires_at, revoked_at")
+    .select("id, user_id, email, purpose, expires_at, revoked_at")
     .eq("token_hash", token_hash)
     .is("revoked_at", null)
     .maybeSingle();
@@ -143,6 +159,14 @@ export async function redeemVerificationToken(
   // regardless, so a broken read would otherwise be entirely silent.
   if (lookupErr) console.error("[email-verification] token lookup failed:", lookupErr);
   if (!row || !isVerificationTokenLive(row)) return { result: "no_token" };
+
+  // This endpoint is a public GET, so it is the cheapest way to turn a token
+  // into a confirmed address: one request, no session, no form. That is fine
+  // for a token only an inbox could hold, and unacceptable for one we handed
+  // to whoever asked — see `mailboxProvingPurposes`.
+  if (!purposeProvesMailbox(row.purpose)) {
+    return { result: "not_proof", email: row.email };
+  }
 
   // Stamp the redemption. Best-effort: a PostgrestBuilder is a lazy thenable,
   // so the .then() is what actually issues the request (and swallows failure).

--- a/src/lib/email-verification.test.ts
+++ b/src/lib/email-verification.test.ts
@@ -6,8 +6,11 @@ import {
   emailVerificationLabel,
   isEmailVerified,
   isVerificationTokenLive,
+  mailboxProvingPurposes,
+  purposeProvesMailbox,
   tokenProvesEmail,
   verificationExpiry,
+  verificationPurposes,
   verifyRedirectPath,
 } from "./email-verification";
 
@@ -130,5 +133,34 @@ describe("buildVerifyUrl", () => {
     });
     expect(url).toContain("next=%2Faccount");
     expect(url).not.toContain("evil.example");
+  });
+});
+
+describe("purposeProvesMailbox", () => {
+  it("accepts every purpose whose token only ever arrives by email", () => {
+    for (const purpose of ["interest", "waiver", "manager_resend", "self_resend", "email_change"]) {
+      expect(purposeProvesMailbox(purpose)).toBe(true);
+    }
+  });
+
+  it("rejects code_of_conduct, whose token is returned in a waiver's own response", () => {
+    // Not a badge quibble. `submitWaiverWithPdf` is public and hands this token
+    // to whoever posted the form, so treating it as mailbox proof let anyone
+    // confirm any address — and a confirmed address is what the club's
+    // manager-bootstrap trigger keys on.
+    expect(purposeProvesMailbox("code_of_conduct")).toBe(false);
+  });
+
+  it("fails closed on an unknown purpose", () => {
+    expect(purposeProvesMailbox("something_new")).toBe(false);
+    expect(purposeProvesMailbox("")).toBe(false);
+  });
+
+  it("keeps mailboxProvingPurposes a strict subset of the declared purposes", () => {
+    // Guards the filter: a new purpose added to `verificationPurposes` lands in
+    // the proving set by default, so anything that must not prove a mailbox has
+    // to be excluded deliberately, the way code_of_conduct is.
+    expect(mailboxProvingPurposes.every((p) => verificationPurposes.includes(p))).toBe(true);
+    expect(mailboxProvingPurposes).not.toContain("code_of_conduct");
   });
 });

--- a/src/lib/email-verification.ts
+++ b/src/lib/email-verification.ts
@@ -46,12 +46,55 @@ export const verificationPurposes = [
    * The "sign the code of conduct" link, offered after a waiver and repeated in
    * the confirmation email. Someone who has just signed a waiver is a locked
    * applicant with no way to log in, so this token is how they prove who they
-   * are when they come back to it days later. Opening it proves the mailbox as
-   * well, like every other token here.
+   * are when they come back to it days later.
+   *
+   * Unlike every other purpose here, it does NOT prove the mailbox — see
+   * `mailboxProvingPurposes`.
    */
   "code_of_conduct",
 ] as const;
 export type VerificationPurpose = (typeof verificationPurposes)[number];
+
+/**
+ * The purposes whose token is only ever DELIVERED BY EMAIL, and which therefore
+ * prove control of the mailbox when one comes back to us.
+ *
+ * `code_of_conduct` is deliberately absent, and that absence is load-bearing.
+ * Its token is emailed, but `submitWaiverWithPdf` also returns it to the caller
+ * in the HTTP response, so the "sign the code of conduct" button can work the
+ * moment a waiver is signed. Waiver signing is public and unauthenticated, so
+ * anyone can post any address and be handed a live token for it without a
+ * single email being read. A value we give to whoever asked proves nothing
+ * about who reads that inbox.
+ *
+ * So the token still IDENTIFIES a signer (that is what it is for, and a locked
+ * applicant has no other way to say who they are), but it must never reach a
+ * path that stamps `auth.users.email_confirmed_at`. Three paths would otherwise
+ * take it: the public `/api/verify-email/<token>` redemption, the waiver's own
+ * `vt` proof, and the code-of-conduct acceptance. Each now asks this question
+ * first.
+ *
+ * That matters beyond a wrong badge: a confirmed address is what the
+ * `handle_new_user_role` trigger keys the club's manager bootstrap on.
+ *
+ * The capability is not lost. The waiver confirmation email carries its own
+ * `waiver`-purpose "confirm your email address" button, which is mailbox-proving
+ * because it only ever exists inside that email.
+ */
+export const mailboxProvingPurposes = verificationPurposes.filter(
+  (purpose) => purpose !== "code_of_conduct",
+);
+
+/**
+ * Does a token minted for this purpose prove the address it names?
+ *
+ * Takes a plain string because the value arrives from the database, where the
+ * CHECK constraint is the only thing keeping it in the union. An unrecognised
+ * purpose fails closed.
+ */
+export function purposeProvesMailbox(purpose: string): boolean {
+  return (mailboxProvingPurposes as readonly string[]).includes(purpose);
+}
 
 /** ISO expiry for a token minted at `now`. */
 export function verificationExpiry(now: Date = new Date()): string {

--- a/src/lib/waiver.functions.ts
+++ b/src/lib/waiver.functions.ts
@@ -130,8 +130,14 @@ async function proveSubmittedEmail(
   if (!raw) return false;
   try {
     const { lookupVerificationToken } = await import("@/lib/email-verification.server");
-    const { tokenProvesEmail } = await import("@/lib/email-verification");
-    const token = await lookupVerificationToken(admin, raw);
+    const { tokenProvesEmail, mailboxProvingPurposes } = await import("@/lib/email-verification");
+    // Only a token that reached an inbox can answer this. Notably that excludes
+    // the code-of-conduct token, which this very handler returns to the caller
+    // in its response — without this scope, one submission's response token was
+    // the next submission's proof of the same address.
+    const token = await lookupVerificationToken(admin, raw, {
+      purposes: mailboxProvingPurposes,
+    });
     return Boolean(token && tokenProvesEmail(token.email, submittedEmail));
   } catch (e) {
     console.error("[submitWaiverWithPdf] verification token lookup failed:", e);

--- a/supabase/migrations/20260820000000_scope_role_helpers_to_caller.sql
+++ b/supabase/migrations/20260820000000_scope_role_helpers_to_caller.sql
@@ -1,0 +1,94 @@
+-- Stop `has_role` and `has_active_paid_membership` answering about other people.
+--
+-- Both are SECURITY DEFINER and both hold `EXECUTE` for `authenticated`, because
+-- RLS policies call them and a policy runs as the querying role. But a function
+-- `authenticated` may execute is also reachable as `POST /rest/v1/rpc/<name>`
+-- with the anon key and any session — and neither one restricted `_user_id`.
+-- So any signed-in person could ask, about ANY uuid: is this account a manager?
+-- is it a paying member?
+--
+-- Uuids are not hard to come by. `blog_comments` exposes `user_id` under its
+-- public SELECT grant next to the commenter's name, and `calendar_events`
+-- exposes `created_by`. That turns a general oracle into a targeted one: pick a
+-- named person off the blog, learn their club status. This repo already closed
+-- exactly this shape once — `20260802000000_private_rls_helpers.sql` moved
+-- `event_is_invite_only`, `is_event_invitee` and `is_commenter_blocked` into the
+-- non-exposed `private` schema, citing advisors 0028/0029 and the same
+-- "callable with any uuid the caller likes" reasoning. These two were left in
+-- `public` because server code calls them as RPCs, so they need the other fix:
+-- keep them callable, and make them refuse the question.
+--
+-- The rule: answer only about yourself, unless there is no `auth.uid()` at all.
+--
+--   * RLS policies always pass `auth.uid()`, so they are unaffected.
+--   * Server functions using the caller-scoped client (`requireSupabaseAuth`)
+--     pass `context.userId`, which IS `auth.uid()`.
+--   * Service-role callers have no `auth.uid()` (it is NULL) and must keep
+--     asking about anybody — the notification digest, the manager agent API
+--     checking a token owner, and the calendar feed all do exactly that.
+--   * `anon` cannot reach either function; EXECUTE was revoked from PUBLIC and
+--     anon when each was created, and stays revoked here.
+--
+-- The browser never calls either one: `useRoles` reads its own `user_roles` rows
+-- through RLS instead, so nothing client-side changes.
+--
+-- Both keep returning FALSE rather than NULL or an error when the answer is
+-- refused. `SELECT EXISTS(...)` never returning NULL is a documented contract
+-- these functions rely on (see the RPC-nullability note in CLAUDE.md and
+-- `src/lib/supabase-rpc.ts`), and a refusal that raised would turn a probe into
+-- a different, equally readable signal.
+--
+-- Body logic is otherwise untouched, and no grant changes, so
+-- `supabase/lint/client-grants-expected.txt` needs no edit.
+
+CREATE OR REPLACE FUNCTION public.has_role(_user_id UUID, _role public.app_role)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    (
+      -- NULL means service role (anon holds no EXECUTE), which asks about others
+      -- legitimately. A real session may only ask about itself.
+      (SELECT auth.uid()) IS NULL
+      OR _user_id = (SELECT auth.uid())
+    )
+    AND EXISTS (
+      SELECT 1 FROM public.user_roles
+      WHERE user_id = _user_id AND role = _role
+    )
+$$;
+
+CREATE OR REPLACE FUNCTION public.has_active_paid_membership(_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    (
+      (SELECT auth.uid()) IS NULL
+      OR _user_id = (SELECT auth.uid())
+    )
+    AND EXISTS (
+      SELECT 1
+      FROM public.memberships m
+      JOIN public.membership_plans p ON p.id = m.plan_id
+      WHERE m.user_id = _user_id
+        AND m.status = 'active'
+        AND p.kind <> 'trial'
+        AND m.price_cents > 0
+    )
+$$;
+
+-- Re-assert the grants the bodies rely on. `CREATE OR REPLACE` keeps the
+-- existing ACL, so these are belt-and-braces rather than a change: they restate
+-- the intent next to the code it protects, and make a from-scratch replay land
+-- in the same place as the live database.
+REVOKE EXECUTE ON FUNCTION public.has_role(UUID, public.app_role) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.has_role(UUID, public.app_role) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.has_active_paid_membership(UUID) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.has_active_paid_membership(UUID) TO authenticated, service_role;


### PR DESCRIPTION
Came out of an audit of whether this repo is safe to make public. The repo *contents* are clean — no credential has ever been committed. But stress-testing that conclusion turned up two live security bugs that publication would hand attackers on a plate, and both are fixed here.

## ⚠️ Contains a migration that has NOT been applied

`supabase/migrations/20260820000000_scope_role_helpers_to_caller.sql` is waiting. Per `docs/database-changes.md` it must not run against production until this PR is approved. **Do not merge before applying it.**

What the SQL does: `CREATE OR REPLACE` on `public.has_role(uuid, app_role)` and `public.has_active_paid_membership(uuid)`, adding a caller check to each body. It re-asserts the existing `REVOKE`/`GRANT` on both (no-ops, restated next to the code they protect). It creates nothing, drops nothing, and changes no grants — so `client-grants-expected.txt` is untouched, and it is purely additive in the expand/contract sense.

## 1. An in-band token could confirm any email address

A verification token was matched on its **hash alone**, so it authenticated any flow rather than the one it was minted for. Combined with `submitWaiverWithPdf` returning a live `code_of_conduct` token **in its HTTP response** — so the "sign the code of conduct" button works before any email arrives — anyone could mark any address as verified without ever reading a mailbox. Waiver signing is public and unauthenticated, so the token was there for the asking.

Three paths stamped `auth.users.email_confirmed_at` from it:

- `GET /api/verify-email/<token>` — the cheapest, a single unauthenticated request;
- the waiver's own `?vt=` proof, where one submission's response token was the next submission's proof of the same address;
- accepting the code of conduct.

This reached further than a wrong "verified" badge. A confirmed address is what `handle_new_user_role` keys the club's manager bootstrap on, and the guard added in `20260721091500` assumed confirmation implied a real mailbox.

Fixed as one invariant rather than three patches: `mailboxProvingPurposes` names the purposes whose token is only ever delivered by email, `code_of_conduct` is excluded because it is also handed back in-band, and all three paths ask before confirming. `lookupVerificationToken` now requires callers to declare the purposes they accept.

**What changes for people:** signing the code of conduct no longer marks your email verified. Nothing is lost — the waiver confirmation email carries its own "confirm your email address" button, which only ever exists inside that email.

## 2. Anyone signed in could probe whether a named person is a manager

`has_role` and `has_active_paid_membership` are `SECURITY DEFINER` with `EXECUTE` for `authenticated` (RLS policies need it). But that also makes them reachable as `POST /rest/v1/rpc/<name>` with the anon key and any session, and neither restricted `_user_id`.

Uuids are cheap: `blog_comments` publishes `user_id` under its public SELECT grant beside the commenter's name, and `calendar_events` publishes `created_by`. So it was a targeted oracle — pick a named person off the blog, learn their standing in the club.

This repo closed the same shape once already (`20260802000000` moved three helpers into `private`). These two stayed in `public` because server code calls them as RPCs, so they get the other fix: still callable, but they refuse the question. Each answers only when `_user_id = auth.uid()`, or when there is no `auth.uid()` at all — the service role, which legitimately asks about anybody.

Nothing legitimate changes: RLS policies pass `auth.uid()`, caller-scoped server functions pass `context.userId` (which *is* `auth.uid()`), and every other call site uses the service-role client — checked one by one rather than assumed. The browser never calls either; `useRoles` reads its own `user_roles` rows through RLS.

## 3. A guard for the committed `.env`

`.env` is tracked because Lovable Cloud generates it and re-commits it on every sync (confirmed with Lovable directly), so gitignoring it starts a churn fight rather than removing anything. It holds only publishable values. But in a public repo a tracked `.env` is the easiest way to leak a credential, and nothing would have noticed.

`scripts/check-committed-env.mjs` audits **what git has, not your working copy** — a local service-role key stays fine, committing one does not. Two independent rules, because each covers the other's blind spot: an allowlist of key names, and a deny-list of value shapes (including any JWT whose `role` claim is not `anon`). It runs as a **pre-commit hook** reading the index, so a secret is refused before the commit object exists, and in **CI** reading HEAD. Both are kept deliberately: the hook is bypassable with `--no-verify`, only runs for people who installed it, and does not exist on Lovable's side — which is where this file is actually written.

## 4. Notes, corrected

- CLAUDE.md gains a "This repository is going public" section: rotate rather than revert a leaked credential, keep member data out of commits and PR threads, treat RLS as a live and publicly readable boundary, keep fixtures synthetic.
- The "Environment variables" section said `.env` values were "not committed meaningfully" — the opposite of true, in the file every agent reads first. It now explains what `.env` is, that Lovable owns it, that it must never gain a secret, and that **bun auto-loads it** so any `bun run …` here talks to the live club.
- **`SUPABASE_DB_URL` is not configured.** The repo's docs say CI holds one production credential; the drift job log says `SUPABASE_DB_URL:` empty and `##[warning]… did NOT run`, on every run since inception, while reporting green. Good news for publishing (nothing to leak); bad news operationally — **neither live check has ever run**, so `client-grants-expected.txt` has only ever been verified against the migration files, never against production. Recorded in CLAUDE.md rather than fixed, since setting that secret is a production decision.
- `supabase-lint.yml` was the only workflow with no `permissions:` block, inheriting the repo default token scope while running migrations from a PR's own tree. Now pinned to `contents: read`.

## Audit result

Full history scanned after unshallowing the clone (885 commits, all refs): gitleaks plus an independent entropy pass plus targeted pickaxe for each unprefixed secret name. Exactly one JWT has ever been committed — the `anon` one. No service-role key, `sbp_`/`sb_secret_`, PAT, AWS key, Slack token, or private key anywhere, reachable or dangling. No member PII in migrations, history, commit messages, all 2 issues, all 45 PRs and their comment threads, or the Actions logs sampled. `waivers` storage bucket is private and correctly scoped — a member cannot read another member's waiver row or PDF.

## Still to do before the repo goes public

1. **Run the client-grants check against the live database, by hand, once** — it has never executed, so the boundary is unverified against production. This one is not something I can do.
2. **Deploy fix 1** to the live site.
3. **Apply the migration** for fix 2.

All three need to be live *before* the switch is flipped, because these commits telegraph both bugs.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (1896 passing) and `bun run build` all pass locally; `bun.lock` untouched. The migration was replayed against a throwaway Postgres with `auth.uid()` and the client roles scaffolded, confirming: service role still true, self-query true, another session's probe now false for both functions, result never NULL, `anon` still denied EXECUTE.

CI on this PR is red for an unrelated reason — GitHub Actions has been failing repo-wide since ~01:45Z today with no runner assigned (`runner_id: 0`, no steps), on `main` and unrelated branches too.