### PR TITLE
Fail the drift workflow when its credential is missing

### DIFF
--- a/.github/workflows/migration-drift.yml
+++ b/.github/workflows/migration-drift.yml
@@ -56,25 +56,31 @@ jobs:
       # A single read-only SELECT against the migration ledger. psql ships on
       # the ubuntu-latest image, so there is nothing to install.
       #
-      # A missing secret warns and passes rather than failing, so that setting
-      # the workflow up does not wedge main. That means a green check here does
-      # NOT prove there is no drift unless the secret is set — read the summary,
-      # which says which of the two happened.
+      # A missing secret FAILS the job. It used to warn and pass, which meant
+      # every run since the repo began reported success while asking the
+      # database nothing — a green tick that said "no drift" when it meant "the
+      # job started". That is worse than having no check at all: a missing check
+      # is a known gap, a false green stops anyone from looking. So an unarmed
+      # check is red, and a green tick here means the live database was asked.
       - name: Compare supabase/migrations against the live ledger
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
           if [ -z "$SUPABASE_DB_URL" ]; then
-            echo "::warning::SUPABASE_DB_URL is not set — the migration drift check did NOT run."
+            echo "::error::SUPABASE_DB_URL is not set, so the migration drift check could not run."
             {
-              echo "### ⚠️ Migration drift check not armed"
+              echo "### ❌ Migration drift check not armed"
               echo
-              echo "\`SUPABASE_DB_URL\` is not set, so this run checked nothing."
-              echo "A green tick here does **not** mean the migrations are applied."
+              echo "\`SUPABASE_DB_URL\` is not set, so this run checked nothing — and it"
+              echo "fails rather than passing, because a green tick on this job has to mean"
+              echo "the live database was actually asked."
               echo
-              echo "See \`supabase/lint/README.md\` for the least-privilege role to create."
+              echo "Fix it by adding the secret under **Settings → Secrets and variables →"
+              echo "Actions → Repository secrets**. See \`supabase/lint/README.md\` for the"
+              echo "least-privilege role to create: do not paste the dashboard's default"
+              echo "superuser URI."
             } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
+            exit 1
           fi
           psql "$SUPABASE_DB_URL" \
             -v ON_ERROR_STOP=1 --csv --tuples-only --quiet --pset pager=off \
@@ -103,14 +109,14 @@ jobs:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
           if [ -z "$SUPABASE_DB_URL" ]; then
-            echo "::warning::SUPABASE_DB_URL is not set — the client grants check did NOT run."
+            echo "::error::SUPABASE_DB_URL is not set, so the client grants check could not run."
             {
-              echo "### ⚠️ Client grants check not armed"
+              echo "### ❌ Client grants check not armed"
               echo
-              echo "\`SUPABASE_DB_URL\` is not set, so this run checked nothing."
-              echo "A green tick here does **not** mean the client grants are correct."
+              echo "\`SUPABASE_DB_URL\` is not set, so this run checked nothing — and it"
+              echo "fails rather than passing, for the same reason as the step above."
             } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
+            exit 1
           fi
           psql "$SUPABASE_DB_URL" \
             -v ON_ERROR_STOP=1 --csv --tuples-only --quiet --pset pager=off \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,12 +38,16 @@ requests, the CI logs, and the screenshot artifacts.
 - CI is designed to hold exactly one production credential (`SUPABASE_DB_URL`,
   used only by `migration-drift.yml`), as a GitHub secret, and that workflow
   deliberately never runs on `pull_request`; keep it that way. Forks get no
-  secrets. **But the secret is not actually configured today** — every drift run
-  since the repo began has logged `SUPABASE_DB_URL:` empty and
-  `##[warning]SUPABASE_DB_URL is not set — the ... check did NOT run`, while
-  still reporting green. So nothing is currently at risk of leaking there, and
-  equally **the workflow has never checked anything**. Until that secret is set,
-  a green tick on Migration drift means only that the job ran.
+  secrets. **But the secret is not actually configured today**, so nothing is
+  currently at risk of leaking there — and equally, **the workflow checked
+  nothing from the repo's first day until 2026-08-21**: every run logged
+  `SUPABASE_DB_URL:` empty and passed anyway. Since then both steps **fail**
+  when the secret is missing, so Migration drift is expected to be **red** until
+  somebody adds it (Settings → Secrets and variables → Actions; the
+  least-privilege role to create is in `supabase/lint/README.md`). A red tick
+  there means "not armed", a green one now means the live database was really
+  asked. Do not soften those guards back to a pass to get the tick green — the
+  quiet green is the bug that hid this for months.
   - Both checks were run **by hand on 2026-08-20**, against the live database
     through Lovable's SQL access rather than the workflow, and both came back
     clean: **18 client grants live, 18 expected, 0 unexpected**, and every
@@ -516,8 +520,13 @@ owner/manager policies (`20260727120000_waiver_storage_policies.sql`).
     so it neither publishes nor comments: its gallery is the artifact on the
     run's own page.
 - **Migration drift CI:** `.github/workflows/migration-drift.yml` checks every
-  migration file against the **live** ledger. Not on PRs — it holds a
-  production credential (see "Schema drift" in `docs/database-changes.md`).
+  migration file against the **live** ledger, and the grants `anon` /
+  `authenticated` actually hold against `supabase/lint/client-grants-expected.txt`.
+  Not on PRs — it holds a production credential (see "Schema drift" in
+  `docs/database-changes.md`). Both steps fail if `SUPABASE_DB_URL` is unset, so
+  the job is red until the secret exists; `scripts/migration-drift-workflow.test.ts`
+  pins that, and pins the credential out of every `pull_request`-triggered
+  workflow. Only the checkers' `--selftest` runs on PRs, from `ci.yml`.
 - **Supabase lint CI:** `.github/workflows/supabase-lint.yml` (path-filtered to
   `supabase/**`) starts a local Postgres, applies every migration to it (which
   is not the live database, see `docs/database-changes.md`), and runs the

--- a/docs/database-changes.md
+++ b/docs/database-changes.md
@@ -141,8 +141,10 @@ way) means updating the PR and asking again.
     here) would receive that secret while running a script the PR itself can
     edit. So drift surfaces a merge later, not in the PR. Only the checker's
     `--selftest` runs on PRs, from `ci.yml`.
-  - Without the `SUPABASE_DB_URL` secret it warns and passes, so a green tick
-    only means "no drift" once the secret is set — the job summary says which.
+  - Without the `SUPABASE_DB_URL` secret it **fails**, so a green tick always
+    means the live database was actually asked. The secret is not configured
+    yet, so expect this job to be red until somebody adds it; the run summary
+    says whether the failure is a missing secret or real drift.
   - It proves a **ledger row exists**, not that the SQL ran. Since step 4 above
     writes that row by hand, a recorded-but-unapplied migration still passes.
     Step 5 (verify the object exists) is the part only a human/agent can do.

--- a/scripts/migration-drift-workflow.test.ts
+++ b/scripts/migration-drift-workflow.test.ts
@@ -41,6 +41,28 @@ function missingSecretGuards(source: string): string[] {
   );
 }
 
+/**
+ * What triggers a workflow: everything above `jobs:`, with comments removed.
+ *
+ * The comments matter — migration-drift.yml's header explains at length why it
+ * avoids `pull_request`, and a rule that read those would report the workflow
+ * that follows the rule most carefully.
+ */
+function triggers(source: string): string {
+  return source
+    .split(/^jobs:/m)[0]
+    .split("\n")
+    .map((line) => line.replace(/(^|\s)#.*$/, "$1"))
+    .join("\n");
+}
+
+/**
+ * Matched without the trailing colon on purpose: GitHub accepts `on: [push,
+ * pull_request]` and a bare `on: pull_request` as well as the block form, and a
+ * rule that only saw `pull_request:` would pass on both.
+ */
+const PULL_REQUEST_TRIGGER = /\bpull_request(_target)?\b/;
+
 describe("the migration drift workflow", () => {
   it("has a step for each live check", () => {
     // A rename that made the regexes below match nothing would turn every rule
@@ -68,8 +90,7 @@ describe("the migration drift workflow", () => {
   });
 
   it("never runs on a pull request, so the credential stays away from unreviewed code", () => {
-    const triggers = read(DRIFT_WORKFLOW).split(/^jobs:/m)[0];
-    expect(triggers).not.toMatch(/^\s*pull_request(_target)?:/m);
+    expect(triggers(read(DRIFT_WORKFLOW))).not.toMatch(PULL_REQUEST_TRIGGER);
   });
 });
 
@@ -82,8 +103,7 @@ describe("the other workflows", () => {
     const offenders = workflowFiles().filter((file) => {
       const source = read(file);
       if (!source.includes("secrets.SUPABASE_DB_URL")) return false;
-      const triggers = source.split(/^jobs:/m)[0];
-      return /^\s*pull_request(_target)?:/m.test(triggers);
+      return PULL_REQUEST_TRIGGER.test(triggers(source));
     });
     expect(
       offenders,

--- a/scripts/migration-drift-workflow.test.ts
+++ b/scripts/migration-drift-workflow.test.ts
@@ -80,6 +80,9 @@ describe("the migration drift workflow", () => {
 
   it("fails rather than passing when the secret is missing", () => {
     const guards = missingSecretGuards(read(DRIFT_WORKFLOW));
+    // Without this the loop below passes by finding no work, which is the same
+    // shape of false green the workflow itself was fixed for.
+    expect(guards.length).toBeGreaterThan(0);
     for (const guard of guards) {
       expect(
         guard,

--- a/scripts/migration-drift-workflow.test.ts
+++ b/scripts/migration-drift-workflow.test.ts
@@ -1,0 +1,93 @@
+// The two properties the live-database workflow depends on, checked here rather
+// than trusted.
+//
+// `.github/workflows/migration-drift.yml` asks the live database two questions
+// nothing else can answer: is every migration in the repo actually applied, and
+// do the client grants match `supabase/lint/client-grants-expected.txt`. Both
+// need the `SUPABASE_DB_URL` secret, and both used to warn-and-pass without it.
+// So every run since the repo began reported success while checking nothing,
+// which is worse than having no check: a green tick stops anyone from looking.
+//
+//   1. an unarmed check exits non-zero, so a green tick means it really ran,
+//   2. and the credential never reaches a `pull_request` run, because a same-repo
+//      PR branch (how Lovable and every agent push here) does receive secrets
+//      while running scripts the PR itself can rewrite.
+//
+// Neither rule is visible in a passing run — a workflow that quietly loses
+// either one still goes green — which is why they are pinned in the unit suite.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const WORKFLOW_DIR = resolve(process.cwd(), ".github/workflows");
+const DRIFT_WORKFLOW = "migration-drift.yml";
+
+function workflowFiles(): string[] {
+  return readdirSync(WORKFLOW_DIR)
+    .filter((file) => file.endsWith(".yml") || file.endsWith(".yaml"))
+    .sort();
+}
+
+function read(file: string): string {
+  return readFileSync(join(WORKFLOW_DIR, file), "utf8");
+}
+
+/** The `if [ -z "$SUPABASE_DB_URL" ]; then … fi` blocks, one per live step. */
+function missingSecretGuards(source: string): string[] {
+  return [...source.matchAll(/if \[ -z "\$SUPABASE_DB_URL" \]; then\n([\s\S]*?)\n\s*fi\n/g)].map(
+    (match) => match[1],
+  );
+}
+
+describe("the migration drift workflow", () => {
+  it("has a step for each live check", () => {
+    // A rename that made the regexes below match nothing would turn every rule
+    // here into a test that passes by finding no work.
+    const source = read(DRIFT_WORKFLOW);
+    expect([...source.matchAll(/secrets\.SUPABASE_DB_URL/g)]).toHaveLength(2);
+  });
+
+  it("guards every step that is handed the credential", () => {
+    const source = read(DRIFT_WORKFLOW);
+    expect(missingSecretGuards(source)).toHaveLength(
+      [...source.matchAll(/secrets\.SUPABASE_DB_URL/g)].length,
+    );
+  });
+
+  it("fails rather than passing when the secret is missing", () => {
+    const guards = missingSecretGuards(read(DRIFT_WORKFLOW));
+    for (const guard of guards) {
+      expect(
+        guard,
+        "an unarmed check must exit non-zero, or a green tick means only that the job started",
+      ).toContain("exit 1");
+      expect(guard).not.toContain("exit 0");
+    }
+  });
+
+  it("never runs on a pull request, so the credential stays away from unreviewed code", () => {
+    const triggers = read(DRIFT_WORKFLOW).split(/^jobs:/m)[0];
+    expect(triggers).not.toMatch(/^\s*pull_request(_target)?:/m);
+  });
+});
+
+describe("the other workflows", () => {
+  it("has workflows to check", () => {
+    expect(workflowFiles().length).toBeGreaterThan(3);
+  });
+
+  it("keeps the live database credential out of anything a pull request triggers", () => {
+    const offenders = workflowFiles().filter((file) => {
+      const source = read(file);
+      if (!source.includes("secrets.SUPABASE_DB_URL")) return false;
+      const triggers = source.split(/^jobs:/m)[0];
+      return /^\s*pull_request(_target)?:/m.test(triggers);
+    });
+    expect(
+      offenders,
+      "a same-repo pull request receives secrets and can rewrite the script that reads them",
+    ).toEqual([]);
+  });
+});

--- a/supabase/lint/README.md
+++ b/supabase/lint/README.md
@@ -69,9 +69,12 @@ the job loudly (psql exit 2); it cannot pass silently.
 
 ### Reading the result
 
-Without the secret the job prints a warning, writes a notice to the run summary,
-and **passes**. So a green tick only means "no drift" once the secret is set —
-read the summary, not just the ✅.
+Without the secret both steps write a notice to the run summary and **fail**.
+That is deliberate: an unarmed check that passed made every run green while
+asking the database nothing, which is worse than having no check, because a
+green tick is what stops anyone from looking. So a red job here means either
+real drift or a missing secret, and the summary says which. Never soften the
+guard back to a pass to clear the tick.
 
 A migration legitimately waiting to be applied (the contract phase of an
 expand/contract change, which must land _after_ the code deploys) goes in


### PR DESCRIPTION
Closes #57

## What was wrong

`.github/workflows/migration-drift.yml` asks the live database the two questions nothing else in this pipeline can answer: is every migration in `supabase/migrations/` actually applied, and do `anon`/`authenticated` hold exactly the grants in `supabase/lint/client-grants-expected.txt`.

Both need the `SUPABASE_DB_URL` secret, and both warned and then `exit 0`'d when it was missing. The secret has never been configured, so every run since the repo began reported success while asking the database nothing. A green tick that means "the job started" is worse than no check at all: a missing check is a known gap, a false green is what stops anyone from looking. And this is the workflow that exists to catch the failure mode production has already hit once (`column waivers.approval_status does not exist`, migration merged but never applied).

## The change

Both guards now print `::error::`, write the reason to the run summary, and `exit 1`.

Nothing else about the workflow moved. It still runs only on pushes to `main`, the daily schedule and `workflow_dispatch` — **never on `pull_request`**, because a same-repo PR branch does receive secrets while running a script the PR itself can rewrite. Forks still get no secrets. The credential is not added to any other workflow.

## ⚠️ A human still has to add the secret, and until then this job goes red

I cannot set a repository secret, and did not try: it is a production database credential.

Until somebody adds it, **the Migration drift workflow will fail on every push to `main` and on the daily schedule.** That is the intended behaviour of this PR, not a regression to fix — red is the accurate description of "this check is not armed". The failure is loud and self-explaining: the run summary says the secret is missing and where to set it.

To arm it:

1. **Settings → Secrets and variables → Actions → New repository secret**, named `SUPABASE_DB_URL`.
2. Do **not** paste the Supabase dashboard's default connection URI. That is the `postgres` superuser with read/write on `auth.users` and the `waivers` PII. `supabase/lint/README.md` has the three-line `CREATE ROLE ci_migration_reader` to make instead, which needs `SELECT` on one table.
3. GitHub-hosted runners are IPv4-only while the direct `db.PROJECT_REF.supabase.co` host is IPv6-only, so it likely needs the Supavisor session-pooler host instead. A wrong host fails loudly (psql exit 2); it cannot pass silently.

Once set, a green tick on this job finally means what it always claimed to.

Note this PR's own checks are unaffected — Migration drift does not run on pull requests, so CI here is the usual lint/typecheck/test/build plus e2e.

## Tests

`scripts/migration-drift-workflow.test.ts` (new) pins the two properties a passing run cannot show:

- every step handed the credential guards on it being empty, and that guard exits non-zero;
- no `pull_request`-triggered workflow references `secrets.SUPABASE_DB_URL`, in any of the trigger syntaxes GitHub accepts (comments are stripped first, so this workflow's own explanation of why it avoids pull requests is not read as a trigger).

Both would otherwise be invisible: a workflow that quietly lost either one still goes green. Checked by mutation — flipping an `exit 1` back to `exit 0` fails the suite, and so does handing the secret to a workflow triggered by `on: [push, pull_request]`.

## Docs

`CLAUDE.md`, `supabase/lint/README.md` and `docs/database-changes.md` each described the warn-and-pass behaviour as fact. All three now say the job fails unarmed, that it is expected to be red until the secret exists, and that softening the guard to clear the tick is the bug this fixes.

## What a person feels

Nobody using the site sees anything. The audience here is whoever looks at the checks on `main`: they get one red job with a summary telling them what to do, instead of a green tick that was never true.

## Verified

`bun run deps`, then `bun run lint`, `bun run typecheck`, `bun run test` (2032 passing), `bun run build` — all clean. `bun.lock` untouched.