### PR TITLE
Gate /update-password on the recovery session

### DIFF
--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -174,9 +174,12 @@ exchanging the token in the URL fragment, so a session arriving late takes the
 panel back off. And a session can lapse between opening the link and pressing
 the button, so `updateUser` refusing with a missing session puts the same panel
 back rather than printing GoTrue's own wording under the field.
-`isMissingSessionError()` is what recognises that refusal, and
-`describePasswordError()` has a branch for it as well, for any caller that
-shows the message instead.
+`isMissingSessionError()` is what recognises that refusal.
+
+`describePasswordError()` has a branch for the same refusal, and it is worded
+for `/account`: the change-password card there can hit it when a member's
+sign-in has lapsed, and the answer for them is to sign in again rather than to
+ask for a reset link.
 
 `/auth` sign-in is deliberately untouched. It checks nothing: an existing member
 holding an older, shorter password keeps signing in with it, because these rules

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -155,6 +155,29 @@ without holding up the form. If that fetch fails the check falls back to the
 email alone. The reason it bothers is that the field is showing a rule that
 mentions your name, and a screen should not list a rule it is not applying.
 
+### When the reset link has expired
+
+Reset links time out, and each one only works once, so a fair share of people
+reach `/update-password` with no recovery session at all. That screen therefore
+has three states rather than one: it says it is checking while the Supabase
+client works out whether the link carried a session, and then either shows the
+form or shows a panel saying the link has expired.
+
+It does not show both. Rendering the form without a session hands somebody who
+is already locked out a form that cannot succeed, and a toast saying so fades
+while the form stays. The panel stays put instead, and carries the two ways
+back: a button to `/reset-password` for a fresh link, and a link to `/auth` to
+sign in with an emailed link and skip the password.
+
+A session can also land a beat after the page does, because the client is still
+exchanging the token in the URL fragment, so a session arriving late takes the
+panel back off. And a session can lapse between opening the link and pressing
+the button, so `updateUser` refusing with a missing session puts the same panel
+back rather than printing GoTrue's own wording under the field.
+`isMissingSessionError()` is what recognises that refusal, and
+`describePasswordError()` has a branch for it as well, for any caller that
+shows the message instead.
+
 `/auth` sign-in is deliberately untouched. It checks nothing: an existing member
 holding an older, shorter password keeps signing in with it, because these rules
 apply when a password is **set**, never when one is used. Nobody is locked out

--- a/src/lib/password-policy.test.ts
+++ b/src/lib/password-policy.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   checkPassword,
   describePasswordError,
+  isMissingSessionError,
   hasVariety,
   isTooLong,
   meetsLength,
@@ -294,6 +295,28 @@ describe("checkPassword", () => {
   });
 });
 
+describe("isMissingSessionError", () => {
+  // Every one of these means the same thing to the person on /update-password:
+  // the link they arrived on is spent, and no password they type will save.
+  it.each([
+    "Auth session missing!",
+    "AuthSessionMissingError: Auth session missing!",
+    "session_not_found",
+    "Session from session_id claim in JWT does not exist",
+    "JWT expired",
+  ])("recognises %s", (message) => {
+    expect(isMissingSessionError(message)).toBe(true);
+  });
+
+  it.each([
+    "Password is known to be weak and easy to guess, please choose a different one.",
+    "Password should be at least 8 characters.",
+    "New password should be different from the old password.",
+  ])("leaves a password refusal alone: %s", (message) => {
+    expect(isMissingSessionError(message)).toBe(false);
+  });
+});
+
 describe("describePasswordError", () => {
   it("turns Supabase's bare weak-password refusal into something actionable", () => {
     const supabaseMessage =
@@ -321,7 +344,16 @@ describe("describePasswordError", () => {
   });
 
   it("passes an unrecognised message through rather than swallowing it", () => {
-    expect(describePasswordError("Auth session missing!")).toBe("Auth session missing!");
+    expect(describePasswordError("Database error saving new user")).toBe(
+      "Database error saving new user",
+    );
+  });
+
+  it("explains a spent reset link rather than printing GoTrue's session error", () => {
+    const rewritten = describePasswordError("Auth session missing!");
+    expect(rewritten).not.toContain("Auth session missing");
+    expect(rewritten).toMatch(/expired/i);
+    expect(rewritten).toMatch(/fresh link/i);
   });
 
   it("contains no em dash, which the copy rules forbid", () => {
@@ -329,6 +361,7 @@ describe("describePasswordError", () => {
       describePasswordError("Password is known to be weak and easy to guess."),
       describePasswordError("Password should be at least 8 characters."),
       describePasswordError("Password cannot be longer than 72 characters"),
+      describePasswordError("Auth session missing!"),
       passwordProblem("short"),
       passwordProblem("aaaaaaaaaaaaaaaaaa"),
       passwordProblem("utsjitsu training club"),

--- a/src/lib/password-policy.test.ts
+++ b/src/lib/password-policy.test.ts
@@ -349,11 +349,11 @@ describe("describePasswordError", () => {
     );
   });
 
-  it("explains a spent reset link rather than printing GoTrue's session error", () => {
+  it("says the session is gone rather than printing GoTrue's own wording", () => {
     const rewritten = describePasswordError("Auth session missing!");
     expect(rewritten).not.toContain("Auth session missing");
-    expect(rewritten).toMatch(/expired/i);
-    expect(rewritten).toMatch(/fresh link/i);
+    expect(rewritten).toMatch(/signed out/i);
+    expect(rewritten).toMatch(/not saved/i);
   });
 
   it("contains no em dash, which the copy rules forbid", () => {

--- a/src/lib/password-policy.ts
+++ b/src/lib/password-policy.ts
@@ -361,10 +361,12 @@ export function isMissingSessionError(message: string): boolean {
  */
 export function describePasswordError(message: string): string {
   const text = message.toLowerCase();
-  // Not a password problem: the link they arrived on is spent. Say that, since
-  // retyping a different password would fail in exactly the same way.
+  // Not a password problem: there is nobody to save it for any more. Worded for
+  // /account, the caller that can actually reach this. /update-password
+  // recognises the same refusal earlier and offers a fresh reset link instead,
+  // since "sign in again" is no use to somebody who came here locked out.
   if (isMissingSessionError(message)) {
-    return "That reset link has expired, so the new password was not saved. Ask for a fresh link and set it again.";
+    return "You have been signed out, so the new password was not saved. Sign in again and set it once more.";
   }
   if (text.includes("known to be weak")) return BREACHED_MESSAGE;
   if (text.includes("should be at least")) {

--- a/src/lib/password-policy.ts
+++ b/src/lib/password-policy.ts
@@ -328,6 +328,29 @@ export function passwordProblem(password: string, context: PasswordContext = {})
 }
 
 /**
+ * Whether Supabase is saying there is no session to change a password on.
+ *
+ * This is what a spent recovery link produces at submit time: the token in the
+ * emailed link timed out or was already used, so `updateUser` has nobody to
+ * update. It is not a password problem at all, and the screen that gets this
+ * should stop showing a form and offer a new link instead.
+ *
+ * Matched loosely, and on several wordings, because they come from GoTrue and
+ * the client rather than from us: the browser client raises its own "Auth
+ * session missing!" before any request goes out, while a session revoked on the
+ * server comes back as `session_not_found` or an expired JWT.
+ */
+export function isMissingSessionError(message: string): boolean {
+  const text = message.toLowerCase();
+  return (
+    text.includes("session missing") ||
+    text.includes("session_not_found") ||
+    text.includes("session from session_id claim in jwt does not exist") ||
+    text.includes("jwt expired")
+  );
+}
+
+/**
  * Supabase's own password refusals, rewritten for the person reading them.
  *
  * The strings are matched loosely on purpose: they come from GoTrue, we do not
@@ -338,6 +361,11 @@ export function passwordProblem(password: string, context: PasswordContext = {})
  */
 export function describePasswordError(message: string): string {
   const text = message.toLowerCase();
+  // Not a password problem: the link they arrived on is spent. Say that, since
+  // retyping a different password would fail in exactly the same way.
+  if (isMissingSessionError(message)) {
+    return "That reset link has expired, so the new password was not saved. Ask for a fresh link and set it again.";
+  }
   if (text.includes("known to be weak")) return BREACHED_MESSAGE;
   if (text.includes("should be at least")) {
     return `A bit short. Use at least ${PASSWORD_MIN_LENGTH} characters.`;

--- a/src/routes/update-password.test.tsx
+++ b/src/routes/update-password.test.tsx
@@ -1,0 +1,177 @@
+// Arriving here with a spent reset link is the ordinary case, not an edge one:
+// links time out and people click them twice. What is pinned below is that the
+// page never shows a password form it cannot save, and that what it shows
+// instead stays on screen with a way to get another link.
+//
+// The router, the site chrome and Supabase are mocked out. What is under test
+// is this page's gate on the recovery session.
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const getSession = vi.fn();
+const updateUser = vi.fn();
+const onAuthStateChange = vi.fn();
+const unsubscribe = vi.fn();
+const getMyProfile = vi.fn();
+const navigate = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => opts,
+  Link: ({ children, to, ...rest }: { children: ReactNode; to?: string }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+  useNavigate: () => navigate,
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: {
+      getSession: (...args: unknown[]) => getSession(...args),
+      updateUser: (...args: unknown[]) => updateUser(...args),
+      onAuthStateChange: (...args: unknown[]) => onAuthStateChange(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/waiver.functions", () => ({
+  getMyProfile: (...args: unknown[]) => getMyProfile(...args),
+}));
+
+vi.mock("@/lib/pwned-passwords", () => ({
+  lookupBreachedPassword: vi.fn().mockResolvedValue("safe"),
+}));
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+vi.mock("@/components/site/SiteLayout", () => ({
+  SiteLayout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+const { Route } = await import("./update-password");
+const UpdatePassword = (Route as unknown as { component: () => ReactNode }).component;
+
+const SESSION = { user: { id: "u1", email: "ada@example.com" } };
+
+/** Hands the page a session the way the Supabase client would, whenever it asks. */
+function withSession(session: unknown) {
+  getSession.mockResolvedValue({ data: { session } });
+}
+
+/** The callback the page registered with `onAuthStateChange`, to fire by hand. */
+function authListener(): (event: string, session: unknown) => void {
+  return onAuthStateChange.mock.calls[0][0];
+}
+
+const expiredPanel = () => screen.queryByRole("alert");
+const passwordField = () => screen.queryByLabelText("New password");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  onAuthStateChange.mockReturnValue({ data: { subscription: { unsubscribe } } });
+  getMyProfile.mockResolvedValue({ first_name: "Ada", last_name: "Lovelace" });
+  updateUser.mockResolvedValue({ error: null });
+  withSession(null);
+});
+
+describe("/update-password", () => {
+  it("says it is checking before the session has resolved", () => {
+    getSession.mockReturnValue(new Promise(() => {}));
+    render(<UpdatePassword />);
+    expect(screen.getByRole("status")).toHaveTextContent(/checking your link/i);
+    expect(passwordField()).not.toBeInTheDocument();
+  });
+
+  it("does not render the form when the link got us no session", async () => {
+    render(<UpdatePassword />);
+    await screen.findByRole("alert");
+    expect(passwordField()).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Update password" })).not.toBeInTheDocument();
+  });
+
+  it("keeps the expired state on screen with a way to get another link", async () => {
+    render(<UpdatePassword />);
+    const panel = await screen.findByRole("alert");
+    expect(panel).toHaveTextContent(/expired/i);
+    expect(screen.getByRole("link", { name: /send me a new link/i })).toHaveAttribute(
+      "href",
+      "/reset-password",
+    );
+    expect(screen.getByRole("link", { name: /sign in with an emailed link/i })).toHaveAttribute(
+      "href",
+      "/auth",
+    );
+    // A panel, not a toast: nothing takes it away again on its own.
+    const { toast } = await import("sonner");
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("does not ask the server for a profile when there is no session", async () => {
+    render(<UpdatePassword />);
+    await screen.findByRole("alert");
+    expect(getMyProfile).not.toHaveBeenCalled();
+  });
+
+  it("renders the form when the link carried a session", async () => {
+    withSession(SESSION);
+    render(<UpdatePassword />);
+    expect(await screen.findByLabelText("New password")).toBeInTheDocument();
+    expect(expiredPanel()).not.toBeInTheDocument();
+  });
+
+  it("clears the expired panel if the session lands a beat late", async () => {
+    render(<UpdatePassword />);
+    await screen.findByRole("alert");
+    authListener()("PASSWORD_RECOVERY", SESSION);
+    expect(await screen.findByLabelText("New password")).toBeInTheDocument();
+    expect(expiredPanel()).not.toBeInTheDocument();
+  });
+
+  it("fetches the profile once when the session arrives twice", async () => {
+    withSession(SESSION);
+    render(<UpdatePassword />);
+    await screen.findByLabelText("New password");
+    authListener()("SIGNED_IN", SESSION);
+    await waitFor(() => expect(getMyProfile).toHaveBeenCalledTimes(1));
+  });
+
+  it("hands back the expired panel when the session lapsed before submitting", async () => {
+    withSession(SESSION);
+    updateUser.mockResolvedValue({ error: { message: "Auth session missing!" } });
+    render(<UpdatePassword />);
+    await userEvent.type(await screen.findByLabelText("New password"), "otter kettle marina");
+    await userEvent.click(screen.getByRole("button", { name: "Update password" }));
+
+    const panel = await screen.findByRole("alert");
+    expect(panel).toHaveTextContent(/expired/i);
+    expect(panel).not.toHaveTextContent(/Auth session missing/);
+    expect(passwordField()).not.toBeInTheDocument();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("keeps a password refusal next to the rules rather than blanking the form", async () => {
+    withSession(SESSION);
+    updateUser.mockResolvedValue({
+      error: { message: "Password is known to be weak and easy to guess." },
+    });
+    render(<UpdatePassword />);
+    await userEvent.type(await screen.findByLabelText("New password"), "otter kettle marina");
+    await userEvent.click(screen.getByRole("button", { name: "Update password" }));
+
+    // Matched on the alert rather than the text, because the rule list beside
+    // the field mentions breaches too.
+    expect(await screen.findByRole("alert")).toHaveTextContent(/public data breach/i);
+    expect(passwordField()).toBeInTheDocument();
+  });
+
+  it("stops listening for the session once the page is gone", async () => {
+    withSession(SESSION);
+    const view = render(<UpdatePassword />);
+    await screen.findByLabelText("New password");
+    view.unmount();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/src/routes/update-password.test.tsx
+++ b/src/routes/update-password.test.tsx
@@ -135,6 +135,27 @@ describe("/update-password", () => {
     expect(expiredPanel()).not.toBeInTheDocument();
   });
 
+  it("holds the form when the listener beats getSession to it", async () => {
+    // The other ordering, and the one production hits most: the auth event
+    // lands first and the getSession answer, which knows nothing about it,
+    // arrives afterwards saying there is no session. That answer must not
+    // pull the form out from under somebody already typing into it.
+    let answer: (result: { data: { session: unknown } }) => void = () => {};
+    getSession.mockReturnValue(
+      new Promise<{ data: { session: unknown } }>((resolve) => {
+        answer = resolve;
+      }),
+    );
+    render(<UpdatePassword />);
+    authListener()("PASSWORD_RECOVERY", SESSION);
+    await screen.findByLabelText("New password");
+
+    answer({ data: { session: null } });
+    await waitFor(() => expect(getMyProfile).toHaveBeenCalledTimes(1));
+    expect(passwordField()).toBeInTheDocument();
+    expect(expiredPanel()).not.toBeInTheDocument();
+  });
+
   it("fetches the profile once when the session arrives twice", async () => {
     withSession(SESSION);
     render(<UpdatePassword />);

--- a/src/routes/update-password.test.tsx
+++ b/src/routes/update-password.test.tsx
@@ -96,6 +96,10 @@ describe("/update-password", () => {
     render(<UpdatePassword />);
     const panel = await screen.findByRole("alert");
     expect(panel).toHaveTextContent(/expired/i);
+    // The heading has to agree with the panel rather than promising the thing
+    // the panel just said is not possible.
+    expect(screen.queryByText("Set a new password")).not.toBeInTheDocument();
+    expect(screen.getByText("Reset link expired")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /send me a new link/i })).toHaveAttribute(
       "href",
       "/reset-password",
@@ -120,6 +124,7 @@ describe("/update-password", () => {
     render(<UpdatePassword />);
     expect(await screen.findByLabelText("New password")).toBeInTheDocument();
     expect(expiredPanel()).not.toBeInTheDocument();
+    expect(screen.getByText("Set a new password")).toBeInTheDocument();
   });
 
   it("clears the expired panel if the session lands a beat late", async () => {

--- a/src/routes/update-password.test.tsx
+++ b/src/routes/update-password.test.tsx
@@ -54,7 +54,9 @@ vi.mock("@/components/site/SiteLayout", () => ({
 const { Route } = await import("./update-password");
 const UpdatePassword = (Route as unknown as { component: () => ReactNode }).component;
 
-const SESSION = { user: { id: "u1", email: "ada@example.com" } };
+// The local part is long enough for the "not built out of your email" rule to
+// bite: tokens under four characters are dropped, so "ada@" would prove nothing.
+const SESSION = { user: { id: "u1", email: "adalovelace@example.com" } };
 
 /** Hands the page a session the way the Supabase client would, whenever it asks. */
 function withSession(session: unknown) {
@@ -154,6 +156,21 @@ describe("/update-password", () => {
     await waitFor(() => expect(getMyProfile).toHaveBeenCalledTimes(1));
     expect(passwordField()).toBeInTheDocument();
     expect(expiredPanel()).not.toBeInTheDocument();
+  });
+
+  it("keeps the form usable when the profile fetch fails", async () => {
+    // The profile only sharpens the "not built out of your name" rule, so
+    // losing it must not cost somebody the form. The email the session carries
+    // still feeds the check.
+    withSession(SESSION);
+    getMyProfile.mockRejectedValue(new Error("network"));
+    render(<UpdatePassword />);
+    expect(await screen.findByLabelText("New password")).toBeInTheDocument();
+    expect(expiredPanel()).not.toBeInTheDocument();
+    await userEvent.type(screen.getByLabelText("New password"), "adalovelace kettle");
+    await userEvent.click(screen.getByRole("button", { name: "Update password" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/anyone who knows you could guess/i);
+    expect(updateUser).not.toHaveBeenCalled();
   });
 
   it("fetches the profile once when the session arrives twice", async () => {

--- a/src/routes/update-password.tsx
+++ b/src/routes/update-password.tsx
@@ -1,10 +1,17 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import type { Session } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
 import { SiteLayout } from "@/components/site/SiteLayout";
 import { NewPasswordField } from "@/components/site/NewPasswordField";
-import { describePasswordError, passwordProblem, type BreachStatus } from "@/lib/password-policy";
+import {
+  describePasswordError,
+  isMissingSessionError,
+  passwordProblem,
+  type BreachStatus,
+} from "@/lib/password-policy";
 import { getMyProfile } from "@/lib/waiver.functions";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -17,9 +24,19 @@ export const Route = createFileRoute("/update-password")({
   component: UpdatePasswordPage,
 });
 
+/**
+ * Whether the link this page was opened with actually got us a session.
+ *
+ * `expired` covers every way of arriving without one: a link that has timed
+ * out, one that was already used, and the page opened on its own. They all
+ * come down to the same thing for the person in front of it, and it is not a
+ * thing a toast can carry, because the answer is to go and get another link.
+ */
+type LinkState = "checking" | "expired" | "ready";
+
 function UpdatePasswordPage() {
   const navigate = useNavigate();
-  const [ready, setReady] = useState(false);
+  const [link, setLink] = useState<LinkState>("checking");
   const [personal, setPersonal] = useState<(string | null | undefined)[]>([]);
   const [password, setPassword] = useState("");
   const [breach, setBreach] = useState<BreachStatus>("idle");
@@ -27,13 +44,15 @@ function UpdatePasswordPage() {
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
-    // Supabase parses the recovery token from the URL hash automatically.
-    supabase.auth.getSession().then(async ({ data }) => {
-      if (!data.session) toast.error("Reset link is invalid or expired. Request a new one.");
-      const email = data.session?.user.email ?? null;
+    let cancelled = false;
+    let adopted = false;
+
+    async function adopt(session: Session) {
+      if (adopted || cancelled) return;
+      adopted = true;
+      const email = session.user.email ?? null;
       setPersonal([email]);
-      setReady(true);
-      if (!data.session) return;
+      setLink("ready");
       // The field promises to refuse a password built out of the person's NAME
       // as well as their address, and the recovery session only carries the
       // address. Fetch the rest so this screen enforces the list it is showing,
@@ -41,6 +60,7 @@ function UpdatePasswordPage() {
       // already usable, and a name arriving late only tightens the check.
       try {
         const profile = await getMyProfile();
+        if (cancelled) return;
         setPersonal([
           email,
           profile?.first_name,
@@ -51,7 +71,26 @@ function UpdatePasswordPage() {
       } catch {
         // Leave the email-only check in place. Supabase still has the last word.
       }
+    }
+
+    // Supabase parses the recovery token from the URL hash automatically, and
+    // it can land a beat after mount. Since the form is gated on the session
+    // now, a late arrival has to take the expired panel back off the screen
+    // rather than leave somebody looking at it holding a link that works.
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session) void adopt(session);
     });
+
+    void supabase.auth.getSession().then(({ data }) => {
+      if (cancelled || adopted) return;
+      if (data.session) return void adopt(data.session);
+      setLink("expired");
+    });
+
+    return () => {
+      cancelled = true;
+      sub.subscription.unsubscribe();
+    };
   }, []);
 
   async function onSubmit(e: React.FormEvent) {
@@ -63,6 +102,10 @@ function UpdatePasswordPage() {
     setBusy(true);
     const { error } = await supabase.auth.updateUser({ password });
     setBusy(false);
+    // A session can lapse between opening the link and pressing the button.
+    // Nothing typed into this form will save now, so hand back the way out
+    // instead of an alert sitting above a form that is finished.
+    if (error && isMissingSessionError(error.message)) return setLink("expired");
     // Not a toast: this stops somebody, so it has to still be on screen while
     // they fix it, next to the rules it is about.
     if (error) return setProblem(describePasswordError(error.message));
@@ -78,7 +121,41 @@ function UpdatePasswordPage() {
             <CardTitle>Set a new password</CardTitle>
           </CardHeader>
           <CardContent>
-            {ready && (
+            {link === "checking" && (
+              <p
+                className="flex items-center gap-2 text-sm text-muted-foreground"
+                role="status"
+                aria-live="polite"
+              >
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                Checking your link...
+              </p>
+            )}
+
+            {link === "expired" && (
+              <div
+                className="space-y-3 rounded-lg border border-destructive/40 bg-destructive/5 p-4"
+                role="alert"
+              >
+                <p className="text-sm font-medium">That reset link has expired.</p>
+                <p className="text-sm text-muted-foreground">
+                  Reset links stop working after a while, and each one only works once. Ask for a
+                  fresh one and it will be in your inbox in a minute.
+                </p>
+                <Button asChild size="sm">
+                  <Link to="/reset-password">Send me a new link</Link>
+                </Button>
+                <p className="text-sm text-muted-foreground">
+                  Rather skip the password?{" "}
+                  <Link to="/auth" className="underline underline-offset-4">
+                    Sign in with an emailed link
+                  </Link>{" "}
+                  instead.
+                </p>
+              </div>
+            )}
+
+            {link === "ready" && (
               <form onSubmit={onSubmit} className="space-y-4">
                 <NewPasswordField
                   id="new-pw"

--- a/src/routes/update-password.tsx
+++ b/src/routes/update-password.tsx
@@ -118,7 +118,12 @@ function UpdatePasswordPage() {
       <section className="mx-auto max-w-md px-4 py-16">
         <Card>
           <CardHeader>
-            <CardTitle>Set a new password</CardTitle>
+            {/* The heading has to agree with the panel under it: "Set a new
+                password" over "that link has expired" reads as a page arguing
+                with itself, to somebody who is already locked out. */}
+            <CardTitle>
+              {link === "expired" ? "Reset link expired" : "Set a new password"}
+            </CardTitle>
           </CardHeader>
           <CardContent>
             {link === "checking" && (
@@ -140,7 +145,7 @@ function UpdatePasswordPage() {
                 <p className="text-sm font-medium">That reset link has expired.</p>
                 <p className="text-sm text-muted-foreground">
                   Reset links stop working after a while, and each one only works once. Ask for a
-                  fresh one and it will be in your inbox in a minute.
+                  fresh one and check your inbox.
                 </p>
                 <Button asChild size="sm">
                   <Link to="/reset-password">Send me a new link</Link>


### PR DESCRIPTION
Closes #61

## The problem

`/update-password` set `ready` whether or not `getSession()` found a session. Someone opening a reset link that had expired or was already used got a toast, and then the password form anyway. Once the toast faded there was nothing on screen saying why, and the form could only fail, with GoTrue's own wording under it when it did.

## What changed

The page now has three states instead of one:

- **checking** while the client works out whether the link carried a session (`role="status"`, so it is announced, not a blank card),
- **expired** when it did not: a panel that stays on screen, headed "Reset link expired", with a button to `/reset-password` for a fresh one and a link to `/auth` to sign in with an emailed link and skip the password,
- **ready**, the form, unchanged.

Two ways the session moves under the page are handled with it:

- It can arrive a beat after mount, because the client is still exchanging the token in the URL fragment. Gating the form on the session means a late arrival has to take the panel back off, so the page listens for it and adopts the session once, in either arrival order.
- It can lapse between opening the link and pressing the button. `isMissingSessionError()` recognises that refusal and puts the panel back rather than showing a password alert above a form that is finished.

`describePasswordError()` gains a branch for the same refusal, but worded for `/account`, the caller that can actually reach it now: the change-password card there hits this when a member's sign-in has lapsed, and the useful answer for them is to sign in again rather than to ask for a reset link.

No new panel component: this follows the `loadError` shape from `manager.contact-messages.tsx`.

## What the user will feel

Someone who clicks a reset link too late, or clicks the one from last week twice, no longer gets a form that cannot work. They get one screen that stays put telling them the link has expired, with a button that takes them straight to asking for a new one, and a second way in if they would rather not bother with a password at all. Nobody who is locked out is left guessing whether the page or their typing is at fault.

Someone with a working link sees no change beyond a brief "Checking your link..." in place of the previously blank card, which was already there as an empty panel while the session resolved.

Nothing is sent, nothing is deleted, and no existing password stops working.

## Tests

- `src/routes/update-password.test.tsx` (new): the form never renders without a session, the panel carries both ways back and no toast fires, the heading agrees with whichever state is showing, a late session clears the panel in either arrival order, the profile is fetched once when the session arrives twice, a session lapsing at submit time hands the panel back instead of printing GoTrue's message, and a password refusal still sits next to the rules with the form intact.
- `src/lib/password-policy.test.ts`: the new matcher across the wordings GoTrue and the client produce, plus its copy. The old "unrecognised message passes through" case used `Auth session missing!`, which is now recognised, so it moved to a message that really is unrecognised.

`bun run lint`, `bun run typecheck`, `bun run test` (2046 passing) and `bun run build` all pass locally. `docs/passwords.md` gained a "When the reset link has expired" section.

`/update-password` is deliberately not walked by the e2e tour (it needs a token only its own email carries), so the coverage above is the unit suite.

## One thing left alone, on purpose

If the browser already holds an unrelated valid session, a dead reset link still renders the form, because `getSession()` returns the stored session rather than one derived from the link. That predates this change and has no security consequence: the person is already signed in to that account and can change its password from `/account` anyway. Tightening it (adopting only on a `PASSWORD_RECOVERY` event) would regress a real case, since that event does not fire again if the page is reloaded after the token exchange, so a valid recovery would then show the expired panel. Worth a separate decision rather than widening this PR.