### PR TITLE
Stop the pricing CTA dead-ending signed-out prospects

### DIFF
--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -87,9 +87,13 @@ no self-serve sign-up: a login exists only once a manager has approved your
 waiver. A signed-in member gets "Manage your membership" straight to
 `/membership`. Everyone else gets "Join the club" into `/register-interest`,
 plus a sign-in link carrying `redirect=/membership` for a member who happens to
-be signed out. Until the browser has resolved the session it shows the
-signed-out branch, which is what the server renders anyway and is right for
-almost everyone reading a public pricing page.
+be signed out. That redirect is honoured when they already have a live session
+and when they sign in with a password; the emailed magic link still finishes on
+`/account`, because `MagicLinkSignIn` hard-codes its `emailRedirectTo` and never
+sees the parameter (true of every `?redirect=` link on the site, not just this
+one). Until the browser has resolved the session it shows the signed-out
+branch, which is what the server renders anyway and is right for almost
+everyone reading a public pricing page.
 
 **Any other public page linking into `_authenticated` needs the same
 treatment**, for the same reason: the gate behind it has nothing a person

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -81,6 +81,20 @@ the manager screens read the live catalogue now. A price change is edited in
 two places: the plan (immediate, drives what people actually pay) and the
 pricing page copy (a code change, like any other website wording).
 
+Its call to action (`MembershipCta`) reads who is looking before it decides
+where to send them, because `/membership` is behind the auth gate and there is
+no self-serve sign-up: a login exists only once a manager has approved your
+waiver. A signed-in member gets "Manage your membership" straight to
+`/membership`. Everyone else gets "Join the club" into `/register-interest`,
+plus a sign-in link carrying `redirect=/membership` for a member who happens to
+be signed out. Until the browser has resolved the session it shows the
+signed-out branch, which is what the server renders anyway and is right for
+almost everyone reading a public pricing page.
+
+**Any other public page linking into `_authenticated` needs the same
+treatment**, for the same reason: the gate behind it has nothing a person
+without a login can do.
+
 ## What an ended membership is called
 
 `memberships.status = 'expired'` is one stored word for two different endings,

--- a/e2e/member/membership.spec.ts
+++ b/e2e/member/membership.spec.ts
@@ -14,6 +14,19 @@ test.afterAll(async () => {
   await adminClient().from("memberships").delete().in("payment_reference", references);
 });
 
+// How a signed-in member reaches this page from the public site. The pricing
+// page's call to action swaps once the browser knows who is reading, so this is
+// the half of that swap a unit test cannot see happen in a real session.
+test("the pricing page takes a signed-in member to their membership page", async ({ page }) => {
+  await page.goto("/pricing");
+
+  await page.getByRole("main").getByRole("link", { name: "Manage your membership" }).click();
+
+  await expect(page).toHaveURL(/\/membership$/);
+  await expect(page.getByText("You're an active member. See you on the mat!")).toBeVisible();
+  await expectPageRendered(page);
+});
+
 test("the member's status and memberships show on their membership page", async ({ page }) => {
   await page.goto("/membership");
 

--- a/e2e/public/auth-gate.spec.ts
+++ b/e2e/public/auth-gate.spec.ts
@@ -1,5 +1,7 @@
 // Asking for a member screen while signed out sends you to sign in, and
-// remembers where you were going.
+// remembers where you were going. The other half of that: a public page must
+// not point someone at the gate in the first place, because there is no
+// self-serve sign-up behind it.
 
 import { expect, test } from "../support/test";
 
@@ -21,4 +23,32 @@ test("the sign-in page points people with no login at the waiver", async ({ page
     "href",
     "/waiver",
   );
+});
+
+// /membership is behind the auth gate and a login only exists once the club has
+// approved your waiver, so the pricing page's call to action has to read who is
+// looking at it. Sending a prospect who just decided on the price to a sign-in
+// box is losing them at the best moment they will ever have.
+test("the pricing page sends a signed-out visitor to the joining funnel, not the gate", async ({
+  page,
+}) => {
+  await page.goto("/pricing");
+
+  await page.getByRole("main").getByRole("link", { name: "Join the club" }).click();
+
+  await expect(page).toHaveURL(/\/register-interest$/);
+  await expect(page.getByRole("heading", { name: "Start your free trial" })).toBeVisible();
+});
+
+test("a member who is signed out can still get from pricing to their membership", async ({
+  page,
+}) => {
+  await page.goto("/pricing");
+
+  await page.getByRole("main").getByRole("link", { name: "Sign in" }).click();
+
+  // Signing in from here lands on the page they were reaching for, rather than
+  // dropping them on their account to find it again.
+  await expect(page).toHaveURL(/\/auth\?redirect=%2Fmembership$/);
+  await expect(page.getByRole("textbox", { name: "Email" })).toBeVisible();
 });

--- a/e2e/public/auth-gate.spec.ts
+++ b/e2e/public/auth-gate.spec.ts
@@ -47,8 +47,10 @@ test("a member who is signed out can still get from pricing to their membership"
 
   await page.getByRole("main").getByRole("link", { name: "Sign in" }).click();
 
-  // Signing in from here lands on the page they were reaching for, rather than
-  // dropping them on their account to find it again.
+  // The link asks to come back to /membership rather than dropping them on
+  // their account to find it again. Only the URL is asserted here: what /auth
+  // then does with the parameter is SignInForms' business, and it currently
+  // honours it on the password form but not on the emailed magic link.
   await expect(page).toHaveURL(/\/auth\?redirect=%2Fmembership$/);
   await expect(page.getByRole("textbox", { name: "Email" })).toBeVisible();
 });

--- a/src/components/site/MembershipCta.test.tsx
+++ b/src/components/site/MembershipCta.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mockUseAuth = vi.fn();
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    to,
+    search,
+    children,
+    ...props
+  }: {
+    to: string;
+    search?: { redirect?: string };
+    children: React.ReactNode;
+  }) => (
+    <a
+      href={search?.redirect ? `${to}?redirect=${encodeURIComponent(search.redirect)}` : to}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+import { MembershipCta } from "./MembershipCta";
+
+describe("MembershipCta", () => {
+  afterEach(() => {
+    mockUseAuth.mockReset();
+  });
+
+  // The bug this component exists for: /membership is behind the auth gate and
+  // there is no self-serve sign-up, so linking a signed-out prospect at it
+  // parked them in a sign-in box waiting for an email that never comes.
+  it("sends a signed-out visitor into the joining funnel, never at the member area", () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false });
+    render(<MembershipCta />);
+
+    expect(screen.getByRole("link", { name: "Join the club" })).toHaveAttribute(
+      "href",
+      "/register-interest",
+    );
+    expect(screen.queryByRole("link", { name: /manage your membership/i })).not.toBeInTheDocument();
+    for (const link of screen.getAllByRole("link")) {
+      expect(link.getAttribute("href")).not.toBe("/membership");
+    }
+  });
+
+  // Someone who already trains here and happens to be signed out is the other
+  // half of the old "Join or manage" label. They still need a way through.
+  it("offers a signed-out visitor a sign-in that lands on their membership page", () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false });
+    render(<MembershipCta />);
+
+    expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute(
+      "href",
+      "/auth?redirect=%2Fmembership",
+    );
+  });
+
+  it("takes a signed-in member straight to their membership page", () => {
+    mockUseAuth.mockReturnValue({ user: { id: "u1" }, loading: false });
+    render(<MembershipCta />);
+
+    expect(screen.getByRole("link", { name: "Manage your membership" })).toHaveAttribute(
+      "href",
+      "/membership",
+    );
+    expect(screen.queryByRole("link", { name: "Join the club" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Sign in" })).not.toBeInTheDocument();
+  });
+
+  // The session resolves a tick after hydration, and the server has no session
+  // at all. Whatever is on screen in the meantime has to be pressable, and it
+  // has to be the same thing the server rendered.
+  it("shows the joining branch while the session is still resolving", () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: true });
+    render(<MembershipCta />);
+
+    expect(screen.getByRole("link", { name: "Join the club" })).toHaveAttribute(
+      "href",
+      "/register-interest",
+    );
+  });
+});

--- a/src/components/site/MembershipCta.tsx
+++ b/src/components/site/MembershipCta.tsx
@@ -1,0 +1,51 @@
+import { Link } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/useAuth";
+
+/**
+ * The pricing page's "so how do I actually pay?" call to action.
+ *
+ * It has to know who is reading, because only one of the two audiences can use
+ * /membership. That page sits behind the auth gate, and this site has no
+ * self-serve sign-up: a login only exists once a manager has approved your
+ * waiver. So an unconditional link to it walked a prospective member into a
+ * sign-in box with nothing to do in it, where the one available action asks
+ * for an email that will never get a link (issue #58). Someone who has just
+ * read the prices and decided is the worst person on the site to dead-end.
+ *
+ * While the session is still resolving we render the signed-out branch rather
+ * than a spinner or an empty slot. It is what the server renders anyway, it is
+ * right for the large majority of people reading a public pricing page, and it
+ * always leaves something on screen to press. SiteHeader treats "not known
+ * yet" the same way, so the two agree.
+ */
+export function MembershipCta() {
+  const { user } = useAuth();
+
+  if (user) {
+    return (
+      <Button asChild variant="outline">
+        <Link to="/membership">Manage your membership</Link>
+      </Button>
+    );
+  }
+
+  return (
+    <div>
+      <Button asChild variant="outline">
+        <Link to="/register-interest">Join the club</Link>
+      </Button>
+      <p className="mt-3 max-w-prose text-sm text-muted-foreground">
+        Joining starts with a free class, so there's nothing to pay yet. Already have a login?{" "}
+        <Link
+          to="/auth"
+          search={{ redirect: "/membership" }}
+          className="font-semibold text-primary underline"
+        >
+          Sign in
+        </Link>{" "}
+        to buy or renew your membership.
+      </p>
+    </div>
+  );
+}

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Check } from "lucide-react";
+import { MembershipCta } from "@/components/site/MembershipCta";
 import { SiteLayout } from "@/components/site/SiteLayout";
 import { Testimonials } from "@/components/site/Testimonials";
 import { Button } from "@/components/ui/button";
@@ -163,9 +164,7 @@ function Pricing() {
           classes during the UTS summer break.
         </p>
         <div className="mt-6">
-          <Button asChild variant="outline">
-            <Link to="/membership">Join or manage your membership</Link>
-          </Button>
+          <MembershipCta />
         </div>
       </section>
 


### PR DESCRIPTION
Closes #58

## The dead end

`/pricing` ended with an unconditional "Join or manage your membership" button pointing at `/membership`. That route is inside `_authenticated`, so a signed-out visitor was bounced to `/auth`: a bare sign-in box that never says why they landed there. There is no self-serve sign-up on this site, so the only available action was entering an email and being told a sign-in link had been sent, for an account that does not exist.

The person most likely to walk into that is a prospective member on a phone who has just read the prices and decided they are interested. That is the worst moment on the site to lose someone.

## What changed

The CTA now reads who is looking before deciding where to send them, the same gate `SiteHeader` has always used:

- **Signed in** → "Manage your membership", straight to `/membership`.
- **Signed out** → "Join the club", into `/register-interest`, with a line underneath: "Joining starts with a free class, so there's nothing to pay yet. Already have a login? **Sign in** to buy or renew your membership." That sign-in link carries `redirect=/membership` (see the caveat below).

While the browser is still working out the session it renders the signed-out branch. That is what the server renders anyway, it is right for almost everyone reading a public pricing page, and it always leaves something pressable on screen. `SiteHeader` treats "not known yet" the same way, so the two agree.

## What the user will feel

**A prospective member** presses a button that now leads somewhere they can actually use. Instead of a sign-in wall and a wait for an email that never arrives, they land on the 30-second interest form, and the line under the button tells them up front that joining starts with a free class so there is nothing to pay yet.

**An existing member, signed in**, sees a shorter and more honest label ("Manage your membership") and goes exactly where they went before. Nothing about their journey changes.

**An existing member who is signed out** used to be the only person the old button served correctly. They keep a route: the sign-in link, which asks to come back to `/membership`.

Nobody gets an extra step, no email goes out, and nothing is deleted or moved.

## One thing found on the way, deliberately not fixed here

The `redirect=/membership` is honoured when the person already has a live session, and by the password form. It is **not** honoured by the emailed magic link: `MagicLinkSignIn` in `SignInForms.tsx` hard-codes `emailRedirectTo: ${origin}/account` and is never handed the `redirect` prop at all, so that path always finishes on `/account`.

That is pre-existing and site-wide, not something this branch introduced: every `?redirect=` link on the site is affected the same way (`/calendar`, `/code-of-conduct`, `/kb/$slug`, `/blog/$slug`). Fixing it means changing where every one of those lands after a magic-link sign-in, which is a behaviour change with its own blast radius and deserves its own PR rather than riding in on a pricing-page button. So this branch keeps the parameter, consistent with the rest of the site, and the doc plus the e2e comment now say plainly which paths honour it. Happy to open the follow-up if you want it.

## Scope

- The branch lives in `src/components/site/MembershipCta.tsx`, so it is unit-testable and `src/routes/pricing.tsx` changes by exactly one line. Two other branches are editing that file (the free-trial copy and the class schedule), so this should merge cleanly with both.
- Checked the rest of the site for the same pattern, as the issue suggested. `/pricing` was the only public page linking into `_authenticated`. `src/routes/email-settings/$token.tsx` links at `/notifications`, but its reader arrived from a notification email, so they do have a login: that one is fine as it is.
- **No sign-up flow was built**, deliberately. Accounts here are created when a manager approves a waiver, and that gate is the club's, not an accident of the code. If self-serve sign-up is ever wanted it is a product decision with a waiver-approval consequence, not a fix for this button. Routing prospects into the interest funnel is the honest answer today.

## Tests

- `src/components/site/MembershipCta.test.tsx`: all four states. Signed out goes to `/register-interest` and never at `/membership`; the sign-in link carries the redirect; signed in goes to `/membership` with the joining copy gone; the still-resolving state shows the pressable joining branch.
- `e2e/public/auth-gate.spec.ts`: a signed-out visitor clicking the CTA on `/pricing` reaches the free-trial form, and the sign-in link lands on `/auth?redirect=%2Fmembership`. Runs at desktop and phone width.
- `e2e/member/membership.spec.ts`: the signed-in half of the swap, clicked through in a real session. That is the part a unit test cannot see happen.

## Docs

`docs/memberships.md` owns the pricing-page section; it now records what the CTA does for each audience and why, the magic-link caveat above, and the rule that any other public page linking into `_authenticated` needs the same treatment.

## Verification

`bun run deps`, then `bun run lint`, `bun run typecheck`, `bun run test` (2030 passing) and `bun run build` all green locally. `bunx tsc -p e2e/tsconfig.json` clean too. `bun.lock` untouched.
