### PR TITLE
Make it clear on the home page that the public can join

### DIFF
--- a/scripts/e2e-gallery-report.test.ts
+++ b/scripts/e2e-gallery-report.test.ts
@@ -7,6 +7,7 @@ import {
   collectEntries,
   entrySlug,
   flowGroups,
+  pageAnchor,
   pageGroups,
   shotHref,
   tourProjects,
@@ -249,6 +250,10 @@ describe("buildGalleryHtml", () => {
     expect(html).toContain("/faq");
   });
 
+  it("gives each page a stable id, so a review can link at one screen", () => {
+    expect(html).toContain('id="page-faq"');
+  });
+
   it("says which page failed, in words rather than Playwright's own", () => {
     expect(html).toContain("failed");
     expect(html).not.toContain("unexpected");
@@ -261,6 +266,22 @@ describe("buildGalleryHtml", () => {
     });
     expect(nasty).not.toContain("<script>alert(1)</script>");
     expect(nasty).toContain("&lt;script&gt;");
+  });
+});
+
+describe("pageAnchor", () => {
+  // These ids get pasted into pull request descriptions, so they have to keep
+  // meaning the same screen from one run to the next.
+  it("names a path after itself", () => {
+    expect(pageAnchor("/faq")).toBe("page-faq");
+    expect(pageAnchor("/manager/waivers")).toBe("page-manager-waivers");
+  });
+
+  // "/" slugs to nothing, so without its own case it would land on slugify's
+  // fallback and collide with any other path that slugs away to nothing.
+  it("does not let the home page fall back to a shared name", () => {
+    expect(pageAnchor("/")).toBe("page-home");
+    expect(pageAnchor("/")).not.toBe(pageAnchor("/!"));
   });
 });
 

--- a/scripts/e2e-gallery-report.ts
+++ b/scripts/e2e-gallery-report.ts
@@ -136,6 +136,18 @@ export function pageGroups(entries: Entry[]): { path: string; byProject: Map<str
   return [...byPath.entries()].map(([path, byProject]) => ({ path, byProject }));
 }
 
+/**
+ * The `id` of a page's section in the gallery, so a review can link straight at
+ * the screen it is talking about.
+ *
+ * `slugify` alone will not do: the home page's path is "/", which has no
+ * alphanumerics left after slugging and would collide with every other
+ * path that slugs to nothing.
+ */
+export function pageAnchor(path: string): string {
+  return path === "/" ? "page-home" : `page-${slugify(path)}`;
+}
+
 /** Every project that walked the tour, in first-seen order. */
 export function tourProjects(entries: Entry[]): string[] {
   return [...new Set(entries.filter(isTourEntry).map((entry) => entry.project))];
@@ -211,7 +223,7 @@ export function buildGalleryHtml(entries: Entry[], meta: { title: string; subtit
           );
         })
         .join("\n");
-      return `<section class="page"><h2>${escapeHtml(path)}</h2><div class="shots">${figures}</div></section>`;
+      return `<section class="page" id="${escapeHtml(pageAnchor(path))}"><h2>${escapeHtml(path)}</h2><div class="shots">${figures}</div></section>`;
     })
     .join("\n");
 

--- a/src/lib/faq.test.ts
+++ b/src/lib/faq.test.ts
@@ -56,6 +56,14 @@ describe("homepage FAQ selection", () => {
 });
 
 describe("who can join", () => {
+  // The homepage order comes from `homepageFaqIds`, so leading there costs
+  // /faq nothing. Keep the trial offer first in the array itself: /faq renders
+  // it in order, and so does the FAQPage JSON-LD built from it.
+  it("leaves the trial offer first on the full FAQ page", () => {
+    expect(faqItems[0].id).toBe("trial-offer");
+    expect(faqItems[1].id).toBe("open-to-public");
+  });
+
   it("answers the eligibility question with a plain no, not a qualified one", () => {
     const item = faqItems.find((f) => f.id === "open-to-public");
     expect(item).toBeDefined();

--- a/src/lib/faq.test.ts
+++ b/src/lib/faq.test.ts
@@ -17,8 +17,8 @@ describe("faq content", () => {
 });
 
 describe("homepage FAQ selection", () => {
-  it("surfaces exactly three reassuring questions", () => {
-    expect(homepageFaqItems).toHaveLength(3);
+  it("surfaces exactly four reassuring questions", () => {
+    expect(homepageFaqItems).toHaveLength(4);
   });
 
   it("only references ids that exist in the source of truth", () => {
@@ -45,5 +45,21 @@ describe("homepage FAQ selection", () => {
     expect(homepageFaqIds).toContain("experience");
     expect(homepageFaqIds).toContain("trial-offer");
     expect(homepageFaqIds).toContain("jjj-vs-bjj");
+  });
+
+  // The club's name reads as a university club, so someone from the public can
+  // assume they are not eligible and leave without ever asking. This question
+  // has to be on the homepage, and first in the list, for them to see it.
+  it("leads with the question about joining without being a UTS student", () => {
+    expect(homepageFaqIds[0]).toBe("open-to-public");
+  });
+});
+
+describe("who can join", () => {
+  it("answers the eligibility question with a plain no, not a qualified one", () => {
+    const item = faqItems.find((f) => f.id === "open-to-public");
+    expect(item).toBeDefined();
+    expect(item!.q).toMatch(/UTS student/i);
+    expect(item!.a).toMatch(/^No\./);
   });
 });

--- a/src/lib/faq.ts
+++ b/src/lib/faq.ts
@@ -5,13 +5,18 @@
 // homepage. Keep every question/answer here so the two never drift.
 
 export type FaqItem = {
-  /** Stable slug used to select items (e.g. the homepage trio) without matching on prose. */
+  /** Stable slug used to select items (e.g. the homepage set) without matching on prose. */
   id: string;
   q: string;
   a: string;
 };
 
 export const faqItems: FaqItem[] = [
+  {
+    id: "open-to-public",
+    q: "Do I need to be a UTS student to join?",
+    a: "No. The club is open to everyone. UTS students, UTS staff and people with no connection to the university all train in the same classes. The gym has its own street entrance on Harris Street, and reception just asks you to sign the sign-in sheet, so there's no student card to show. Students pay a lower fee, everyone else pays the public rate.",
+  },
   {
     id: "trial-offer",
     q: "Is there a trial offer?",
@@ -44,11 +49,19 @@ export const faqItems: FaqItem[] = [
   },
 ];
 
-// The three most reassuring questions to surface on the homepage, where
-// hesitation actually strikes. Deliberately chosen to COMPLEMENT the "Your
-// first class" page (which already covers gear + what to wear), so the gear /
-// clothing questions are intentionally excluded here to avoid redundancy.
-export const homepageFaqIds = ["experience", "trial-offer", "jjj-vs-bjj"] as const;
+// The most reassuring questions to surface on the homepage, where hesitation
+// actually strikes. Deliberately chosen to COMPLEMENT the "Your first class"
+// page (which already covers gear + what to wear), so the gear / clothing
+// questions are intentionally excluded here to avoid redundancy.
+//
+// "open-to-public" leads because the club's name reads as a university club,
+// and someone who assumes they are not eligible leaves without asking.
+export const homepageFaqIds = [
+  "open-to-public",
+  "experience",
+  "trial-offer",
+  "jjj-vs-bjj",
+] as const;
 
 export const homepageFaqItems: FaqItem[] = homepageFaqIds.map((id) => {
   const item = faqItems.find((f) => f.id === id);

--- a/src/lib/faq.ts
+++ b/src/lib/faq.ts
@@ -20,7 +20,7 @@ export const faqItems: FaqItem[] = [
   {
     id: "open-to-public",
     q: "Do I need to be a UTS student to join?",
-    a: "No. The club is open to everyone. UTS students, UTS staff and people with no connection to the university all train in the same classes. The gym has its own street entrance on Harris Street, so you don't need to be enrolled at UTS to get to class. Students pay a lower fee, everyone else pays the public rate.",
+    a: "No. The club is open to everyone. UTS students, UTS staff and people with no connection to the university all train in the same classes. The gym is inside UTS Building 4 on Harris Street, which is open to the public, so there's no student card to show at the door. Students pay a lower fee, everyone else pays the public rate.",
   },
   {
     id: "equipment",

--- a/src/lib/faq.ts
+++ b/src/lib/faq.ts
@@ -13,14 +13,14 @@ export type FaqItem = {
 
 export const faqItems: FaqItem[] = [
   {
-    id: "open-to-public",
-    q: "Do I need to be a UTS student to join?",
-    a: "No. The club is open to everyone. UTS students, UTS staff and people with no connection to the university all train in the same classes. The gym has its own street entrance on Harris Street, and reception just asks you to sign the sign-in sheet, so there's no student card to show. Students pay a lower fee, everyone else pays the public rate.",
-  },
-  {
     id: "trial-offer",
     q: "Is there a trial offer?",
     a: "Absolutely. Your first two sessions are on us. It's a great opportunity to experience our training firsthand and see if it's the right fit.",
+  },
+  {
+    id: "open-to-public",
+    q: "Do I need to be a UTS student to join?",
+    a: "No. The club is open to everyone. UTS students, UTS staff and people with no connection to the university all train in the same classes. The gym has its own street entrance on Harris Street, so you don't need to be enrolled at UTS to get to class. Students pay a lower fee, everyone else pays the public rate.",
   },
   {
     id: "equipment",
@@ -55,7 +55,9 @@ export const faqItems: FaqItem[] = [
 // questions are intentionally excluded here to avoid redundancy.
 //
 // "open-to-public" leads because the club's name reads as a university club,
-// and someone who assumes they are not eligible leaves without asking.
+// and someone who assumes they are not eligible leaves without asking. It sits
+// second in `faqItems` above, though: /faq renders that array in order (and
+// emits its FAQPage JSON-LD from it), and the trial offer keeps that slot.
 export const homepageFaqIds = [
   "open-to-public",
   "experience",

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -44,7 +44,7 @@ function Home() {
           <div>
             <span className="inline-flex items-start gap-2 rounded-full border bg-background px-3 py-1 text-xs font-medium text-primary">
               <span className="mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full bg-primary" /> UTS
-              students, staff and the public welcome
+              students, staff and public members welcome
             </span>
             <h1 className="mt-5 text-4xl font-bold leading-[1.05] tracking-tight md:text-6xl">
               Learn practical self-defence at <span className="text-primary">UTS Ultimo</span>.

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -160,8 +160,8 @@ function Home() {
             <div>
               <h2 className="text-3xl font-bold md:text-4xl">Train with us this week</h2>
               <p className="mt-2 max-w-xl text-muted-foreground">
-                Classes run at ActivateFit Gym, on Harris Street in Ultimo. You enter straight from
-                the street, so you don't need campus access to get to class.
+                Classes run at ActivateFit Gym, inside UTS Building 4 on Harris Street in Ultimo.
+                The building is open to the public, so anyone can come to class.
               </p>
             </div>
             <Button asChild variant="outline" className="hidden md:inline-flex">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -43,8 +43,7 @@ function Home() {
         <div className="mx-auto grid max-w-6xl gap-10 px-4 pt-12 pb-16 md:grid-cols-2 md:items-center md:pt-20 md:pb-24">
           <div>
             <span className="inline-flex items-center gap-2 rounded-full border bg-background px-3 py-1 text-xs font-medium text-primary">
-              <span className="h-1.5 w-1.5 rounded-full bg-primary" /> Now enrolling. Everyone
-              welcome, UTS or not
+              <span className="h-1.5 w-1.5 rounded-full bg-primary" /> Open to everyone, UTS or not
             </span>
             <h1 className="mt-5 text-4xl font-bold leading-[1.05] tracking-tight md:text-6xl">
               Learn practical self-defence at <span className="text-primary">UTS Ultimo</span>.
@@ -161,8 +160,8 @@ function Home() {
             <div>
               <h2 className="text-3xl font-bold md:text-4xl">Train with us this week</h2>
               <p className="mt-2 max-w-xl text-muted-foreground">
-                Classes run at ActivateFit Gym, on Harris Street in Ultimo. You enter from the
-                street, and there's no student card to show at reception.
+                Classes run at ActivateFit Gym, on Harris Street in Ultimo. You enter straight from
+                the street, so you don't need campus access to get to class.
               </p>
             </div>
             <Button asChild variant="outline" className="hidden md:inline-flex">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -13,7 +13,7 @@ export const Route = createFileRoute("/")({
     meta: buildPageMeta({
       title: "UTS Jitsu | Practical Japanese Jiu-Jitsu in Sydney",
       description:
-        "Learn practical self-defence at UTS Ultimo. Beginner-friendly Japanese Jiu-Jitsu classes Mon, Wed & Sat. First two sessions free.",
+        "Beginner-friendly Japanese Jiu-Jitsu at UTS Ultimo, open to everyone and not just UTS students. Classes Mon, Wed & Sat. First two sessions free.",
       path: "/",
     }),
     links: [
@@ -43,16 +43,16 @@ function Home() {
         <div className="mx-auto grid max-w-6xl gap-10 px-4 pt-12 pb-16 md:grid-cols-2 md:items-center md:pt-20 md:pb-24">
           <div>
             <span className="inline-flex items-center gap-2 rounded-full border bg-background px-3 py-1 text-xs font-medium text-primary">
-              <span className="h-1.5 w-1.5 rounded-full bg-primary" /> Now enrolling for the
-              semester
+              <span className="h-1.5 w-1.5 rounded-full bg-primary" /> Now enrolling. Everyone
+              welcome, UTS or not
             </span>
             <h1 className="mt-5 text-4xl font-bold leading-[1.05] tracking-tight md:text-6xl">
               Learn practical self-defence at <span className="text-primary">UTS Ultimo</span>.
             </h1>
             <p className="mt-5 max-w-lg text-base text-muted-foreground md:text-lg">
-              Build real self-defence skills in a fun and welcoming environment. Japanese Jiu-Jitsu
-              at the UTS Ultimo campus. Classes are for beginners and experienced martial artists
-              alike.
+              Build real self-defence skills in a fun and welcoming environment. We train Japanese
+              Jiu-Jitsu in Ultimo, and you don't need to be a UTS student to join us. Classes are
+              for beginners and experienced martial artists alike.
             </p>
             <div className="mt-8 flex flex-wrap gap-3">
               <Button asChild size="lg">
@@ -131,8 +131,8 @@ function Home() {
             },
             {
               icon: Users,
-              title: "Inclusive community",
-              body: "All levels welcome. We move at your pace, together.",
+              title: "Open to everyone",
+              body: "You don't need to be a UTS student. All levels welcome, at your own pace.",
             },
             {
               icon: Dumbbell,
@@ -161,7 +161,8 @@ function Home() {
             <div>
               <h2 className="text-3xl font-bold md:text-4xl">Train with us this week</h2>
               <p className="mt-2 max-w-xl text-muted-foreground">
-                Classes run at ActivateFit Gym, on Harris Street in Ultimo.
+                Classes run at ActivateFit Gym, on Harris Street in Ultimo. You enter from the
+                street, and there's no student card to show at reception.
               </p>
             </div>
             <Button asChild variant="outline" className="hidden md:inline-flex">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -44,7 +44,7 @@ function Home() {
           <div>
             <span className="inline-flex items-start gap-2 rounded-full border bg-background px-3 py-1 text-xs font-medium text-primary">
               <span className="mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full bg-primary" /> UTS
-              students, UTS staff and general public alike
+              students, staff and the public welcome
             </span>
             <h1 className="mt-5 text-4xl font-bold leading-[1.05] tracking-tight md:text-6xl">
               Learn practical self-defence at <span className="text-primary">UTS Ultimo</span>.
@@ -52,7 +52,8 @@ function Home() {
             <p className="mt-5 max-w-lg text-base text-muted-foreground md:text-lg">
               Build real self-defence skills in a fun and welcoming environment. We train Japanese
               Jiu-Jitsu in Ultimo and welcome the general public and local community, with special
-              rates for UTS students. Classes are for beginners and experienced martial artists.
+              rates for UTS students. Classes are for beginners and experienced martial artists
+              alike.
             </p>
             <div className="mt-8 flex flex-wrap gap-3">
               <Button asChild size="lg">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -13,7 +13,7 @@ export const Route = createFileRoute("/")({
     meta: buildPageMeta({
       title: "UTS Jitsu | Practical Japanese Jiu-Jitsu in Sydney",
       description:
-        "Beginner-friendly Japanese Jiu-Jitsu at UTS Ultimo, open to everyone and not just UTS students. Classes Mon, Wed & Sat. First two sessions free.",
+        "Learn practical self-defence at UTS Ultimo. Beginner-friendly Japanese Jiu-Jitsu classes Mon, Wed & Sat. First two sessions free.",
       path: "/",
     }),
     links: [
@@ -42,16 +42,17 @@ function Home() {
         <div className="absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-background" />
         <div className="mx-auto grid max-w-6xl gap-10 px-4 pt-12 pb-16 md:grid-cols-2 md:items-center md:pt-20 md:pb-24">
           <div>
-            <span className="inline-flex items-center gap-2 rounded-full border bg-background px-3 py-1 text-xs font-medium text-primary">
-              <span className="h-1.5 w-1.5 rounded-full bg-primary" /> Open to everyone, UTS or not
+            <span className="inline-flex items-start gap-2 rounded-full border bg-background px-3 py-1 text-xs font-medium text-primary">
+              <span className="mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full bg-primary" /> UTS
+              students, UTS staff and general public alike
             </span>
             <h1 className="mt-5 text-4xl font-bold leading-[1.05] tracking-tight md:text-6xl">
               Learn practical self-defence at <span className="text-primary">UTS Ultimo</span>.
             </h1>
             <p className="mt-5 max-w-lg text-base text-muted-foreground md:text-lg">
               Build real self-defence skills in a fun and welcoming environment. We train Japanese
-              Jiu-Jitsu in Ultimo, and you don't need to be a UTS student to join us. Classes are
-              for beginners and experienced martial artists alike.
+              Jiu-Jitsu in Ultimo and welcome the general public and local community, with special
+              rates for UTS students. Classes are for beginners and experienced martial artists.
             </p>
             <div className="mt-8 flex flex-wrap gap-3">
               <Button asChild size="lg">
@@ -131,7 +132,7 @@ function Home() {
             {
               icon: Users,
               title: "Open to everyone",
-              body: "You don't need to be a UTS student. All levels welcome, at your own pace.",
+              body: "UTS students, staff and the general public train together. All levels welcome, at your own pace.",
             },
             {
               icon: Dumbbell,


### PR DESCRIPTION
## See it

The two pages this branch changes, in the end-to-end run's gallery (seeded fixture club, not the live one):

| Page | Preview |
| --- | --- |
| `/` | [desktop and phone](https://fryorcraken.github.io/jitsu-au/pr-48/index.html#page-home) |
| `/faq` | [desktop and phone](https://fryorcraken.github.io/jitsu-au/pr-48/index.html#page-faq) |

[Whole gallery](https://fryorcraken.github.io/jitsu-au/pr-48/index.html) · [test report](https://fryorcraken.github.io/jitsu-au/pr-48/report/index.html)

Each link lands on that page's section, showing it at both widths. The anchors come from `c79970d` and are named after the route, not the screenshot: shot files are content-hashed, so a URL pointing at a PNG changes as soon as that page's pixels change, which on this branch is exactly the page being linked.

## What changes for people using the site

The club is called UTS Jitsu and trains on the UTS campus, so the home page read as a university-only club. Nothing above the fold said otherwise, and the only place that spelled it out was the "For the general public" price table two clicks away. Someone from the public who assumed they were not eligible had no reason to click through and find out.

The home page now says who is welcome, in the places where that assumption gets made:

- **Hero badge**, the first thing read: "UTS students, staff and public members welcome".
- **Hero paragraph**: we welcome the general public and local community, with special rates for UTS students.
- **The second value-prop card**, "Open to everyone", which now carries both who trains here and the all-levels/own-pace idea it had before.
- **The venue blurb** above the class times, answering the natural follow-up: how someone who isn't a student gets into a gym on a university campus. The gym is inside UTS Building 4, and the building is open to the public.

There's also a new FAQ entry, **"Do I need to be a UTS student to join?"**, in the shared FAQ source, so it appears on `/faq` (and in that page's structured data) as well as leading the "Common questions" block on the home page.

## What a visitor feels

Nothing gets slower or adds a step. This is copy only: no new fields, no new screens, no email, and members and managers see nothing different.

## Getting the facts right

Copy that stated more than the repo could back was the failure mode here, so the corrections are worth listing:

- A first draft said the gym was **off campus**. `/classes` says the opposite: it is in UTS Building 4.
- A second draft said reception "just asks you to sign the sign-in sheet". `/first-class` scopes that to the **trial**, after which reception enters you into their system.
- On review, @fryorcraken pointed out the gym is **inside** Building 4 and that the building is itself public. The replacement wording ("its own street entrance") had the geography backwards the other way.
- Review also replaced the negative framing ("you don't need to be a UTS student") with naming who is welcome, and reverted the meta-description change as not worth the space.
- The badge briefly read "UTS students, UTS staff and general public alike". That named three groups and then said nothing about them: "alike" is a comparative needing a predicate to attach to, which a bare chip label has not got. It now ends on "welcome".

**One open question** on the review thread: the Building 4 fact came with "during business hours", which is deliberately not repeated in the copy, since Monday runs to 7pm and Wednesday to 7:30pm and an eligibility answer cannot resolve a doubt about evening access. If evening entry needs something extra, that belongs on `/first-class` with the arrival instructions.

## Kept in step with `main`

`main` moved three times while this was open, twice into the same lines:

- **#72** made every page read the address from `venue.ts` and added a guard that fails any page restating the street. The venue blurb here had hardcoded "Harris Street", so it now composes from `VENUE_NAME` / `VENUE_ADDRESS_SHORT` / `VENUE_BUILDING`. The FAQ answer dropped its copy of the street too: the guard does not scan `faq.ts`, but a second copy of the address is exactly what that change exists to prevent, and an eligibility answer does not need directions.
- **#71** moved the weekly schedule into `lib/schedule.ts`; that conflict was imports only.
- **#49** changed the Saturday class time, which this branch now shows.

## Tests

`src/lib/faq.test.ts` pins the decisions, not just the shape: four homepage items rather than three; the new question leading the homepage block; its answer opening with a plain "No."; and the trial offer keeping first place in `faqItems`, since `/faq` and its JSON-LD render that array in order while the homepage order comes from `homepageFaqIds`.

`scripts/e2e-gallery-report.test.ts` pins the new page anchors, including that `/` does not fall back to a shared id.

## Checks

`bun run lint`, `bun run typecheck`, `bun run test` (2111 passing after the merges) and `bun run build` all pass locally. The home page was opened in a real browser at 320px, 375px and 1280px: the badge is a single line at 375px and up, and wraps at 320px with its leading dot pinned to the first line rather than floating between the two.