### PR TITLE
One shared source for the weekly class schedule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -781,9 +781,11 @@ Practical rules:
   for most things: form rules in `src/lib/validation.ts`, server work in
   `src/lib/*.functions.ts` (`createServerFn` + Zod), writes from the browser
   through `useResilientSubmit`, RPC shapes in `src/lib/supabase-rpc.ts`, page
-  chrome in `components/site/*Layout`, indexable pages in `src/lib/seo.ts`. If
-  your change seems to need a _second_ way to do one of these, that is a design
-  decision to raise with the user, not a shortcut to take quietly.
+  chrome in `components/site/*Layout`, indexable pages in `src/lib/seo.ts`, and
+  the club facts every page repeats in `src/lib/venue.ts` (name, address,
+  phone), `src/lib/schedule.ts` (the weekly class times) and `src/lib/faq.ts`.
+  If your change seems to need a _second_ way to do one of these, that is a
+  design decision to raise with the user, not a shortcut to take quietly.
 - **Extracting logic into a pure module is usually the whole "make it easy"
   step.** `validation.ts` and `submit-resilience.ts` exist because behaviour was
   pulled out of handlers and components until it could be tested directly. Do

--- a/src/lib/schedule.test.ts
+++ b/src/lib/schedule.test.ts
@@ -1,0 +1,96 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { beginnerDaysShort, scheduleDays, weeklySchedule } from "./schedule";
+
+describe("the weekly schedule", () => {
+  it("lists a day, a time and a note for every session", () => {
+    expect(weeklySchedule.length).toBeGreaterThan(0);
+    for (const session of weeklySchedule) {
+      expect(session.day.trim().length).toBeGreaterThan(0);
+      expect(session.time.trim().length).toBeGreaterThan(0);
+      expect(session.note.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("names each day once", () => {
+    const days = weeklySchedule.map((s) => s.day);
+    expect(new Set(days).size).toBe(days.length);
+  });
+
+  // AGENTS.md: no em dash in copy, en dash only for a numeric range.
+  it("writes times with an en dash and no em dash anywhere in the copy", () => {
+    for (const session of weeklySchedule) {
+      expect(session.time, `${session.day} should use an en dash range`).toMatch(
+        /^\d{1,2}:\d{2}(am|pm)? – \d{1,2}:\d{2}(am|pm)$/,
+      );
+      expect(`${session.day} ${session.note}`).not.toContain("—");
+    }
+  });
+
+  // "from September" reads as next month every August, so the promise never
+  // looks stale. A month in a note has to carry the year it belongs to.
+  it("dates any month it names, so a stale promise shows as stale", () => {
+    const months =
+      /\b(January|February|March|April|May|June|July|August|September|October|November|December)\b/;
+    for (const session of weeklySchedule) {
+      if (!months.test(session.note)) continue;
+      expect(session.note, `"${session.note}" needs the year`).toMatch(/\b20\d{2}\b/);
+    }
+  });
+
+  it("has at least one session a beginner can walk into", () => {
+    expect(weeklySchedule.some((s) => s.openToBeginners)).toBe(true);
+  });
+});
+
+describe("days written out for a sentence", () => {
+  it("lists every training day for the meta descriptions", () => {
+    expect(scheduleDays).toBe("Monday, Wednesday and Saturday");
+  });
+
+  it("offers only the beginner-friendly nights, short form", () => {
+    expect(beginnerDaysShort).toBe("Mon or Wed");
+  });
+
+  it("derives both from the schedule rather than restating it", () => {
+    for (const session of weeklySchedule) {
+      expect(scheduleDays).toContain(session.day);
+      if (session.openToBeginners) expect(beginnerDaysShort).toContain(session.day.slice(0, 3));
+      else expect(beginnerDaysShort).not.toContain(session.day.slice(0, 3));
+    }
+  });
+});
+
+// The drift this module exists to end: two pages each carrying their own copy
+// of the schedule, agreeing on the times and disagreeing on the notes, with a
+// green suite either way. A page that hardcodes a weekday is writing a third
+// copy, so it fails here rather than in front of a prospective member.
+describe("no page keeps its own copy of the schedule", () => {
+  const ROUTES_DIR = resolve(process.cwd(), "src", "routes");
+  const WEEKDAY_LITERAL =
+    /"(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)"|'(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)'/;
+
+  const routeFiles = readdirSync(ROUTES_DIR, { recursive: true })
+    .map(String)
+    .filter((file) => file.endsWith(".tsx"))
+    .sort();
+
+  it("has route files to check", () => {
+    // A moved routes directory would turn the rule below into a test that
+    // passes by finding no work.
+    expect(routeFiles.length).toBeGreaterThan(10);
+  });
+
+  it("hardcodes no weekday under src/routes", () => {
+    const offenders = routeFiles.filter((file) =>
+      WEEKDAY_LITERAL.test(readFileSync(join(ROUTES_DIR, file), "utf8")),
+    );
+    expect(
+      offenders,
+      "read the schedule from @/lib/schedule (or weekday names from @/lib/calendar) instead of hardcoding one",
+    ).toEqual([]);
+  });
+});

--- a/src/lib/schedule.test.ts
+++ b/src/lib/schedule.test.ts
@@ -69,13 +69,13 @@ describe("days written out for a sentence", () => {
 // green suite either way. A page that hardcodes a weekday is writing a third
 // copy, so it fails here rather than in front of a prospective member.
 describe("no page keeps its own copy of the schedule", () => {
-  const ROUTES_DIR = resolve(process.cwd(), "src", "routes");
+  const ROUTES_DIR = resolve(import.meta.dirname, "..", "routes");
   const WEEKDAY_LITERAL =
     /"(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)"|'(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)'/;
 
   const routeFiles = readdirSync(ROUTES_DIR, { recursive: true })
     .map(String)
-    .filter((file) => file.endsWith(".tsx"))
+    .filter((file) => /\.tsx?$/.test(file) && file !== "routeTree.gen.ts")
     .sort();
 
   it("has route files to check", () => {

--- a/src/lib/schedule.ts
+++ b/src/lib/schedule.ts
@@ -1,0 +1,66 @@
+// Single source of truth for the weekly class schedule.
+//
+// It used to live as a hand-kept array in `routes/classes.tsx` and a second,
+// inline one in `routes/index.tsx`, and they had already drifted: the classes
+// page said "All levels welcome" on Monday and Wednesday, the homepage said
+// nothing, and there was no way to notice. A third copy was spelled out in
+// prose on the register-interest confirmation ("Mon or Wed"). One list here,
+// read by all three, is what stops a schedule change from being a change
+// somebody has to remember to make in four places.
+//
+// This is copy, not data. The calendar (`docs/calendar.md`) holds the real,
+// manager-editable entries with dates and RSVPs; these three lines are the
+// at-a-glance version a prospective member reads before they have an account.
+//
+// `schedule.test.ts` also refuses a weekday literal anywhere under
+// `src/routes/`, so re-hardcoding the schedule on a page fails the suite
+// instead of drifting quietly.
+
+export type ClassSession = {
+  /** Weekday name, as printed on screen. */
+  day: string;
+  /**
+   * Local time range. The en dash is deliberate: `AGENTS.md` bans the em dash
+   * in copy but keeps the en dash for numeric ranges.
+   */
+  time: string;
+  /** Who the session is for, printed under the time. */
+  note: string;
+  /**
+   * True where someone with no experience can just turn up. Drives the prose
+   * on the register-interest confirmation, so adding a beginners night updates
+   * that sentence too.
+   */
+  openToBeginners: boolean;
+};
+
+export const weeklySchedule: ClassSession[] = [
+  { day: "Monday", time: "5:30 – 7:00pm", note: "All levels welcome", openToBeginners: true },
+  { day: "Wednesday", time: "6:00 – 7:30pm", note: "All levels welcome", openToBeginners: true },
+  {
+    day: "Saturday",
+    time: "11:00am – 12:30pm",
+    // The year is not decoration. Without it this reads as "next month" every
+    // August, so a promise that never arrived would look fresh forever.
+    note: "Colour belts only, from September 2026",
+    openToBeginners: false,
+  },
+];
+
+/** "Monday, Wednesday and Saturday" / "Mon or Wed": days written out for a sentence. */
+function joinDays(days: string[], conjunction: "and" | "or"): string {
+  if (days.length < 2) return days.join("");
+  return `${days.slice(0, -1).join(", ")} ${conjunction} ${days[days.length - 1]}`;
+}
+
+/** Every training day, for meta descriptions: "Monday, Wednesday and Saturday". */
+export const scheduleDays = joinDays(
+  weeklySchedule.map((s) => s.day),
+  "and",
+);
+
+/** The nights a beginner can walk into, short form for tight prose: "Mon or Wed". */
+export const beginnerDaysShort = joinDays(
+  weeklySchedule.filter((s) => s.openToBeginners).map((s) => s.day.slice(0, 3)),
+  "or",
+);

--- a/src/routes/classes.tsx
+++ b/src/routes/classes.tsx
@@ -3,27 +3,21 @@ import { ArrowRight, Clock, MapPin, Phone } from "lucide-react";
 import { SiteLayout } from "@/components/site/SiteLayout";
 import { Button } from "@/components/ui/button";
 import { buildPageMeta } from "@/lib/seo";
+import { scheduleDays, weeklySchedule } from "@/lib/schedule";
 import { VENUE_PHONE_DISPLAY, VENUE_PHONE_TEL } from "@/lib/venue";
 
 export const Route = createFileRoute("/classes")({
   head: () => ({
     meta: buildPageMeta({
       title: "Classes & Schedule | UTS Jitsu",
-      description:
-        "Weekly Japanese Jiu-Jitsu classes at ActivateFit Gym, Ultimo. Monday, Wednesday and Saturday.",
-      ogDescription: "Monday, Wednesday and Saturday classes at ActivateFit Gym, Ultimo.",
+      description: `Weekly Japanese Jiu-Jitsu classes at ActivateFit Gym, Ultimo. ${scheduleDays}.`,
+      ogDescription: `${scheduleDays} classes at ActivateFit Gym, Ultimo.`,
       path: "/classes",
     }),
     links: [{ rel: "canonical", href: "https://jitsu.au/classes" }],
   }),
   component: Classes,
 });
-
-const schedule = [
-  { day: "Monday", time: "5:30 – 7:00pm", note: "All levels welcome" },
-  { day: "Wednesday", time: "6:00 – 7:30pm", note: "All levels welcome" },
-  { day: "Saturday", time: "11:00am – 12:30pm", note: "Colour belts only, from September" },
-];
 
 function Classes() {
   return (
@@ -39,7 +33,7 @@ function Classes() {
 
       <section className="mx-auto max-w-6xl px-4">
         <div className="grid gap-4 md:grid-cols-3">
-          {schedule.map((s) => (
+          {weeklySchedule.map((s) => (
             <div key={s.day} className="rounded-xl border bg-card p-6">
               <div className="flex items-center gap-2 text-primary">
                 <Clock className="h-4 w-4" />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,6 +6,7 @@ import { CommonQuestions } from "@/components/site/CommonQuestions";
 import { YouTubeEmbed } from "@/components/site/YouTubeEmbed";
 import { Button } from "@/components/ui/button";
 import { buildClubJsonLd, buildPageMeta } from "@/lib/seo";
+import { weeklySchedule } from "@/lib/schedule";
 import heroAsset from "@/assets/training1.jpg.asset.json";
 
 export const Route = createFileRoute("/")({
@@ -170,15 +171,7 @@ function Home() {
           </div>
 
           <div className="mt-8 grid gap-4 md:grid-cols-3">
-            {[
-              { day: "Monday", time: "5:30 – 7:00pm" },
-              { day: "Wednesday", time: "6:00 – 7:30pm" },
-              {
-                day: "Saturday",
-                time: "11:00am – 12:30pm",
-                note: "Colour belts only, from September",
-              },
-            ].map((s) => (
+            {weeklySchedule.map((s) => (
               <div key={s.day} className="rounded-xl border bg-card p-6">
                 <div className="flex items-center gap-2 text-primary">
                   <Clock className="h-4 w-4" />
@@ -188,7 +181,7 @@ function Home() {
                 <p className="mt-1 flex items-center gap-1.5 text-sm text-muted-foreground">
                   <MapPin className="h-3.5 w-3.5" /> ActivateFit Gym, Ultimo
                 </p>
-                {s.note && <p className="mt-3 text-xs text-muted-foreground">{s.note}</p>}
+                <p className="mt-3 text-xs text-muted-foreground">{s.note}</p>
               </div>
             ))}
           </div>

--- a/src/routes/register-interest.tsx
+++ b/src/routes/register-interest.tsx
@@ -13,6 +13,7 @@ import { INTAKE_SUBMIT } from "@/lib/submit-resilience";
 import { useResilientSubmit } from "@/hooks/use-resilient-submit";
 import { submitInterest } from "@/lib/submissions.functions";
 import { buildPageMeta } from "@/lib/seo";
+import { beginnerDaysShort } from "@/lib/schedule";
 
 export const Route = createFileRoute("/register-interest")({
   head: () => ({
@@ -129,8 +130,8 @@ function RegisterInterest() {
             <p className="text-sm font-medium">Not ready? No problem.</p>
             <p className="mt-1 text-sm text-muted-foreground">
               We'll email you the link and you can sign before you come, or we'll sort it at the
-              gym. Either way, just turn up to any beginners class (Mon or Wed). Your first two are
-              free.
+              gym. Either way, just turn up to any beginners class ({beginnerDaysShort}). Your first
+              two are free.
             </p>
           </div>
 


### PR DESCRIPTION
Closes #51

## What this does

The weekly class schedule was hand-kept in two places (`src/routes/classes.tsx` and an inline array in `src/routes/index.tsx`), with a third version spelled out in prose on the register-interest confirmation. `src/lib/schedule.ts` now owns it, following the pattern `src/lib/venue.ts` and `src/lib/faq.ts` already set for shared site facts. Both pages map over it, the classes page's meta descriptions derive their day list from it, and the register-interest sentence derives "Mon or Wed" from the sessions flagged as open to beginners.

This is a preparatory refactor plus the two copy fixes the issue asked for in the same lines.

## What the user will feel

- **On the homepage**, the Monday and Wednesday cards now carry "All levels welcome" underneath the time. That line was already on `/classes` and just missing here, so a prospective member scanning the homepage gets the same reassurance they'd get one click deeper.
- **On the classes page**, the Saturday note now reads "Colour belts only, from September 2026" instead of "from September".
- Nothing else moves. Same three sessions, same times, same layout, no new steps and no emails.

## ⚠️ The discrepancy, and the guess I had to make

The two copies disagreed and there is no way for me to tell which was right, so please check both of these against the actual schedule:

1. **The Monday/Wednesday note.** `classes.tsx` said "All levels welcome"; `index.tsx` said nothing. I kept "All levels welcome" because it matches the rest of the site (register-interest sends beginners to those two nights, the FAQ says training is structured for every skill level). **If Monday or Wednesday is not actually open to all levels, this now says so in one more place** — correct the note in `src/lib/schedule.ts` and it fixes everywhere at once.
2. **The year on "from September".** I wrote **2026**, since it is August 2026 and that is the natural reading. If the colour-belt Saturday class is not starting next month, that year is wrong and needs changing.

Also worth knowing: **the issue's request to change the Saturday time to 11am - 12:30pm is already done on `main`.** Both files say `11:00am – 12:30pm`, so there was nothing to change and I did not touch the times.

## Left alone deliberately

`src/routes/pricing.tsx` also makes a Saturday claim ("best-effort and included in semester price, but not guaranteed"). That is a payment claim rather than a schedule one, it restates no times, and the file is being edited elsewhere right now, so it is untouched. Worth a look at some point: "best-effort, not guaranteed" and "colour belts only, from September 2026" are two different stories about the same session.

## Tests

`src/lib/schedule.test.ts` pins the derived sentences and the shape of the copy (en dash in a time range, no em dash, a named month must carry its year), and **refuses a hardcoded weekday literal anywhere under `src/routes/`**. That last rule is the one that would have caught the existing drift: it fails the unit suite if a page starts keeping its own copy of the schedule again. I verified it fails by reintroducing a literal before reverting.

`bun run lint`, `bun run typecheck`, `bun run test` (2036 passing) and `bun run build` all green locally. `bun.lock` untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVGH4fwjzWAiDNyqD3mtMn)_