### PR TITLE
Formatting toolbar and keyboard shortcuts in the knowledge base editor

### DIFF
--- a/docs/blog.md
+++ b/docs/blog.md
@@ -122,8 +122,10 @@ host the manager is signed in on) ready to paste into a message or a social
 post. It sits with the title rather than with View/Delete because those are off
 the right edge of the table on a phone. A draft has no button: the public route
 serves published posts only, so a draft's URL is a 404 for everyone it is sent
-to. The composer is a Markdown textarea with a small
-formatting toolbar (bold/italic/heading/list/link), an "Insert image" button
+to. The composer is the same Markdown editor the knowledge base
+uses (`MarkdownEditor`, so the toolbar, the keyboard shortcuts and the
+wrap-the-selection behaviour described in `docs/knowledge-base.md` are the same
+on both screens), with an "Insert image" button
 (uploads to `blog-media`, inserts a Markdown image), an "Insert video" dialog
 (YouTube links embed inline; anything else shows as a plain link), a separate
 cover-image uploader, a status picker (draft/published) that warns before

--- a/docs/knowledge-base.md
+++ b/docs/knowledge-base.md
@@ -313,6 +313,32 @@ and not two: the reading order down the left, the markdown body in the main
 window, a live preview underneath, and "Save as new version" publishing what you
 wrote.
 
+**The body has a formatting toolbar, and the shortcuts that go with it.** A
+manager writing an article is thinking about the sentence they want emphasised,
+not about Markdown syntax, so bold, italic, code, heading, both kinds of list,
+quote and link are buttons above the textarea, and each one also answers to the
+binding it has in every other editor: Ctrl/⌘ + B, I, E and K, and Ctrl/⌘ + Shift
+
+- 8, 7 and full stop for the lists and the quote. Each button names its own
+  shortcut. What is stored is still plain Markdown, typed by hand where that is
+  faster.
+
+Three things follow from that, and they are the reason the editor is a component
+rather than a bare textarea:
+
+- **Typing a wrapping character over a selection wraps it**, rather than
+  deleting it. Highlighting a phrase and reaching for `*`, `_`, `` ` ``, a quote
+  mark or a bracket puts it around the phrase, and the phrase stays selected so
+  a second press nests it (`*tidy*`, then `**tidy**`).
+- **Enter carries a list on**, numbering as it goes, and on an item with nothing
+  typed in it takes the marker away instead, which is how a list is left.
+- **Undo still works.** Edits are applied through the browser's own editing
+  machinery, so Ctrl/⌘ + Z takes the bold off rather than doing nothing or
+  jumping back further than anyone meant.
+
+Pressing a button with nothing selected acts on the word the cursor is in, and
+pressing it again takes the formatting off.
+
 **The reading order is the navigation for this screen.** It is on the left
 because that is what it is for: picking what to edit, and arranging what members
 read. Everything that CHANGES a thing (its title, its text, its settings,
@@ -449,6 +475,8 @@ it as a marketing page or a blog post instead.
 | Block splitting, anchoring, permissions     | `src/lib/kb.ts` (pure, tested)                      |
 | Sections, reading order, progress, headings | `src/lib/kb-nav.ts` (pure, tested)                  |
 | Editor decisions (dirty, widening, reorder) | `src/lib/kb-editor.ts` (pure, tested)               |
+| Toolbar, shortcuts, what a keystroke does   | `src/lib/markdown-editing.ts` (pure, tested)        |
+| The body textarea itself                    | `src/components/site/MarkdownEditor.tsx`            |
 | Saving, versioning, promotion, sections     | `src/lib/kb-admin.ts`                               |
 | Reader/annotation/progress server functions | `src/lib/kb.functions.ts`                           |
 | Wire schemas                                | `src/lib/validation.ts`                             |

--- a/docs/knowledge-base.md
+++ b/docs/knowledge-base.md
@@ -317,11 +317,14 @@ wrote.
 manager writing an article is thinking about the sentence they want emphasised,
 not about Markdown syntax, so bold, italic, code, heading, both kinds of list,
 quote and link are buttons above the textarea, and each one also answers to the
-binding it has in every other editor: Ctrl/⌘ + B, I, E and K, and Ctrl/⌘ + Shift
-
-- 8, 7 and full stop for the lists and the quote. Each button names its own
-  shortcut. What is stored is still plain Markdown, typed by hand where that is
-  faster.
+binding it has in every other editor. Bold is `Ctrl+B`, italic `Ctrl+I`, code
+`Ctrl+E`, link `Ctrl+K`; the two lists and the quote are `Ctrl+Shift` with `8`,
+`7` and the full stop. Each button names its own shortcut. On a Mac they are the
+`⌘` versions, because `Ctrl+B` and `Ctrl+E` move the caret in every text field
+on that system and taking them would break something a person already relies on
+(the shifted ones are read off the physical key, so a non-US layout keeps them
+too). What is stored is still plain Markdown, typed by hand where that is
+faster.
 
 Three things follow from that, and they are the reason the editor is a component
 rather than a bare textarea:

--- a/src/components/site/BlogPostEditor.tsx
+++ b/src/components/site/BlogPostEditor.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { MarkdownEditor } from "@/components/site/MarkdownEditor";
 import {
   Select,
   SelectContent,
@@ -144,57 +145,6 @@ export function BlogPostEditor({
   }, [dirty]);
 
   const willUnpublish = initial.status === "published" && status === "draft";
-
-  /** Wrap the current selection in inline Markdown syntax (bold/italic/link). */
-  function wrapSelection(before: string, after: string = before) {
-    const el = bodyRef.current;
-    if (!el) return;
-    const start = el.selectionStart;
-    const end = el.selectionEnd;
-    const selected = body.slice(start, end);
-    setBody(`${body.slice(0, start)}${before}${selected}${after}${body.slice(end)}`);
-    requestAnimationFrame(() => {
-      el.focus();
-      el.setSelectionRange(start + before.length, start + before.length + selected.length);
-    });
-  }
-
-  /** Insert a block marker (e.g. `## `) at the start of the current line,
-   * adding a leading newline only when the cursor isn't already at the start
-   * of a line (so it never inserts a stray blank line at the top of an empty
-   * or freshly-started document). Headings are single-line by definition, so
-   * this ignores the rest of a multi-line selection on purpose. */
-  function insertLinePrefix(prefix: string) {
-    const el = bodyRef.current;
-    const pos = el ? el.selectionStart : body.length;
-    const needsNewline = pos > 0 && body[pos - 1] !== "\n";
-    const insert = `${needsNewline ? "\n" : ""}${prefix}`;
-    setBody(`${body.slice(0, pos)}${insert}${body.slice(pos)}`);
-    requestAnimationFrame(() => {
-      el?.focus();
-      const at = pos + insert.length;
-      el?.setSelectionRange(at, at);
-    });
-  }
-
-  /** Prefix every line touched by the current selection (e.g. turning a
-   * multi-line selection into a multi-item bullet list, one bullet per
-   * line, instead of one bullet swallowing every line as its own text). */
-  function prefixEachLine(prefix: string) {
-    const el = bodyRef.current;
-    const start = el ? el.selectionStart : 0;
-    const end = el ? el.selectionEnd : 0;
-    const lineStart = body.lastIndexOf("\n", start - 1) + 1;
-    let lineEnd = body.indexOf("\n", end);
-    if (lineEnd === -1) lineEnd = body.length;
-    const block = body.slice(lineStart, lineEnd);
-    const prefixed = block
-      .split("\n")
-      .map((line) => `${prefix}${line}`)
-      .join("\n");
-    setBody(`${body.slice(0, lineStart)}${prefixed}${body.slice(lineEnd)}`);
-    requestAnimationFrame(() => el?.focus());
-  }
 
   async function uploadFile(file: File): Promise<{ path: string; url: string } | null> {
     if (!isBlogImageMimeType(file.type)) {
@@ -379,67 +329,50 @@ export function BlogPostEditor({
       </div>
       <div>
         <Label htmlFor="post-body">Body (Markdown)</Label>
-        <div className="mt-1.5 flex flex-wrap gap-1.5">
-          <Button type="button" variant="outline" size="sm" onClick={() => wrapSelection("**")}>
-            Bold
-          </Button>
-          <Button type="button" variant="outline" size="sm" onClick={() => wrapSelection("_")}>
-            Italic
-          </Button>
-          <Button type="button" variant="outline" size="sm" onClick={() => insertLinePrefix("## ")}>
-            Heading
-          </Button>
-          <Button type="button" variant="outline" size="sm" onClick={() => prefixEachLine("- ")}>
-            List
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => wrapSelection("[", "](https://)")}
-          >
-            Link
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={uploadingImage}
-            onClick={() => imageInputRef.current?.click()}
-          >
-            {uploadingImage ? "Uploading..." : "Insert image"}
-          </Button>
-          <input
-            ref={imageInputRef}
-            type="file"
-            className="sr-only"
-            aria-label="Insert image into post body"
-            accept={IMAGE_ACCEPT}
-            onChange={(e) => {
-              const file = e.target.files?.[0];
-              if (file) handleInsertImage(file);
-              e.target.value = "";
-            }}
-          />
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              setVideoUrl("");
-              setVideoDialogOpen(true);
-            }}
-          >
-            Insert video
-          </Button>
-        </div>
-        <Textarea
+        <MarkdownEditor
           id="post-body"
-          ref={bodyRef}
+          textareaRef={bodyRef}
           value={body}
-          onChange={(e) => setBody(e.target.value)}
+          onChange={setBody}
           rows={18}
-          className="mt-2 font-mono text-sm"
+          tools={
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={uploadingImage}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => imageInputRef.current?.click()}
+              >
+                {uploadingImage ? "Uploading..." : "Insert image"}
+              </Button>
+              <input
+                ref={imageInputRef}
+                type="file"
+                className="sr-only"
+                aria-label="Insert image into post body"
+                accept={IMAGE_ACCEPT}
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) handleInsertImage(file);
+                  e.target.value = "";
+                }}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  setVideoUrl("");
+                  setVideoDialogOpen(true);
+                }}
+              >
+                Insert video
+              </Button>
+            </>
+          }
         />
       </div>
       <div>

--- a/src/components/site/MarkdownEditor.test.tsx
+++ b/src/components/site/MarkdownEditor.test.tsx
@@ -4,7 +4,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MarkdownEditor } from "./MarkdownEditor";
 
 function Harness({ initial }: { initial: string }) {
@@ -66,6 +66,28 @@ describe("MarkdownEditor", () => {
     await user.keyboard("*");
 
     expect(editor()).toHaveValue("keep it *tidy*");
+  });
+
+  it("touches nothing when the command has nothing to do", async () => {
+    // Bullets over a run of blank lines change no text. Applying that as an
+    // empty replacement reads to the browser as a backspace at the end of the
+    // document, and costs the undo history this design exists to keep.
+    const exec = vi.fn(() => false);
+    Object.defineProperty(document, "execCommand", { value: exec, configurable: true });
+    try {
+      const user = userEvent.setup();
+      render(<Harness initial={"\n\n\n"} />);
+      const el = editor();
+      el.focus();
+      el.setSelectionRange(0, 3);
+
+      await user.click(screen.getByRole("button", { name: /^Bullet list/ }));
+
+      expect(exec).not.toHaveBeenCalled();
+      expect(editor()).toHaveValue("\n\n\n");
+    } finally {
+      Reflect.deleteProperty(document, "execCommand");
+    }
   });
 
   it("carries a list on to the next line, and ends it on an empty item", async () => {

--- a/src/components/site/MarkdownEditor.test.tsx
+++ b/src/components/site/MarkdownEditor.test.tsx
@@ -1,0 +1,82 @@
+// The DOM half of the Markdown editors: that a button and its shortcut reach
+// the same rule, and that the rules act on what is actually selected in the
+// textarea. The text rules themselves are pinned in `markdown-editing.test.ts`.
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { MarkdownEditor } from "./MarkdownEditor";
+
+function Harness({ initial }: { initial: string }) {
+  const [value, setValue] = useState(initial);
+  return <MarkdownEditor id="body" value={value} onChange={setValue} rows={4} />;
+}
+
+/** Put the caret where a person would have dragged it. */
+function select(el: HTMLTextAreaElement, text: string) {
+  const at = el.value.indexOf(text);
+  el.setSelectionRange(at, at + text.length);
+}
+
+function editor(): HTMLTextAreaElement {
+  return screen.getByRole("textbox") as HTMLTextAreaElement;
+}
+
+describe("MarkdownEditor", () => {
+  it("formats the selection from the toolbar", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial="keep it tidy" />);
+    select(editor(), "tidy");
+
+    await user.click(screen.getByRole("button", { name: /^Bold/ }));
+
+    expect(editor()).toHaveValue("keep it **tidy**");
+  });
+
+  it("names each button with the shortcut it answers to", () => {
+    render(<Harness initial="" />);
+    expect(screen.getByRole("button", { name: "Italic (Ctrl+I)" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Link (Ctrl+K)" })).toBeInTheDocument();
+    // Heading has no conventional binding, so it is offered without one.
+    expect(screen.getByRole("button", { name: "Heading" })).toBeInTheDocument();
+  });
+
+  it("formats the selection from the keyboard", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial="keep it tidy" />);
+    const el = editor();
+    el.focus();
+
+    select(el, "tidy");
+    await user.keyboard("{Control>}i{/Control}");
+    expect(editor()).toHaveValue("keep it _tidy_");
+
+    select(editor(), "tidy");
+    await user.keyboard("{Control>}k{/Control}");
+    expect(editor()).toHaveValue("keep it _[tidy]()_");
+  });
+
+  it("wraps the selection when a pairing character is typed, instead of replacing it", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial="keep it tidy" />);
+    const el = editor();
+    el.focus();
+    select(el, "tidy");
+
+    await user.keyboard("*");
+
+    expect(editor()).toHaveValue("keep it *tidy*");
+  });
+
+  it("carries a list on to the next line, and ends it on an empty item", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial="- gi" />);
+    const el = editor();
+    el.focus();
+    el.setSelectionRange(el.value.length, el.value.length);
+
+    await user.keyboard("{Enter}belt{Enter}{Enter}");
+
+    expect(editor()).toHaveValue("- gi\n- belt\n");
+  });
+});

--- a/src/components/site/MarkdownEditor.tsx
+++ b/src/components/site/MarkdownEditor.tsx
@@ -1,0 +1,181 @@
+// The Markdown body textarea used by the manager editors, with the formatting
+// toolbar and the keyboard shortcuts that go with it.
+//
+// A manager writing an article is not thinking about Markdown syntax, they are
+// thinking about a sentence they want emphasised. So the two ways they will
+// reach for it both work: the buttons, and the shortcuts every other editor on
+// their laptop already answers to (Ctrl/⌘ + B, I, K). Selecting a phrase and
+// typing "*" wraps it rather than deleting it, which is what that keystroke
+// means everywhere else and, before this, silently threw the phrase away.
+//
+// The text rules themselves live in `@/lib/markdown-editing` and are tested
+// there; this file is the part that needs a DOM: focus, selection, and undo.
+import { useRef, type KeyboardEvent, type ReactNode, type RefObject } from "react";
+import { Bold, Code, Heading2, Italic, Link2, List, ListOrdered, Quote } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  MARKDOWN_TOOLS,
+  applyMarkdownCommand,
+  continueListOnEnter,
+  markdownShortcut,
+  replacementFor,
+  shortcutLabel,
+  wrapWithTypedCharacter,
+  type MarkdownCommand,
+  type MarkdownDoc,
+} from "@/lib/markdown-editing";
+
+const ICONS: Record<MarkdownCommand, typeof Bold> = {
+  bold: Bold,
+  italic: Italic,
+  code: Code,
+  heading: Heading2,
+  bullet: List,
+  numbered: ListOrdered,
+  quote: Quote,
+  link: Link2,
+};
+
+/** Whether to spell the shortcuts with ⌘ or with Ctrl. Read at render rather
+ * than kept in state: these screens are client-rendered (`ssr: false`), so
+ * there is no server pass to disagree with. */
+function isApple(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent);
+}
+
+export function MarkdownEditor({
+  id,
+  value,
+  onChange,
+  rows = 22,
+  textareaRef,
+  tools,
+  "aria-describedby": describedBy,
+}: {
+  id: string;
+  value: string;
+  onChange: (next: string) => void;
+  rows?: number;
+  /** For a caller that also inserts text of its own (the blog composer's image
+   * and video buttons need to know where the cursor is). */
+  textareaRef?: RefObject<HTMLTextAreaElement | null>;
+  /** Extra buttons for this editor only, added after the formatting ones. */
+  tools?: ReactNode;
+  "aria-describedby"?: string;
+}) {
+  const ownRef = useRef<HTMLTextAreaElement>(null);
+  const ref = textareaRef ?? ownRef;
+  const apple = isApple();
+
+  /**
+   * Write an edit back through the browser's own editing machinery where it
+   * will take it, so the change joins the undo stack instead of clearing it.
+   * Setting the value straight from React works, but Ctrl+Z afterwards either
+   * does nothing or jumps back further than anyone meant.
+   */
+  function apply(next: MarkdownDoc | null) {
+    const el = ref.current;
+    if (!el || !next) return;
+    const patch = replacementFor(value, next.text);
+    el.focus();
+    el.setSelectionRange(patch.start, patch.end);
+    let handled = false;
+    try {
+      handled = document.execCommand(patch.insert ? "insertText" : "delete", false, patch.insert);
+    } catch {
+      handled = false;
+    }
+    // `execCommand` is missing under the test runner and can be refused by a
+    // browser, so never trust its answer: check what the textarea actually
+    // holds. The fallback writes the value straight onto the element as well as
+    // through `onChange`, because React's re-render is a tick away and the next
+    // keystroke of a fast typist would otherwise land at the old caret.
+    if (!handled || el.value !== next.text) {
+      el.value = next.text;
+      onChange(next.text);
+    }
+    el.setSelectionRange(next.start, next.end);
+  }
+
+  function docFrom(el: HTMLTextAreaElement): MarkdownDoc {
+    return { text: value, start: el.selectionStart, end: el.selectionEnd };
+  }
+
+  function runCommand(command: MarkdownCommand) {
+    const el = ref.current;
+    if (!el) return;
+    apply(applyMarkdownCommand(docFrom(el), command));
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.nativeEvent.isComposing) return;
+    const doc = docFrom(e.currentTarget);
+
+    const command = markdownShortcut(e, apple);
+    if (command) {
+      // Several of these are browser bindings (⌘K is the address bar). Taking
+      // the key is the point: the person is typing in a text box.
+      e.preventDefault();
+      runCommand(command);
+      return;
+    }
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+    if (e.key === "Enter" && !e.shiftKey) {
+      const next = continueListOnEnter(doc);
+      if (next) {
+        e.preventDefault();
+        apply(next);
+      }
+      return;
+    }
+    if (e.key.length === 1) {
+      const next = wrapWithTypedCharacter(doc, e.key);
+      if (next) {
+        e.preventDefault();
+        apply(next);
+      }
+    }
+  }
+
+  return (
+    <div>
+      <div className="mt-1.5 flex flex-wrap gap-1" role="group" aria-label="Formatting">
+        {MARKDOWN_TOOLS.map(({ command, label, shortcut }) => {
+          const Icon = ICONS[command];
+          const hint = shortcut ? `${label} (${shortcutLabel(shortcut, apple)})` : label;
+          return (
+            <Button
+              key={command}
+              type="button"
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              aria-label={hint}
+              title={hint}
+              // Keeps the caret in the textarea: without this the click blurs
+              // it first, and on some browsers the selection goes with it.
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => runCommand(command)}
+            >
+              <Icon className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          );
+        })}
+        {tools}
+      </div>
+      <Textarea
+        id={id}
+        ref={ref}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        rows={rows}
+        aria-describedby={describedBy}
+        className="mt-2 font-mono text-sm"
+      />
+    </div>
+  );
+}

--- a/src/components/site/MarkdownEditor.tsx
+++ b/src/components/site/MarkdownEditor.tsx
@@ -78,8 +78,15 @@ export function MarkdownEditor({
   function apply(next: MarkdownDoc | null) {
     const el = ref.current;
     if (!el || !next) return;
-    const patch = replacementFor(value, next.text);
     el.focus();
+    // A command with nothing to do (bullets over a run of blank lines) would
+    // otherwise send an empty replacement at the end of the document, which
+    // reads as a backspace and costs the undo history the fallback repairs.
+    if (next.text === value) {
+      el.setSelectionRange(next.start, next.end);
+      return;
+    }
+    const patch = replacementFor(value, next.text);
     el.setSelectionRange(patch.start, patch.end);
     let handled = false;
     try {

--- a/src/lib/markdown-editing.test.ts
+++ b/src/lib/markdown-editing.test.ts
@@ -46,6 +46,21 @@ describe("applyMarkdownCommand", () => {
     expect(show(applyMarkdownCommand(doc("keep |it |tidy"), "bold"))).toBe("keep **|it|** tidy");
   });
 
+  it("keeps a line's indentation, rather than stacking a marker in front of it", () => {
+    // Enter continues an indented item as an indented one, so the button has
+    // to read that line the same way ("-   - gi" was neither).
+    expect(show(applyMarkdownCommand(doc("|  gi|"), "bullet"))).toBe("|  - gi|");
+    expect(show(applyMarkdownCommand(doc("|  - gi|"), "bullet"))).toBe("|  gi|");
+  });
+
+  it("leaves the text alone when there is nothing the command can do", () => {
+    // Blank lines are not list items, so this is a no-op, and the editor
+    // relies on the text coming back unchanged to keep its hands off the DOM.
+    expect(applyMarkdownCommand({ text: "\n\n\n", start: 0, end: 3 }, "bullet").text).toBe(
+      "\n\n\n",
+    );
+  });
+
   it("makes a heading, a quote and lists out of the lines the selection touches", () => {
     expect(show(applyMarkdownCommand(doc("Get|ting started"), "heading"))).toBe(
       "## Get|ting started",
@@ -88,6 +103,11 @@ describe("applyMarkdownCommand", () => {
       "[|](https://jitsu.au)",
     );
     expect(show(applyMarkdownCommand(doc("see: |"), "link"))).toBe("see: [|]()");
+    // Double-clicking a word takes the space after it in most browsers, and
+    // "[handbook ]()" glues the link to the word that follows.
+    expect(show(applyMarkdownCommand(doc("see |handbook |here"), "link"))).toBe(
+      "see [handbook](|) here",
+    );
   });
 });
 

--- a/src/lib/markdown-editing.test.ts
+++ b/src/lib/markdown-editing.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyMarkdownCommand,
+  continueListOnEnter,
+  markdownShortcut,
+  replacementFor,
+  shortcutLabel,
+  wrapWithTypedCharacter,
+  type MarkdownDoc,
+} from "./markdown-editing";
+
+/** "Bold the |selection| here" — the pipes say where the selection is, so a
+ * case reads as the thing a person did rather than as two integers. */
+function doc(marked: string): MarkdownDoc {
+  const start = marked.indexOf("|");
+  const end = marked.indexOf("|", start + 1) - 1;
+  return { text: marked.replace(/\|/g, ""), start, end: end < start ? start : end };
+}
+function show(d: MarkdownDoc): string {
+  return d.start === d.end
+    ? `${d.text.slice(0, d.start)}|${d.text.slice(d.start)}`
+    : `${d.text.slice(0, d.start)}|${d.text.slice(d.start, d.end)}|${d.text.slice(d.end)}`;
+}
+
+describe("applyMarkdownCommand", () => {
+  it("wraps the selection and keeps it selected, so a second press can nest", () => {
+    expect(show(applyMarkdownCommand(doc("keep it |tidy|"), "bold"))).toBe("keep it **|tidy|**");
+    expect(show(applyMarkdownCommand(doc("keep it |tidy|"), "italic"))).toBe("keep it _|tidy|_");
+    expect(show(applyMarkdownCommand(doc("run |bun test|"), "code"))).toBe("run `|bun test|`");
+  });
+
+  it("takes the formatting off again when it is already there", () => {
+    expect(show(applyMarkdownCommand(doc("keep it **|tidy|**"), "bold"))).toBe("keep it |tidy|");
+    // Markers swept up inside the selection, e.g. by selecting the whole line.
+    expect(show(applyMarkdownCommand(doc("|**tidy**|"), "bold"))).toBe("|tidy|");
+  });
+
+  it("acts on the word under the cursor when nothing is selected", () => {
+    expect(show(applyMarkdownCommand(doc("keep it ti|dy"), "bold"))).toBe("keep it **|tidy|**");
+    expect(show(applyMarkdownCommand(doc("keep it **ti|dy**"), "bold"))).toBe("keep it |tidy|");
+  });
+
+  it("leaves surrounding whitespace outside the markers", () => {
+    // "** bold **" is not bold in Markdown, and double-clicking a word often
+    // takes the space after it.
+    expect(show(applyMarkdownCommand(doc("keep |it |tidy"), "bold"))).toBe("keep **|it|** tidy");
+  });
+
+  it("makes a heading, a quote and lists out of the lines the selection touches", () => {
+    expect(show(applyMarkdownCommand(doc("Get|ting started"), "heading"))).toBe(
+      "## Get|ting started",
+    );
+    expect(show(applyMarkdownCommand(doc("|gi\nbelt|"), "bullet"))).toBe("|- gi\n- belt|");
+    expect(show(applyMarkdownCommand(doc("|gi\nbelt|"), "numbered"))).toBe("|1. gi\n2. belt|");
+    expect(show(applyMarkdownCommand(doc("|hush|"), "quote"))).toBe("|> hush|");
+  });
+
+  it("toggles a list off, and swaps one kind of list for the other", () => {
+    expect(show(applyMarkdownCommand(doc("|- gi\n- belt|"), "bullet"))).toBe("|gi\nbelt|");
+    expect(show(applyMarkdownCommand(doc("|- gi\n- belt|"), "numbered"))).toBe("|1. gi\n2. belt|");
+    // Any heading level comes off, so the button is "heading on / heading off"
+    // rather than a level picker nobody asked for.
+    expect(show(applyMarkdownCommand(doc("|# Title|"), "heading"))).toBe("|Title|");
+  });
+
+  it("skips the blank lines between paragraphs rather than bulleting them", () => {
+    expect(show(applyMarkdownCommand(doc("|gi\n\nbelt|"), "bullet"))).toBe("|- gi\n\n- belt|");
+  });
+
+  it("does not swallow the next line when the selection ends on a line break", () => {
+    expect(show(applyMarkdownCommand(doc("|gi\n|belt"), "bullet"))).toBe("|- gi|\nbelt");
+  });
+
+  it("puts the cursor where the person still has to type a link", () => {
+    expect(show(applyMarkdownCommand(doc("read the |handbook|"), "link"))).toBe(
+      "read the [handbook](|)",
+    );
+    // A selected address is the address, so the label is what is missing.
+    expect(show(applyMarkdownCommand(doc("|https://jitsu.au|"), "link"))).toBe(
+      "[|](https://jitsu.au)",
+    );
+    expect(show(applyMarkdownCommand(doc("see: |"), "link"))).toBe("see: [|]()");
+  });
+});
+
+describe("wrapWithTypedCharacter", () => {
+  it("wraps the selection instead of replacing it", () => {
+    // The bug this exists for: highlighting a phrase and reaching for "*"
+    // used to delete the phrase.
+    expect(show(wrapWithTypedCharacter(doc("keep it |tidy|"), "*")!)).toBe("keep it *|tidy|*");
+    expect(show(wrapWithTypedCharacter(doc("keep it |tidy|"), "_")!)).toBe("keep it _|tidy|_");
+    expect(show(wrapWithTypedCharacter(doc("|gi|"), "(")!)).toBe("(|gi|)");
+  });
+
+  it("nests on a second press, because the selection stays on the inner text", () => {
+    const once = wrapWithTypedCharacter(doc("keep it |tidy|"), "*")!;
+    expect(show(wrapWithTypedCharacter(once, "*")!)).toBe("keep it **|tidy|**");
+  });
+
+  it("is an ordinary keystroke with nothing selected, or with no closing half", () => {
+    expect(wrapWithTypedCharacter(doc("tidy|"), "*")).toBeNull();
+    expect(wrapWithTypedCharacter(doc("|tidy|"), "a")).toBeNull();
+  });
+});
+
+describe("continueListOnEnter", () => {
+  it("carries the marker onto the next line", () => {
+    expect(show(continueListOnEnter(doc("- gi|"))!)).toBe("- gi\n- |");
+    expect(show(continueListOnEnter(doc("1. gi|"))!)).toBe("1. gi\n2. |");
+    expect(show(continueListOnEnter(doc("  - gi|"))!)).toBe("  - gi\n  - |");
+    expect(show(continueListOnEnter(doc("> hush|"))!)).toBe("> hush\n> |");
+    expect(show(continueListOnEnter(doc("- [x] gi|"))!)).toBe("- [x] gi\n- [ ] |");
+  });
+
+  it("ends the list when the item is empty, rather than adding another", () => {
+    expect(show(continueListOnEnter(doc("- gi\n- |"))!)).toBe("- gi\n|");
+  });
+
+  it("hands Enter back to the browser everywhere else", () => {
+    expect(continueListOnEnter(doc("plain text|"))).toBeNull();
+    // A selection to replace is the browser's job, not ours.
+    expect(continueListOnEnter(doc("- |gi|"))).toBeNull();
+  });
+});
+
+describe("markdownShortcut", () => {
+  const base = {
+    key: "",
+    code: "",
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    altKey: false,
+  };
+
+  it("reads the bindings every other editor uses", () => {
+    expect(markdownShortcut({ ...base, key: "b", ctrlKey: true })).toBe("bold");
+    expect(markdownShortcut({ ...base, key: "I", ctrlKey: true })).toBe("italic");
+    expect(markdownShortcut({ ...base, key: "k", ctrlKey: true })).toBe("link");
+    expect(markdownShortcut({ ...base, key: "e", ctrlKey: true })).toBe("code");
+  });
+
+  it("takes ⌘ on a Mac and leaves Ctrl to the system caret bindings there", () => {
+    // Ctrl+B and Ctrl+E move the caret in every text field on macOS.
+    expect(markdownShortcut({ ...base, key: "b", metaKey: true }, true)).toBe("bold");
+    expect(markdownShortcut({ ...base, key: "b", ctrlKey: true }, true)).toBeNull();
+    expect(markdownShortcut({ ...base, key: "b", metaKey: true })).toBeNull();
+  });
+
+  it("reads the shifted list bindings off the physical key, not the layout", () => {
+    // Shift+8 is "*" on a US keyboard and "(" on a French one.
+    expect(
+      markdownShortcut({ ...base, key: "*", code: "Digit8", ctrlKey: true, shiftKey: true }),
+    ).toBe("bullet");
+    expect(
+      markdownShortcut({ ...base, key: "&", code: "Digit7", ctrlKey: true, shiftKey: true }),
+    ).toBe("numbered");
+    expect(
+      markdownShortcut({ ...base, key: ">", code: "Period", ctrlKey: true, shiftKey: true }),
+    ).toBe("quote");
+  });
+
+  it("leaves plain typing and Alt combinations alone", () => {
+    expect(markdownShortcut({ ...base, key: "b" })).toBeNull();
+    expect(markdownShortcut({ ...base, key: "b", ctrlKey: true, altKey: true })).toBeNull();
+    expect(markdownShortcut({ ...base, key: "z", ctrlKey: true })).toBeNull();
+  });
+});
+
+describe("shortcutLabel", () => {
+  it("spells a binding the way the keyboard in front of the person does", () => {
+    expect(shortcutLabel("Mod+B", false)).toBe("Ctrl+B");
+    expect(shortcutLabel("Mod+B", true)).toBe("⌘B");
+    expect(shortcutLabel("Mod+Shift+8", true)).toBe("⌘⇧8");
+  });
+});
+
+describe("replacementFor", () => {
+  it("describes an edit as the smallest range that changed", () => {
+    // What lets the browser keep the edit in its own undo history.
+    expect(replacementFor("keep it tidy", "keep it **tidy**")).toEqual({
+      start: 8,
+      end: 12,
+      insert: "**tidy**",
+    });
+    expect(replacementFor("- gi", "gi")).toEqual({ start: 0, end: 2, insert: "" });
+    expect(replacementFor("same", "same")).toEqual({ start: 4, end: 4, insert: "" });
+  });
+});

--- a/src/lib/markdown-editing.test.ts
+++ b/src/lib/markdown-editing.test.ts
@@ -67,6 +67,14 @@ describe("applyMarkdownCommand", () => {
     expect(show(applyMarkdownCommand(doc("|gi\n\nbelt|"), "bullet"))).toBe("|- gi\n\n- belt|");
   });
 
+  it("finds the line it is on in a body that opens with a blank line", () => {
+    // `lastIndexOf("\n", -1)` clamps to 0 and matches that leading newline,
+    // which used to put every offset one character out.
+    expect(
+      show(applyMarkdownCommand({ text: "\nGetting started", start: 0, end: 0 }, "heading")),
+    ).toBe("## |\nGetting started");
+  });
+
   it("does not swallow the next line when the selection ends on a line break", () => {
     expect(show(applyMarkdownCommand(doc("|gi\n|belt"), "bullet"))).toBe("|- gi|\nbelt");
   });
@@ -114,6 +122,18 @@ describe("continueListOnEnter", () => {
 
   it("ends the list when the item is empty, rather than adding another", () => {
     expect(show(continueListOnEnter(doc("- gi\n- |"))!)).toBe("- gi\n|");
+  });
+
+  it("splits an item rather than eating it when the caret is at its front", () => {
+    // Reading only what was behind the caret made "- |gi" look like an empty
+    // item, so Enter deleted the bullet AND kept the key, losing the line.
+    expect(show(continueListOnEnter(doc("- |gi"))!)).toBe("- \n- |gi");
+    // Still inside the marker: nothing to continue.
+    expect(continueListOnEnter(doc("-| gi"))).toBeNull();
+  });
+
+  it("ends an empty checklist item too", () => {
+    expect(show(continueListOnEnter(doc("- [ ] |"))!)).toBe("|");
   });
 
   it("hands Enter back to the browser everywhere else", () => {

--- a/src/lib/markdown-editing.ts
+++ b/src/lib/markdown-editing.ts
@@ -1,0 +1,343 @@
+// What the Markdown body editors do to text when you press a toolbar button, a
+// keyboard shortcut, or a character with something selected.
+//
+// Kept out of the components (the same split `kb-editor.ts` uses, for the same
+// reason) because every rule here is about one string and two cursor offsets,
+// and that is worth pinning in a unit test rather than through a rendered
+// textarea. No React, no DOM.
+//
+// Every function speaks the same shape: a document in, a document out, where a
+// document is the whole text plus where the selection sits. Nothing here
+// mutates, focuses, or scrolls anything; `MarkdownEditor` owns that half.
+
+/** The textarea's text and selection, as the editor reads and writes it. */
+export type MarkdownDoc = {
+  text: string;
+  /** Selection start, or the cursor position when `start === end`. */
+  start: number;
+  end: number;
+};
+
+/** A formatting action, shared by the toolbar buttons and the shortcuts. */
+export type MarkdownCommand =
+  | "bold"
+  | "italic"
+  | "code"
+  | "heading"
+  | "bullet"
+  | "numbered"
+  | "quote"
+  | "link";
+
+/**
+ * The toolbar, in order, with the shortcut each button also answers to.
+ *
+ * `shortcut` is written with a `Mod` stand-in rather than "Ctrl" because the
+ * same binding is ⌘ on a Mac and Ctrl everywhere else; `shortcutLabel` picks.
+ * Heading has no shortcut on purpose: there is no conventional one, and
+ * inventing a binding people have to be told about earns less than the button.
+ */
+export const MARKDOWN_TOOLS: {
+  command: MarkdownCommand;
+  label: string;
+  shortcut: string | null;
+}[] = [
+  { command: "bold", label: "Bold", shortcut: "Mod+B" },
+  { command: "italic", label: "Italic", shortcut: "Mod+I" },
+  { command: "code", label: "Code", shortcut: "Mod+E" },
+  { command: "heading", label: "Heading", shortcut: null },
+  { command: "bullet", label: "Bullet list", shortcut: "Mod+Shift+8" },
+  { command: "numbered", label: "Numbered list", shortcut: "Mod+Shift+7" },
+  { command: "quote", label: "Quote", shortcut: "Mod+Shift+." },
+  { command: "link", label: "Link", shortcut: "Mod+K" },
+];
+
+/** "Mod+B" as the person's own keyboard writes it. */
+export function shortcutLabel(shortcut: string, apple: boolean): string {
+  return apple
+    ? shortcut.replace("Mod+", "⌘").replace("Shift+", "⇧")
+    : shortcut.replace("Mod", "Ctrl");
+}
+
+/**
+ * Which command a key press means, or null to let the browser have the key.
+ *
+ * `apple` decides which modifier counts, and it is not cosmetic: on a Mac,
+ * Ctrl+B and Ctrl+E move the caret in every text field on the system, so
+ * claiming them there would break something a person already relies on. ⌘ is
+ * the editing modifier on that keyboard and Ctrl is the editing modifier on
+ * every other one.
+ *
+ * The list-and-quote bindings are matched on `code` rather than `key`: the
+ * character a shifted 7 produces depends on the keyboard layout ("&" on a US
+ * one, "/" on a French one), while the physical key does not.
+ */
+export function markdownShortcut(
+  e: {
+    key: string;
+    code?: string;
+    ctrlKey: boolean;
+    metaKey: boolean;
+    shiftKey: boolean;
+    altKey: boolean;
+  },
+  apple = false,
+): MarkdownCommand | null {
+  const mod = apple ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+  if (!mod || e.altKey) return null;
+  if (e.shiftKey) {
+    if (e.code === "Digit8") return "bullet";
+    if (e.code === "Digit7") return "numbered";
+    if (e.code === "Period") return "quote";
+    return null;
+  }
+  switch (e.key.toLowerCase()) {
+    case "b":
+      return "bold";
+    case "i":
+      return "italic";
+    case "e":
+      return "code";
+    case "k":
+      return "link";
+    default:
+      return null;
+  }
+}
+
+const WORD = /[\p{L}\p{N}_]/u;
+
+/** The word the cursor is sitting in or against, so a shortcut pressed with
+ * nothing selected still has something to act on. Empty range when it is not
+ * touching a word. */
+function wordRangeAt(text: string, at: number): [number, number] {
+  let start = at;
+  let end = at;
+  while (start > 0 && WORD.test(text[start - 1])) start--;
+  while (end < text.length && WORD.test(text[end])) end++;
+  return [start, end];
+}
+
+/** Wrap, or unwrap, the selection in an inline marker (`**`, `_`, `` ` ``). */
+function toggleInline(doc: MarkdownDoc, marker: string): MarkdownDoc {
+  const { text } = doc;
+  let [start, end] = doc.start === doc.end ? wordRangeAt(text, doc.start) : [doc.start, doc.end];
+
+  // Whitespace inside the markers stops Markdown seeing them at all
+  // ("** bold **" renders literally), and picking a word by double-clicking
+  // often takes the space after it. Leave it outside.
+  while (end > start && /\s/.test(text[end - 1])) end--;
+  while (start < end && /\s/.test(text[start])) start++;
+
+  const selected = text.slice(start, end);
+  const m = marker.length;
+
+  // Already wrapped, with the markers just outside the selection.
+  if (text.slice(start - m, start) === marker && text.slice(end, end + m) === marker) {
+    return {
+      text: text.slice(0, start - m) + selected + text.slice(end + m),
+      start: start - m,
+      end: end - m,
+    };
+  }
+  // Already wrapped, with the markers inside the selection.
+  if (selected.length >= m * 2 && selected.startsWith(marker) && selected.endsWith(marker)) {
+    const inner = selected.slice(m, -m);
+    return {
+      text: text.slice(0, start) + inner + text.slice(end),
+      start,
+      end: start + inner.length,
+    };
+  }
+  return {
+    text: `${text.slice(0, start)}${marker}${selected}${marker}${text.slice(end)}`,
+    start: start + m,
+    end: end + m,
+  };
+}
+
+type LineRule = {
+  /** Matches the prefix this command adds, so pressing it again removes it. */
+  match: RegExp;
+  /** Also stripped before adding, so bullet-over-numbered swaps rather than stacks. */
+  clear: RegExp;
+  make: (index: number) => string;
+};
+
+const LINE_RULES: Record<"heading" | "bullet" | "numbered" | "quote", LineRule> = {
+  heading: { match: /^#{1,6} /, clear: /^#{1,6} /, make: () => "## " },
+  bullet: { match: /^[-*+] /, clear: /^([-*+] |\d+\. )/, make: () => "- " },
+  numbered: { match: /^\d+\. /, clear: /^([-*+] |\d+\. )/, make: (i) => `${i + 1}. ` },
+  quote: { match: /^> /, clear: /^> /, make: () => "> " },
+};
+
+/** Add (or remove) a line marker on every line the selection touches, so a
+ * selected block becomes one bullet per line rather than one bullet swallowing
+ * the lot. */
+function toggleLines(doc: MarkdownDoc, kind: keyof typeof LINE_RULES): MarkdownDoc {
+  const rule = LINE_RULES[kind];
+  const { text } = doc;
+  const lineStart = text.lastIndexOf("\n", doc.start - 1) + 1;
+  // A selection dragged to the start of the next line ends on a newline; that
+  // next line is not part of what the person highlighted.
+  const scanFrom = doc.end > doc.start && text[doc.end - 1] === "\n" ? doc.end - 1 : doc.end;
+  const nextBreak = text.indexOf("\n", scanFrom);
+  const lineEnd = nextBreak === -1 ? text.length : nextBreak;
+
+  const lines = text.slice(lineStart, lineEnd).split("\n");
+  const written = lines.filter((line) => line.trim() !== "");
+  const on = written.length > 0 && written.every((line) => rule.match.test(line));
+
+  let counter = 0;
+  const next = lines.map((line) => {
+    if (on) return line.replace(rule.match, "");
+    // Blank lines between paragraphs are not list items; prefixing them leaves
+    // a trail of empty bullets through the block.
+    if (line.trim() === "" && lines.length > 1) return line;
+    return rule.make(counter++) + line.replace(rule.clear, "");
+  });
+
+  const block = next.join("\n");
+  const collapsed = doc.start === doc.end;
+  const shift = next[0].length - lines[0].length;
+  return {
+    text: text.slice(0, lineStart) + block + text.slice(lineEnd),
+    start: collapsed ? Math.max(lineStart, doc.start + shift) : lineStart,
+    end: collapsed ? Math.max(lineStart, doc.start + shift) : lineStart + block.length,
+  };
+}
+
+const URL_LIKE = /^(https?:\/\/|mailto:|\/)\S*$/;
+
+/** `[label](url)`, with the cursor left wherever the person still has to type. */
+function insertLink(doc: MarkdownDoc): MarkdownDoc {
+  const { text } = doc;
+  const [start, end] = doc.start === doc.end ? wordRangeAt(text, doc.start) : [doc.start, doc.end];
+  const selected = text.slice(start, end);
+
+  // A selected address is the address, not the words to show. Leave the label
+  // empty and put the cursor there.
+  if (URL_LIKE.test(selected)) {
+    return {
+      text: `${text.slice(0, start)}[](${selected})${text.slice(end)}`,
+      start: start + 1,
+      end: start + 1,
+    };
+  }
+  const at = start + selected.length + 3;
+  return {
+    text: `${text.slice(0, start)}[${selected}]()${text.slice(end)}`,
+    // Nothing selected and no word to grab: the label is what is missing.
+    start: selected ? at : start + 1,
+    end: selected ? at : start + 1,
+  };
+}
+
+/** Run a toolbar button or its shortcut against the document. */
+export function applyMarkdownCommand(doc: MarkdownDoc, command: MarkdownCommand): MarkdownDoc {
+  switch (command) {
+    case "bold":
+      return toggleInline(doc, "**");
+    case "italic":
+      return toggleInline(doc, "_");
+    case "code":
+      return toggleInline(doc, "`");
+    case "link":
+      return insertLink(doc);
+    default:
+      return toggleLines(doc, command);
+  }
+}
+
+/** Characters that wrap a selection instead of replacing it, and what closes
+ * them. Typing over a selection is normally destructive, which is exactly what
+ * you do NOT want when you have just highlighted a phrase and reached for `*`. */
+const PAIRS: Record<string, string> = {
+  "*": "*",
+  _: "_",
+  "`": "`",
+  "~": "~",
+  '"': '"',
+  "'": "'",
+  "(": ")",
+  "[": "]",
+  "{": "}",
+};
+
+/**
+ * Wrap the selection in the character just typed, keeping the selection on the
+ * inner text so a second press nests (`*word*` then `**word**`).
+ *
+ * Null means "this is an ordinary keystroke": nothing selected, or a character
+ * that has no closing half.
+ */
+export function wrapWithTypedCharacter(doc: MarkdownDoc, char: string): MarkdownDoc | null {
+  const close = PAIRS[char];
+  if (!close || doc.start === doc.end) return null;
+  const selected = doc.text.slice(doc.start, doc.end);
+  return {
+    text: `${doc.text.slice(0, doc.start)}${char}${selected}${close}${doc.text.slice(doc.end)}`,
+    start: doc.start + 1,
+    end: doc.end + 1,
+  };
+}
+
+const LIST_LINE = /^(\s*)(?:([-*+])|(\d+)\.|(>)) (?:(\[[ xX]\]) )?(.*)$/;
+
+/**
+ * What Enter should do inside a list or a quote: carry the marker onto the next
+ * line, and on a marker with nothing typed after it, take the marker away
+ * instead (which is how every editor lets you leave a list).
+ *
+ * Null hands the key back to the browser, which keeps the native newline and
+ * its place in the undo history for the common case.
+ */
+export function continueListOnEnter(doc: MarkdownDoc): MarkdownDoc | null {
+  if (doc.start !== doc.end) return null;
+  const { text, start } = doc;
+  const lineStart = text.lastIndexOf("\n", start - 1) + 1;
+  const match = LIST_LINE.exec(text.slice(lineStart, start));
+  if (!match) return null;
+
+  const [, indent, bullet, number, quote, task, content] = match;
+  if (content.trim() === "" && !task) {
+    // An empty item: end the list rather than adding another empty one.
+    return { text: text.slice(0, lineStart) + text.slice(start), start: lineStart, end: lineStart };
+  }
+  const marker = quote ? "> " : bullet ? `${bullet} ` : `${Number(number) + 1}. `;
+  const insert = `\n${indent}${marker}${task ? "[ ] " : ""}`;
+  return {
+    text: text.slice(0, start) + insert + text.slice(start),
+    start: start + insert.length,
+    end: start + insert.length,
+  };
+}
+
+/**
+ * The smallest single replacement that turns one text into the other.
+ *
+ * The editor applies its edits as a replacement over a range rather than by
+ * swapping the whole value, because that is what lets the browser keep them in
+ * its own undo history: Ctrl+Z after pressing Bold takes the bold off, instead
+ * of doing nothing (or worse, undoing the last ten minutes of typing in one go).
+ */
+export function replacementFor(
+  before: string,
+  after: string,
+): { start: number; end: number; insert: string } {
+  let prefix = 0;
+  const max = Math.min(before.length, after.length);
+  while (prefix < max && before[prefix] === after[prefix]) prefix++;
+  let suffix = 0;
+  while (
+    suffix < max - prefix &&
+    before[before.length - 1 - suffix] === after[after.length - 1 - suffix]
+  ) {
+    suffix++;
+  }
+  return {
+    start: prefix,
+    end: before.length - suffix,
+    insert: after.slice(prefix, after.length - suffix),
+  };
+}

--- a/src/lib/markdown-editing.ts
+++ b/src/lib/markdown-editing.ts
@@ -125,17 +125,27 @@ function wordRangeAt(text: string, at: number): [number, number] {
   return [start, end];
 }
 
+/**
+ * What the command should actually act on: the selection, or the word the
+ * cursor is in, with the whitespace at either edge left out of it.
+ *
+ * Whitespace inside the markers stops Markdown seeing them at all
+ * ("** bold **" renders literally, "[label ]()" glues the link to the next
+ * word), and picking a word by double-clicking takes the space after it in
+ * most browsers, so this is the common case rather than the odd one.
+ */
+function targetRange(doc: MarkdownDoc): [number, number] {
+  const { text } = doc;
+  let [start, end] = doc.start === doc.end ? wordRangeAt(text, doc.start) : [doc.start, doc.end];
+  while (end > start && /\s/.test(text[end - 1])) end--;
+  while (start < end && /\s/.test(text[start])) start++;
+  return [start, end];
+}
+
 /** Wrap, or unwrap, the selection in an inline marker (`**`, `_`, `` ` ``). */
 function toggleInline(doc: MarkdownDoc, marker: string): MarkdownDoc {
   const { text } = doc;
-  let [start, end] = doc.start === doc.end ? wordRangeAt(text, doc.start) : [doc.start, doc.end];
-
-  // Whitespace inside the markers stops Markdown seeing them at all
-  // ("** bold **" renders literally), and picking a word by double-clicking
-  // often takes the space after it. Leave it outside.
-  while (end > start && /\s/.test(text[end - 1])) end--;
-  while (start < end && /\s/.test(text[start])) start++;
-
+  const [start, end] = targetRange(doc);
   const selected = text.slice(start, end);
   const m = marker.length;
 
@@ -178,6 +188,15 @@ const LINE_RULES: Record<"heading" | "bullet" | "numbered" | "quote", LineRule> 
   quote: { match: /^> /, clear: /^> /, make: () => "> " },
 };
 
+/** A line split into its indentation and the rest, because every rule above
+ * applies to what follows the indent. Enter continues an indented item as an
+ * indented item, so the button has to read one the same way rather than
+ * stacking a second marker in front of the spaces. */
+function splitIndent(line: string): [string, string] {
+  const indent = /^[ \t]*/.exec(line)![0];
+  return [indent, line.slice(indent.length)];
+}
+
 /** Add (or remove) a line marker on every line the selection touches, so a
  * selected block becomes one bullet per line rather than one bullet swallowing
  * the lot. */
@@ -193,15 +212,16 @@ function toggleLines(doc: MarkdownDoc, kind: keyof typeof LINE_RULES): MarkdownD
 
   const lines = text.slice(lineStart, lineEnd).split("\n");
   const written = lines.filter((line) => line.trim() !== "");
-  const on = written.length > 0 && written.every((line) => rule.match.test(line));
+  const on = written.length > 0 && written.every((line) => rule.match.test(splitIndent(line)[1]));
 
   let counter = 0;
   const next = lines.map((line) => {
-    if (on) return line.replace(rule.match, "");
+    const [indent, body] = splitIndent(line);
+    if (on) return indent + body.replace(rule.match, "");
     // Blank lines between paragraphs are not list items; prefixing them leaves
     // a trail of empty bullets through the block.
     if (line.trim() === "" && lines.length > 1) return line;
-    return rule.make(counter++) + line.replace(rule.clear, "");
+    return indent + rule.make(counter++) + body.replace(rule.clear, "");
   });
 
   const block = next.join("\n");
@@ -219,7 +239,7 @@ const URL_LIKE = /^(https?:\/\/|mailto:|\/)\S*$/;
 /** `[label](url)`, with the cursor left wherever the person still has to type. */
 function insertLink(doc: MarkdownDoc): MarkdownDoc {
   const { text } = doc;
-  const [start, end] = doc.start === doc.end ? wordRangeAt(text, doc.start) : [doc.start, doc.end];
+  const [start, end] = targetRange(doc);
   const selected = text.slice(start, end);
 
   // A selected address is the address, not the words to show. Leave the label

--- a/src/lib/markdown-editing.ts
+++ b/src/lib/markdown-editing.ts
@@ -107,6 +107,13 @@ export function markdownShortcut(
 
 const WORD = /[\p{L}\p{N}_]/u;
 
+/** Where the line holding `at` begins. `lastIndexOf` on its own is wrong here:
+ * asked to search from -1 it clamps to 0 and matches a leading newline, which
+ * put the whole of a body that opens with a blank line one character out. */
+function lineStartAt(text: string, at: number): number {
+  return at === 0 ? 0 : text.lastIndexOf("\n", at - 1) + 1;
+}
+
 /** The word the cursor is sitting in or against, so a shortcut pressed with
  * nothing selected still has something to act on. Empty range when it is not
  * touching a word. */
@@ -177,7 +184,7 @@ const LINE_RULES: Record<"heading" | "bullet" | "numbered" | "quote", LineRule> 
 function toggleLines(doc: MarkdownDoc, kind: keyof typeof LINE_RULES): MarkdownDoc {
   const rule = LINE_RULES[kind];
   const { text } = doc;
-  const lineStart = text.lastIndexOf("\n", doc.start - 1) + 1;
+  const lineStart = lineStartAt(text, doc.start);
   // A selection dragged to the start of the next line ends on a newline; that
   // next line is not part of what the person highlighted.
   const scanFrom = doc.end > doc.start && text[doc.end - 1] === "\n" ? doc.end - 1 : doc.end;
@@ -290,19 +297,32 @@ const LIST_LINE = /^(\s*)(?:([-*+])|(\d+)\.|(>)) (?:(\[[ xX]\]) )?(.*)$/;
  * instead (which is how every editor lets you leave a list).
  *
  * Null hands the key back to the browser, which keeps the native newline and
- * its place in the undo history for the common case.
+ * its place in the undo history for the common case. The whole line is read,
+ * not just the part before the caret: pressing Enter from the front of "- gi"
+ * splits the item in two, and reading only what is behind the caret made that
+ * look like an empty item and ate the text.
  */
 export function continueListOnEnter(doc: MarkdownDoc): MarkdownDoc | null {
   if (doc.start !== doc.end) return null;
   const { text, start } = doc;
-  const lineStart = text.lastIndexOf("\n", start - 1) + 1;
-  const match = LIST_LINE.exec(text.slice(lineStart, start));
+  const lineStart = lineStartAt(text, start);
+  const lineBreak = text.indexOf("\n", start);
+  const lineEnd = lineBreak === -1 ? text.length : lineBreak;
+  const match = LIST_LINE.exec(text.slice(lineStart, lineEnd));
   if (!match) return null;
 
-  const [, indent, bullet, number, quote, task, content] = match;
-  if (content.trim() === "" && !task) {
-    // An empty item: end the list rather than adding another empty one.
-    return { text: text.slice(0, lineStart) + text.slice(start), start: lineStart, end: lineStart };
+  const [whole, indent, bullet, number, quote, task, content] = match;
+  // Caret still inside the marker itself: there is no item to continue yet.
+  if (start < lineStart + (whole.length - content.length)) return null;
+
+  if (content.trim() === "") {
+    // An empty item: end the list rather than adding another empty one. A
+    // checklist counts, or a tick box would be the one thing no keystroke ends.
+    return {
+      text: text.slice(0, lineStart) + text.slice(lineEnd),
+      start: lineStart,
+      end: lineStart,
+    };
   }
   const marker = quote ? "> " : bullet ? `${bullet} ` : `${Number(number) + 1}. `;
   const insert = `\n${indent}${marker}${task ? "[ ] " : ""}`;

--- a/src/routes/_authenticated/manager.kb.tsx
+++ b/src/routes/_authenticated/manager.kb.tsx
@@ -42,9 +42,9 @@ import { CSS } from "@dnd-kit/utilities";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { MarkdownEditor } from "@/components/site/MarkdownEditor";
 import { Badge } from "@/components/ui/badge";
 import {
   Select,
@@ -1543,14 +1543,14 @@ function KnowledgeBaseManager() {
 
                   <div>
                     <Label htmlFor="body">Body (Markdown)</Label>
-                    <Textarea
+                    <MarkdownEditor
                       id="body"
                       value={body}
-                      onChange={(e) => setBody(e.target.value)}
+                      onChange={setBody}
                       rows={22}
-                      className="mt-1.5 font-mono text-sm"
+                      aria-describedby="body-hint"
                     />
-                    <p className="mt-1.5 text-xs text-muted-foreground">
+                    <p id="body-hint" className="mt-1.5 text-xs text-muted-foreground">
                       Members comment paragraph by paragraph. Editing the words of a paragraph
                       detaches its comments, which are then shown as being about earlier wording.
                       Adding or moving paragraphs elsewhere leaves other comments where they are.


### PR DESCRIPTION
## What changes for the people using the site

**For a manager writing a knowledge base article at `/manager/kb`.** The body
field now has a row of formatting buttons above it (bold, italic, code, heading,
bullet list, numbered list, quote, link), and each one also answers to the
keyboard shortcut it has in every other editor on their laptop:

| | |
| --- | --- |
| Bold | Ctrl + B |
| Italic | Ctrl + I |
| Code | Ctrl + E |
| Link | Ctrl + K |
| Bullet list | Ctrl + Shift + 8 |
| Numbered list | Ctrl + Shift + 7 |
| Quote | Ctrl + Shift + . |

Each button names its own shortcut when you hover it. On a Mac they are the
Command versions, so Ctrl + B and Ctrl + E still move the caret the way macOS
moves it everywhere else.

Three things that are not the toolbar, and probably matter more day to day:

- **Typing a wrapping character over a selection wraps it**, instead of deleting
  it. Highlighting a phrase and reaching for `*` used to throw the phrase away.
  Now it goes around it, and the phrase stays selected, so pressing `*` again
  gives you `**bold**`. Same for `_`, backtick, quote marks and brackets.
- **Enter carries a list on**, numbering as it goes, and on a bullet with
  nothing typed in it takes the marker away instead, which is how you leave a
  list.
- **Undo still works.** Pressing a button or a shortcut joins the browser's own
  undo history, so Ctrl + Z takes the bold off rather than doing nothing or
  jumping back further than anyone meant.

Nothing changes about what gets stored: it is still plain Markdown, and typing
it by hand is still faster for anyone who knows it. Nothing changes for members
reading an article, and no new email goes out.

**Also for a manager writing a blog post at `/manager/blog`.** That composer
already had a smaller version of this toolbar, written against its own textarea.
Rather than keep two sets of rules in step, both screens now use the same
editor, so the blog composer gains the shortcuts and the three behaviours above.
Its Insert image and Insert video buttons are unchanged; the formatting buttons
there are now icons, matching the knowledge base.

Left out on purpose: the waiver template editor still has a plain textarea. It
is the same component away, but changing the wording people sign is a different
job from writing an article, and it was not what this change was asked to do.

## Technical notes

- `src/lib/markdown-editing.ts` (new, pure, tested) holds every rule about what
  a button, a shortcut or a keystroke does to the text: one string and two
  cursor offsets in, the same shape out. No React, no DOM, the same split
  `kb-editor.ts` uses.
- `src/components/site/MarkdownEditor.tsx` (new) is the DOM half: focus,
  selection, and applying the edit through `document.execCommand` where the
  browser takes it, which is what keeps the change in the native undo stack. It
  never trusts that call's answer, and falls back to a plain controlled update
  (writing the element as well, so a fast typist's next keystroke does not land
  at the stale caret).
- `BlogPostEditor` now composes that component and passes its image/video
  buttons through a `tools` slot; its three inline selection helpers are gone.
- The shifted list bindings are matched on `KeyboardEvent.code`, not `key`, so
  they survive a non-US keyboard layout.
- Tests: 24 cases in `src/lib/markdown-editing.test.ts` for the text rules,
  5 in `src/components/site/MarkdownEditor.test.tsx` for the DOM half.
  `bun run lint`, `bun run typecheck`, `bun run test` (2023 passing) and
  `bun run build` are all green locally, and both CI checks are green on the
  head commit.
- The third commit fixes three list-rule bugs a review of the diff caught, each
  with a test that fails without it: Enter at the front of an item ate the line,
  an empty `- [ ] ` could never be escaped, and a body opening with a blank line
  was one offset out.
- Docs: the editor section of `docs/knowledge-base.md` and the composer
  paragraph in `docs/blog.md`.
