### PR TITLE
Give the public address its street number

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -46,8 +46,10 @@ entry takes a title and a start time and nothing else:
   it is the manager's answer and is left alone; the only thing that overrides it
   is a start that moves past it, which would make the entry backwards.
 - **Location** is pre-filled with the club's gym (ActivateFit Gym, UTS Building 4,
-  745 Harris St, Ultimo). Somewhere else, or nowhere booked yet: overwrite or
-  clear it.
+  745 Harris Street, Ultimo NSW 2007), built from the shared venue constants in
+  `src/lib/venue.ts` so it is the same address the public pages, the map links
+  and the structured data give. Somewhere else, or nowhere booked yet: overwrite
+  or clear it.
 
 Both are only defaults on the add form. Editing an existing date shows what that
 date actually has, so an entry with no location keeps having none.

--- a/src/components/site/SiteFooter.tsx
+++ b/src/components/site/SiteFooter.tsx
@@ -1,7 +1,14 @@
 import { Link } from "@tanstack/react-router";
 import { Instagram, Youtube, Phone, MessageCircle } from "lucide-react";
 import logoAsset from "@/assets/UTS_JITSU_CMYK.png.asset.json";
-import { GOOGLE_MAPS_URL, VENUE_PHONE_DISPLAY, VENUE_PHONE_TEL, WHATSAPP_URL } from "@/lib/venue";
+import {
+  GOOGLE_MAPS_URL,
+  VENUE_ADDRESS,
+  VENUE_NAME,
+  VENUE_PHONE_DISPLAY,
+  VENUE_PHONE_TEL,
+  WHATSAPP_URL,
+} from "@/lib/venue";
 
 export function SiteFooter() {
   return (
@@ -119,7 +126,7 @@ export function SiteFooter() {
             rel="noopener noreferrer"
             className="hover:text-foreground"
           >
-            ActivateFit Gym, Harris Street, Ultimo NSW
+            {VENUE_NAME}, {VENUE_ADDRESS}
           </a>
         </div>
       </div>

--- a/src/lib/calendar.test.ts
+++ b/src/lib/calendar.test.ts
@@ -241,7 +241,10 @@ describe("defaultEndForStart", () => {
 
 describe("DEFAULT_EVENT_LOCATION", () => {
   it("is the gym the club trains at, spelled out to the building", () => {
-    // Composed from the shared venue name, so a rename reaches the calendar too.
-    expect(DEFAULT_EVENT_LOCATION).toBe("ActivateFit Gym, UTS Building 4, 745 Harris St, Ultimo");
+    // Composed from the shared venue constants, so a rename or a corrected
+    // address reaches the calendar too instead of being restated here.
+    expect(DEFAULT_EVENT_LOCATION).toBe(
+      "ActivateFit Gym, UTS Building 4, 745 Harris Street, Ultimo NSW 2007",
+    );
   });
 });

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -6,7 +6,7 @@
 // absolute UTC instants for each date, handling DST via the Intl API (no
 // timezone dependency).
 
-import { VENUE_NAME } from "./venue";
+import { VENUE_ADDRESS, VENUE_NAME } from "./venue";
 
 export const CLUB_TIME_ZONE = "Australia/Sydney";
 
@@ -115,11 +115,11 @@ export const DEFAULT_EVENT_DURATION_MINUTES = 60;
 
 /**
  * Where the club trains, pre-filled on a new calendar entry. Built from the
- * shared venue name so a rename reaches the calendar too; the rest is more
- * specific than the marketing address because it has to get someone from the
- * street to the mats.
+ * shared venue constants, which now carry the building and street number this
+ * line used to restate on its own. It has to get someone from the street to the
+ * mats, and so does every other surface, so there is one address for all of them.
  */
-export const DEFAULT_EVENT_LOCATION = `${VENUE_NAME}, UTS Building 4, 745 Harris St, Ultimo`;
+export const DEFAULT_EVENT_LOCATION = `${VENUE_NAME}, ${VENUE_ADDRESS}`;
 
 /**
  * Read a `datetime-local` value ("YYYY-MM-DDTHH:MM", seconds optional) as plain

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -398,7 +398,11 @@ describe("club details match the site", () => {
     // ended up naming a 1.8km street with no number on it.
     for (const source of [footer, contact, classes, home]) {
       expect(source).toContain("@/lib/venue");
+      // Neither the full street name nor a restated number. "Harris St" on its
+      // own is left alone: the contact page's directions name the Harris St /
+      // Thomas St corner, which is a landmark, not a second copy of the address.
       expect(source).not.toMatch(/Harris Street/);
+      expect(source).not.toMatch(/\d+\s+Harris/);
     }
     expect(VENUE_ADDRESS).toContain(VENUE_STREET_ADDRESS);
   });

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -21,9 +21,11 @@ import { Route as RootRoute } from "@/routes/__root";
 import { Route as AboutRoute } from "@/routes/about";
 import {
   GOOGLE_MAPS_URL,
+  VENUE_ADDRESS,
   VENUE_PHONE_DISPLAY,
   VENUE_PHONE_E164,
   VENUE_PHONE_TEL,
+  VENUE_STREET_ADDRESS,
   WHATSAPP_URL,
 } from "./venue";
 
@@ -314,10 +316,24 @@ describe("buildClubJsonLd", () => {
 
   it("carries a postal address a search engine can place on a map", () => {
     const address = club.address as Record<string, string>;
+    // `streetAddress` is pinned to the literal on purpose. A bare street name
+    // is not an address: Harris Street runs about 1.8km, so a schema saying
+    // "Harris Street" places the club anywhere along it. Deriving the
+    // expectation from `venue.ts` would have accepted that too.
+    expect(address.streetAddress).toBe("745 Harris Street");
+    expect(address.streetAddress).toBe(VENUE_STREET_ADDRESS);
     expect(address.addressLocality).toBe("Ultimo");
     expect(address.addressRegion).toBe("NSW");
     expect(address.postalCode).toBe("2007");
     expect(address.addressCountry).toBe("AU");
+  });
+
+  it("gives the training location the same address as the club", () => {
+    const location = club.location as Record<string, unknown>;
+    expect(location.name).toBe("ActivateFit Gym");
+    // Two copies of the address in one document that disagree is worse than
+    // one, so they are built from the same parts.
+    expect(location.address).toEqual(club.address);
   });
 
   it("serialises to valid JSON for the ld+json script tag", () => {
@@ -343,6 +359,9 @@ describe("buildClubJsonLd", () => {
 
   it("points hasMap at the same deep link the site links out to", () => {
     expect(club.hasMap).toBe(GOOGLE_MAPS_URL);
+    // And that link searches an address with a number in it, so it drops a pin
+    // on the building rather than leaning on a business name resolving.
+    expect(decodeURIComponent(GOOGLE_MAPS_URL)).toContain("745 Harris Street");
   });
 });
 
@@ -353,6 +372,8 @@ describe("club details match the site", () => {
   const footer = readFileSync(join(srcDir, "components", "site", "SiteFooter.tsx"), "utf8");
   const contact = readFileSync(join(srcDir, "routes", "contact.tsx"), "utf8");
   const instructors = readFileSync(join(srcDir, "routes", "instructors.tsx"), "utf8");
+  const classes = readFileSync(join(srcDir, "routes", "classes.tsx"), "utf8");
+  const home = readFileSync(join(srcDir, "routes", "index.tsx"), "utf8");
 
   it("uses the phone number the footer and contact page dial", () => {
     // Pinned to the literal digits, deliberately.
@@ -368,6 +389,18 @@ describe("club details match the site", () => {
     expect(VENUE_PHONE_TEL).toBe("tel:0493631759");
     expect(VENUE_PHONE_DISPLAY).toBe("0493 631 759");
     expect(WHATSAPP_URL).toBe("https://wa.me/61493631759");
+  });
+
+  it("shows the same street address the structured data claims", () => {
+    // Every page that tells a visitor where the club is reads the constant
+    // instead of restating the street, which is what keeps the pages, the map
+    // links and the schema from drifting apart. Restating it is how the site
+    // ended up naming a 1.8km street with no number on it.
+    for (const source of [footer, contact, classes, home]) {
+      expect(source).toContain("@/lib/venue");
+      expect(source).not.toMatch(/Harris Street/);
+    }
+    expect(VENUE_ADDRESS).toContain(VENUE_STREET_ADDRESS);
   });
 
   it("has the footer and contact page read that number rather than restate it", () => {

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -11,7 +11,15 @@
 // so the rules stay unit-testable and free of any server import.
 
 import { PUBLIC_PAGES, type SitemapPage } from "./public-pages";
-import { GOOGLE_MAPS_URL, VENUE_NAME, VENUE_PHONE_E164 } from "./venue";
+import {
+  GOOGLE_MAPS_URL,
+  VENUE_NAME,
+  VENUE_PHONE_E164,
+  VENUE_POSTCODE,
+  VENUE_STATE,
+  VENUE_STREET_ADDRESS,
+  VENUE_SUBURB,
+} from "./venue";
 import trainingAsset from "../assets/training1.jpg.asset.json";
 import logoAsset from "../assets/UTS_JITSU_CMYK.png.asset.json";
 
@@ -199,6 +207,23 @@ export function buildRobotsTxt(host: string | null | undefined): string {
 }
 
 /**
+ * The club's postal address, built from the parts in `venue.ts` so the schema
+ * cannot say one thing while the pages say another. `streetAddress` carries the
+ * street number: a bare street name is not an address a search engine can place
+ * on a map, and Harris Street is nearly two kilometres long.
+ */
+function postalAddress(): Record<string, string> {
+  return {
+    "@type": "PostalAddress",
+    streetAddress: VENUE_STREET_ADDRESS,
+    addressLocality: VENUE_SUBURB,
+    addressRegion: VENUE_STATE,
+    postalCode: VENUE_POSTCODE,
+    addressCountry: "AU",
+  };
+}
+
+/**
  * Structured data describing the club, emitted once on the home page.
  *
  * This is what lets a search engine understand that jitsu.au is a martial arts
@@ -244,25 +269,11 @@ export function buildClubJsonLd(): Record<string, unknown> {
     founder: { "@type": "Person", name: "Franck Royer" },
     areaServed: { "@type": "City", name: "Sydney" },
     hasMap: GOOGLE_MAPS_URL,
-    address: {
-      "@type": "PostalAddress",
-      streetAddress: "Harris Street",
-      addressLocality: "Ultimo",
-      addressRegion: "NSW",
-      postalCode: "2007",
-      addressCountry: "AU",
-    },
+    address: postalAddress(),
     location: {
       "@type": "Place",
       name: VENUE_NAME,
-      address: {
-        "@type": "PostalAddress",
-        streetAddress: "Harris Street",
-        addressLocality: "Ultimo",
-        addressRegion: "NSW",
-        postalCode: "2007",
-        addressCountry: "AU",
-      },
+      address: postalAddress(),
     },
     sameAs: [...CLUB_SOCIAL_URLS],
   };

--- a/src/lib/venue.test.ts
+++ b/src/lib/venue.test.ts
@@ -1,17 +1,41 @@
 import { describe, it, expect } from "vitest";
-import { VENUE_NAME, VENUE_ADDRESS, GOOGLE_MAPS_URL, APPLE_MAPS_URL } from "./venue";
+import {
+  VENUE_NAME,
+  VENUE_ADDRESS,
+  VENUE_ADDRESS_SHORT,
+  VENUE_STREET_ADDRESS,
+  GOOGLE_MAPS_URL,
+  APPLE_MAPS_URL,
+} from "./venue";
 
 describe("venue", () => {
-  it("exposes the display name and address", () => {
+  it("exposes the display name and an address with a street number", () => {
+    // Pinned to the literals, deliberately. Rebuilding the expectation from the
+    // same parts that compose the constant passes just as happily on "Harris
+    // Street, Ultimo NSW", which is the address the site shipped with: Harris
+    // Street runs about 1.8km through Ultimo and Pyrmont, so a first-timer with
+    // that address has a street, not a door.
     expect(VENUE_NAME).toBe("ActivateFit Gym");
-    expect(VENUE_ADDRESS).toBe("Harris Street, Ultimo NSW");
+    expect(VENUE_STREET_ADDRESS).toBe("745 Harris Street");
+    expect(VENUE_ADDRESS).toBe("UTS Building 4, 745 Harris Street, Ultimo NSW 2007");
+    expect(VENUE_ADDRESS_SHORT).toBe("745 Harris Street, Ultimo");
   });
 
+  it("keeps every address form built on the same street address", () => {
+    expect(VENUE_STREET_ADDRESS).toMatch(/^\d+ /);
+    for (const form of [VENUE_ADDRESS, VENUE_ADDRESS_SHORT]) {
+      expect(form).toContain(VENUE_STREET_ADDRESS);
+    }
+  });
+
+  // Both deep-links search the street address rather than the business name, so
+  // they resolve on their own instead of relying on a listing whose name may not
+  // match the one the site shows.
   it("builds a Google Maps deep-link with an encoded query", () => {
     const url = new URL(GOOGLE_MAPS_URL);
     expect(url.origin + url.pathname).toBe("https://www.google.com/maps/search/");
     expect(url.searchParams.get("api")).toBe("1");
-    expect(url.searchParams.get("query")).toContain("ActivateFit Gym");
+    expect(url.searchParams.get("query")).toBe("745 Harris Street, Ultimo NSW 2007");
     // The raw string must be percent-encoded (no bare spaces).
     expect(GOOGLE_MAPS_URL).not.toContain(" ");
   });
@@ -19,7 +43,7 @@ describe("venue", () => {
   it("builds an Apple Maps deep-link with an encoded query", () => {
     const url = new URL(APPLE_MAPS_URL);
     expect(url.origin + url.pathname).toBe("https://maps.apple.com/");
-    expect(url.searchParams.get("q")).toContain("ActivateFit Gym");
+    expect(url.searchParams.get("q")).toBe("745 Harris Street, Ultimo NSW 2007");
     expect(APPLE_MAPS_URL).not.toContain(" ");
   });
 });

--- a/src/lib/venue.ts
+++ b/src/lib/venue.ts
@@ -2,7 +2,24 @@
 // footer so the address and "Open in Maps" targets stay consistent everywhere.
 
 export const VENUE_NAME = "ActivateFit Gym";
-export const VENUE_ADDRESS = "Harris Street, Ultimo NSW";
+
+// The address in parts, because every other form below is built from them. The
+// street NUMBER is the part that matters: Harris Street runs about 1.8km through
+// Ultimo and Pyrmont, so "Harris Street" on its own sends a first-timer to the
+// wrong end of it. Anything that states where the club is (page copy, the map
+// deep-links, the structured data in `seo.ts`, the default calendar location)
+// derives from here rather than restating the address, so they cannot drift.
+export const VENUE_STREET_ADDRESS = "745 Harris Street";
+/** Which door. "745 Harris St" is a large UTS building, so this earns its place. */
+export const VENUE_BUILDING = "UTS Building 4";
+export const VENUE_SUBURB = "Ultimo";
+export const VENUE_STATE = "NSW";
+export const VENUE_POSTCODE = "2007";
+
+/** Everything someone needs to find the door. Footer, contact card, calendar. */
+export const VENUE_ADDRESS = `${VENUE_BUILDING}, ${VENUE_STREET_ADDRESS}, ${VENUE_SUBURB} ${VENUE_STATE} ${VENUE_POSTCODE}`;
+/** Street and suburb, for running copy where the rest would just be noise. */
+export const VENUE_ADDRESS_SHORT = `${VENUE_STREET_ADDRESS}, ${VENUE_SUBURB}`;
 
 // The club's mobile. One literal, in local dialling form; every other shape the
 // site needs is derived from it below, so there is no way for the number the
@@ -24,9 +41,11 @@ export const VENUE_PHONE_TEL = `tel:${VENUE_PHONE_LOCAL}`;
 /** wa.me wants the international number with no leading `+`. */
 export const WHATSAPP_URL = `https://wa.me/${VENUE_PHONE_E164.slice(1)}`;
 
-// Full search string used to build the map deep-links. Kept specific enough
-// (name + street + suburb) to drop a pin on the right building.
-const VENUE_MAP_QUERY = "ActivateFit Gym, Harris Street, Ultimo NSW 2007";
+// Search string behind the map deep-links. It is the street address, not the
+// business name: a name has to resolve in whichever map app the visitor uses,
+// and Google currently lists this room under a different name from the one the
+// site shows. A numbered street address resolves on its own, everywhere.
+const VENUE_MAP_QUERY = `${VENUE_STREET_ADDRESS}, ${VENUE_SUBURB} ${VENUE_STATE} ${VENUE_POSTCODE}`;
 
 // Deep-links open the user's map app of choice. They are plain anchors — no
 // third-party scripts or cookies load until the visitor taps one.

--- a/src/routes/classes.tsx
+++ b/src/routes/classes.tsx
@@ -3,7 +3,13 @@ import { ArrowRight, Clock, MapPin, Phone } from "lucide-react";
 import { SiteLayout } from "@/components/site/SiteLayout";
 import { Button } from "@/components/ui/button";
 import { buildPageMeta } from "@/lib/seo";
-import { VENUE_PHONE_DISPLAY, VENUE_PHONE_TEL } from "@/lib/venue";
+import {
+  VENUE_ADDRESS_SHORT,
+  VENUE_NAME,
+  VENUE_PHONE_DISPLAY,
+  VENUE_PHONE_TEL,
+  VENUE_STREET_ADDRESS,
+} from "@/lib/venue";
 
 export const Route = createFileRoute("/classes")({
   head: () => ({
@@ -32,8 +38,8 @@ function Classes() {
         <p className="text-sm font-semibold uppercase tracking-wider text-primary">Classes</p>
         <h1 className="mt-3 text-4xl font-bold md:text-5xl">Train with us in Ultimo.</h1>
         <p className="mt-5 text-lg text-muted-foreground">
-          Sessions run at ActivateFit Gym on Harris Street, a modern, well-equipped facility on the
-          main UTS campus, easy to reach from the CBD.
+          Sessions run at {VENUE_NAME}, {VENUE_STREET_ADDRESS}, a modern, well-equipped facility on
+          the main UTS campus, easy to reach from the CBD.
         </p>
       </section>
 
@@ -78,7 +84,9 @@ function Classes() {
             <p className="flex items-center gap-2 text-sm font-semibold text-primary">
               <MapPin className="h-4 w-4" /> Location
             </p>
-            <h2 className="mt-2 text-2xl font-bold">ActivateFit Gym, Harris Street, Ultimo NSW</h2>
+            <h2 className="mt-2 text-2xl font-bold">
+              {VENUE_NAME}, {VENUE_ADDRESS_SHORT}
+            </h2>
             <p className="mt-2 flex items-center gap-2 text-sm text-muted-foreground">
               <Phone className="h-4 w-4" />{" "}
               <a href={VENUE_PHONE_TEL} className="hover:text-foreground">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,6 +6,7 @@ import { CommonQuestions } from "@/components/site/CommonQuestions";
 import { YouTubeEmbed } from "@/components/site/YouTubeEmbed";
 import { Button } from "@/components/ui/button";
 import { buildClubJsonLd, buildPageMeta } from "@/lib/seo";
+import { VENUE_ADDRESS_SHORT, VENUE_NAME } from "@/lib/venue";
 import heroAsset from "@/assets/training1.jpg.asset.json";
 
 export const Route = createFileRoute("/")({
@@ -161,7 +162,7 @@ function Home() {
             <div>
               <h2 className="text-3xl font-bold md:text-4xl">Train with us this week</h2>
               <p className="mt-2 max-w-xl text-muted-foreground">
-                Classes run at ActivateFit Gym, on Harris Street in Ultimo.
+                Classes run at {VENUE_NAME}, {VENUE_ADDRESS_SHORT}.
               </p>
             </div>
             <Button asChild variant="outline" className="hidden md:inline-flex">


### PR DESCRIPTION
Closes #64

## What the user will feel

A first-timer heading to a trial class now gets an address that takes them to the door: **ActivateFit Gym, UTS Building 4, 745 Harris Street, Ultimo NSW 2007**. Before this, every public page said "Harris Street, Ultimo NSW", and Harris Street runs about 1.8km through Ultimo and Pyrmont.

Where it changed, as a visitor sees it:

- **Contact page** location card: now shows the building and the number under the gym name. The "Getting there" directions ("enter via Building 4, at the corner of Harris St and Thomas St") are unchanged and now agree with the address above them.
- **Google Maps and Apple Maps** buttons (contact page, classes page, footer): these searched the business name before. They now search `745 Harris Street, Ultimo NSW 2007`, so they drop a pin on the building instead of depending on a listing resolving.
- **Footer**: "ActivateFit Gym, UTS Building 4, 745 Harris Street, Ultimo NSW 2007". It is one line longer on a phone.
- **Classes page**: "Sessions run at ActivateFit Gym, 745 Harris Street, ..." and the Location heading reads "ActivateFit Gym, 745 Harris Street, Ultimo".
- **Home page** schedule strip: "Classes run at ActivateFit Gym, 745 Harris Street, Ultimo."
- **Search engines**: the structured data's `streetAddress` was the bare street name, which is not an address anything can place on a map. It now carries the number, in both places the schema states it.
- **Managers** adding a calendar date see the same pre-filled location as before, spelled the same way as the rest of the site ("745 Harris Street, Ultimo NSW 2007" rather than "745 Harris St, Ultimo"). Nothing about the add form changes.

Nobody has to do anything, no email goes out, and no existing data changes.

## Where the number came from

Not invented. The repo already had it, in `src/lib/calendar.ts`, which pre-filled a new calendar entry with `ActivateFit Gym, UTS Building 4, 745 Harris St, Ultimo`. That is the address this PR promotes to being the only one, exactly as the issue suggested. Someone who RSVPs to a calendar date has had a findable address all along; someone reading `/contact` has not.

## How it is kept from drifting again

`src/lib/venue.ts` now holds the address in parts (street address, building, suburb, state, postcode) and composes every form from them:

- `VENUE_ADDRESS` (full, with the building) for the footer and the contact card,
- `VENUE_ADDRESS_SHORT` (street and suburb) for running copy,
- the map deep-link query,
- the `PostalAddress` in `src/lib/seo.ts` (which had two copies of the address, now built by one helper),
- `DEFAULT_EVENT_LOCATION` in `calendar.ts`, which derives from the constants instead of restating them. That is suggestion 4 in the issue, and it is what removes the split that caused this.

The footer, classes and home pages read the constants now instead of holding the address as a literal.

## Tests

- `venue.test.ts` pins the street address, both composed forms, and both map queries, and asserts the street address starts with a number.
- `seo.test.ts` pins `streetAddress` in the structured data, checks `location.address` matches `address`, checks the `hasMap` link carries the number, and adds a source check that the footer, contact, classes and home pages read the venue constants rather than restating the street.
- `calendar.test.ts` follows the composed default location.

These are pinned to the literal `"745 Harris Street"` on purpose. An expectation rebuilt from the same constants it is checking would have been just as green on the address that shipped. Verified by putting the bare street name back: 7 tests fail across the three suites.

Checks run locally: `bun run lint`, `bun run typecheck`, `bun run test` (2029 passing), `bun run build`. `bun.lock` untouched.

## Two things for the reviewer to decide

1. **The name on the door.** The issue notes the Google listing is "UTS Jitsu, UTS Building, 4/745 Harris St", while every page here says "ActivateFit Gym". I have not changed the name, since which one a visitor should look for on the door is your call, not something to infer. Say the word and it is a one-line change in `venue.ts`.
2. **Is a level or room needed?** 745 Harris Street is a large UTS building. The address now names Building 4, and `/contact` adds the Harris St / Thomas St corner and the internal stairs. If there is a level or room number that would help someone arriving late, tell me and I will add it.

Left alone deliberately: the instructors page lists "UTS Jitsu, Harris St, Australia" in Franck's teaching history. That is a CV entry about where he taught, not directions, so it is outside this issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BKfjJAiUHcQVDf3rjQEcjk)_