### PR TITLE
Move the Saturday class to 11:00am - 12:30pm

### DIFF
--- a/src/routes/classes.tsx
+++ b/src/routes/classes.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute("/classes")({
 const schedule = [
   { day: "Monday", time: "5:30 – 7:00pm", note: "All levels welcome" },
   { day: "Wednesday", time: "6:00 – 7:30pm", note: "All levels welcome" },
-  { day: "Saturday", time: "10:30am – 12:00pm", note: "Colour belts only, from September" },
+  { day: "Saturday", time: "11:00am – 12:30pm", note: "Colour belts only, from September" },
 ];
 
 function Classes() {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -175,7 +175,7 @@ function Home() {
               { day: "Wednesday", time: "6:00 – 7:30pm" },
               {
                 day: "Saturday",
-                time: "10:30am – 12:00pm",
+                time: "11:00am – 12:30pm",
                 note: "Colour belts only, from September",
               },
             ].map((s) => (


### PR DESCRIPTION
## What changes for people using the site

Anyone looking up when we train now sees the Saturday session as **11:00am - 12:30pm** instead of 10:30am - 12:00pm. It appears in the two places a prospective member actually looks:

- the home page's three-card "when we train" summary
- the full schedule on `/classes`

Monday and Wednesday are unchanged, as is the "Colour belts only, from September" note on Saturday.

## What this does not touch

The class times on these marketing pages are **hardcoded in the page files**, not read from the club calendar. So this change does not update:

- `/calendar` or anyone's subscribed calendar feed. If a repeating Saturday entry exists there, a manager still needs to change it at `/manager/calendar` (edit the entry, "this and all future dates"), otherwise the two will disagree.
- The manager agent API, which has no calendar or schedule actions at all today.

Worth knowing: because the same three rows are written out twice in the code, these pages can drift apart, and nothing in CI catches it. Reading them from the calendar instead would make the manager screen the single place this is edited. That is a product decision, not part of this change.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (1994 passing) and `bun run build` all green locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFLm5oB5pU1UuYDYHVhiiE)_