### PR TITLE
Stop /pricing selling the free trial as year-round

### DIFF
--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -81,6 +81,22 @@ the manager screens read the live catalogue now. A price change is edited in
 two places: the plan (immediate, drives what people actually pay) and the
 pricing page copy (a code change, like any other website wording).
 
+**The free trial is two sessions, used at any point during the semester**, and
+that is the most the site may claim. `/first-class` states the terms in full.
+`/pricing` sold the same offer as year-round in three places ("all year long",
+"every day of the year", "always free") and the footer repeated it site-wide
+("all year round"), which promised more than the club honours. Shorter
+statements ("first two sessions free", "your first two are on us") are fine:
+they state the offer without claiming a window. `free-trial-copy.test.ts`
+fails the suite if a year-round claim comes back, and pins the qualifier on
+`/pricing` and `/first-class`.
+
+That is the club's **offer**, not the membership row. The `trial_2_session`
+plan is a credit balance with no expiry (above), so a manager can still check
+someone in on a leftover trial session after the semester ends. The two are
+allowed to differ: the site promises the smaller thing, and the club can
+honour more than it promised.
+
 ## What an ended membership is called
 
 `memberships.status = 'expired'` is one stored word for two different endings,

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -91,6 +91,15 @@ they state the offer without claiming a window. `free-trial-copy.test.ts`
 fails the suite if a year-round claim comes back, and pins the qualifier on
 `/pricing` and `/first-class`.
 
+A plan's own `description` is bound by the same rule and is the one place the
+guard cannot see, because it is **data**: managers type it on
+`/manager/membership-plans` and `/membership` prints it. The trial plan's
+seeded description (`20260722000000_memberships.sql`) predates the rule and
+still reads "Your first two sessions, free all year round.", so signed-in
+members are shown the year-round claim the public pages no longer make.
+Correcting it is a manager edit on that screen, not a code change: editing the
+applied migration would change nothing live and only cause drift.
+
 That is the club's **offer**, not the membership row. The `trial_2_session`
 plan is a credit balance with no expiry (above), so a manager can still check
 someone in on a leftover trial session after the semester ends. The two are

--- a/src/components/site/SiteFooter.tsx
+++ b/src/components/site/SiteFooter.tsx
@@ -19,7 +19,7 @@ export function SiteFooter() {
           </div>
           <p className="mt-3 max-w-sm text-sm text-muted-foreground">
             Practical Japanese Jiu-Jitsu in the heart of Sydney. Beginners welcome. First two
-            sessions are free, all year round.
+            sessions are free.
           </p>
         </div>
         <div>

--- a/src/lib/free-trial-copy.test.ts
+++ b/src/lib/free-trial-copy.test.ts
@@ -15,9 +15,9 @@ import { join } from "node:path";
  * all four places. What can be pinned is the claim that must not come back.
  */
 const YEAR_ROUND_CLAIMS = [
-  /all year/i,
+  /all year\b/i,
   /every day of the year/i,
-  /year[- ]round/i,
+  /year[- ]round\b/i,
   /always free/i,
   /free,? always/i,
   /any time of (the )?year/i,

--- a/src/lib/free-trial-copy.test.ts
+++ b/src/lib/free-trial-copy.test.ts
@@ -13,6 +13,12 @@ import { join } from "node:path";
  * There is no single string to import: each page states the offer in the voice
  * and the length that page needs, and the same sentence would read wrong in
  * all four places. What can be pinned is the claim that must not come back.
+ *
+ * The scan reaches the app's own source and nothing else, so it is a guard,
+ * not proof. Copy that lives as **data** is invisible to it: a membership
+ * plan's `description` is typed into `/manager/membership-plans` and rendered
+ * on `/membership`, and the trial plan's seeded one still claims the offer
+ * runs all year (`docs/memberships.md`).
  */
 const YEAR_ROUND_CLAIMS = [
   /all year\b/i,

--- a/src/lib/free-trial-copy.test.ts
+++ b/src/lib/free-trial-copy.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The club's free trial is two sessions, used at any point **during the
+ * semester**. `/first-class` has always stated it that way; `/pricing` sold it
+ * as year-round in three places ("all year long", "every day of the year",
+ * "always free") and the footer repeated it site-wide ("all year round").
+ * Advertising a free offer more broadly than the club honours it is exactly
+ * what ACL s18 covers, so this is worth a guard rather than a one-off fix.
+ *
+ * There is no single string to import: each page states the offer in the voice
+ * and the length that page needs, and the same sentence would read wrong in
+ * all four places. What can be pinned is the claim that must not come back.
+ */
+const YEAR_ROUND_CLAIMS = [
+  /all year/i,
+  /every day of the year/i,
+  /year[- ]round/i,
+  /always free/i,
+  /free,? always/i,
+  /any time of (the )?year/i,
+];
+
+const srcDir = join(import.meta.dirname, "..");
+
+/** Every source file under `dir` that carries user-facing copy, walked recursively. */
+function collectCopyFiles(dir: string): { path: string; source: string }[] {
+  const found: { path: string; source: string }[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // Generated shadcn primitives carry no club copy.
+      if (entry.name === "ui") continue;
+      found.push(...collectCopyFiles(path));
+      continue;
+    }
+    if (!/\.tsx?$/.test(entry.name)) continue;
+    if (/\.test\.tsx?$/.test(entry.name)) continue;
+    if (entry.name === "routeTree.gen.ts") continue;
+    found.push({ path, source: readFileSync(path, "utf8") });
+  }
+  return found;
+}
+
+describe("the free trial is never advertised as year-round", () => {
+  const files = [
+    ...collectCopyFiles(join(srcDir, "routes")),
+    ...collectCopyFiles(join(srcDir, "components", "site")),
+    ...collectCopyFiles(join(srcDir, "lib", "email-templates")),
+    { path: "lib/faq.ts", source: readFileSync(join(srcDir, "lib", "faq.ts"), "utf8") },
+    { path: "lib/seo.ts", source: readFileSync(join(srcDir, "lib", "seo.ts"), "utf8") },
+  ];
+
+  it("finds the copy files (guards against the scan itself breaking)", () => {
+    expect(files.length).toBeGreaterThan(20);
+    expect(files.some(({ path }) => path.endsWith("pricing.tsx"))).toBe(true);
+    expect(files.some(({ path }) => path.endsWith("SiteFooter.tsx"))).toBe(true);
+  });
+
+  it.each(YEAR_ROUND_CLAIMS.map((claim) => ({ claim })))("no page claims $claim", ({ claim }) => {
+    const offenders = files.filter(({ source }) => claim.test(source)).map(({ path }) => path);
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("the pages that sell the trial say when it runs", () => {
+  const pricing = readFileSync(join(srcDir, "routes", "pricing.tsx"), "utf8");
+  const firstClass = readFileSync(join(srcDir, "routes", "first-class.tsx"), "utf8");
+
+  // Shorter statements elsewhere ("first two sessions free") are fine: they
+  // state the offer without claiming a window. These two pages are where
+  // someone decides to come in or to pay, so they carry the qualifier.
+  it("qualifies the offer on /pricing and /first-class", () => {
+    expect(pricing).toMatch(/during the semester/i);
+    expect(firstClass).toMatch(/during the semester/i);
+  });
+});

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute("/pricing")({
       title: "Pricing | UTS Jitsu",
       description:
         "UTS student and general public fees for Japanese Jiu-Jitsu at UTS Ultimo. Casual, semester, and yearly options.",
-      ogDescription: "Casual, semester and yearly options. First two sessions are always free.",
+      ogDescription: "Casual, semester and yearly options. First two sessions free.",
       path: "/pricing",
     }),
     links: [{ rel: "canonical", href: "https://jitsu.au/pricing" }],
@@ -69,7 +69,7 @@ const extras = [
   {
     title: "First two sessions",
     price: "Free",
-    note: "All year long. No gear needed",
+    note: "Any time during the semester. No gear needed",
   },
   {
     title: "Sydney Jitsu yearly membership",
@@ -124,8 +124,8 @@ function Pricing() {
         <p className="text-sm font-semibold uppercase tracking-wider text-primary">Pricing</p>
         <h1 className="mt-3 text-4xl font-bold md:text-5xl">Simple, honest fees.</h1>
         <p className="mt-5 text-lg text-muted-foreground">
-          Your first two sessions are free, every day of the year. When you're ready to join, pick
-          the option that suits how you want to train.
+          Your first two sessions are free, any time during the semester. When you're ready to join,
+          pick the option that suits how you want to train.
         </p>
       </section>
 


### PR DESCRIPTION
Closes #63

The free trial is **two sessions, used at any point during the semester**. `/first-class` has always said that. `/pricing` said something broader in three places, and the site-wide footer said it a fourth time. This brings all four in line. **The offer itself does not change, only what the site claims about it.**

## Every string that changed

Please confirm the new wording states the terms correctly.

| Where | Was | Now |
| --- | --- | --- |
| `/pricing` intro paragraph | Your first two sessions are free, **every day of the year**. | Your first two sessions are free, **any time during the semester**. |
| `/pricing` "Also good to know" card, under "First two sessions / Free" | **All year long.** No gear needed | **Any time during the semester.** No gear needed |
| `/pricing` social/share description (og:description) | Casual, semester and yearly options. First two sessions are **always** free. | Casual, semester and yearly options. First two sessions free. |
| Footer (every page) | Beginners welcome. First two sessions are free, **all year round**. | Beginners welcome. First two sessions are free. |

Nothing else in the site's own copy claimed a window. The home page, the FAQ, the interest form, the offer banner and the trial confirmation email all say "your first two sessions are free" without saying when, which is accurate as it stands, so they are untouched. That keeps the split the issue suggested: brief where the offer is a hook, qualified on the two pages where someone decides to come in or to pay.

## One thing this PR cannot fix: the trial plan's own description

A review of the diff turned up a fifth year-round claim, and it is the one place a code change cannot reach.

The free trial plan carries a **description**, and `/membership` prints it to signed-in members under "Also available". It was seeded in 2026-07 as:

> Your first two sessions, free all year round.

That text is **data, not repo copy**: managers type it on `/manager/membership-plans`, so correcting it is a 10-second edit on that screen, not a commit. (Editing the applied migration file would change nothing live and would only cause drift, so this PR deliberately does not touch it.) Suggested replacement, matching the rest of the site:

> Your first two sessions, free, any time during the semester.

Worth checking on the live screen: if a manager has already reworded it since 2026-07, it may not need anything.

## What the user will feel

A prospective member reading `/pricing` on their phone now sees the same offer they will see on `/first-class` and hear at reception: two free sessions, during the semester. Nobody loses a session they had, and nobody is turned away at the door holding a page that promised more than the club gives. The footer line is a few words shorter on every page. No new steps, no emails, nothing to migrate.

For the club: the public pages no longer advertise the trial more broadly than it is honoured, which was the consumer-law point in the issue. The plan description above is the last place that claim survives.

## Keeping it fixed

`src/lib/free-trial-copy.test.ts` (new) scans the app's copy (routes, `components/site`, the email templates, the FAQ and the SEO strings) and fails on a year-round claim coming back: "all year", "every day of the year", "year round", "always free", "any time of year". It also pins the "during the semester" qualifier on `/pricing` and `/first-class`, so deleting it fails the suite rather than quietly reverting this.

The test says plainly what it cannot see, so nobody reads a green suite as proof: copy that lives as data (the plan description above) is invisible to it.

I deliberately did **not** put the trial's terms in a shared constant. Each of the four places states the offer in the voice and the length that page needs (a card note, a headline sentence, a share blurb, a footer line), and one shared sentence would read wrong in all four. The rule is what is worth pinning, not the sentence.

## Docs

`docs/memberships.md` records the rule next to the plan catalogue: that plan descriptions are bound by it too, why the guard cannot see them, and why the advertised window and the `trial_2_session` plan's own no-expiry credits are allowed to differ (the site promises the smaller thing, and a manager can still check someone in on a leftover trial session afterwards).

## Merge safety

Other branches are editing `src/routes/pricing.tsx` (the CTA, and the class schedule). This diff touches only the free-trial copy there: three isolated lines, one in `SiteFooter.tsx`, plus a new test file and a docs paragraph. Current `main` is merged in and conflict-free.

## Verification

`bun run deps`, then `bun run lint`, `bun run typecheck`, `bun run test` and `bun run build` all pass locally after merging `main` (109 files, 2037 tests). The new guard was checked by putting "All year long" back and watching it fail with the offending file named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164MRnzwpH8h5aDrnXNXHGM