### PR TITLE
Test the bank statement CSV parser, and stop it failing silently

### DIFF
--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -298,6 +298,33 @@ own), and reconciliation, activation and cancellation follow the same
 `edit_invoice` / bank-reconciliation flow as any other plan — see
 `.claude/skills/uts-manager-agent/SKILL.md` and `/manager/reconciliation`.
 
+### Reading the statement CSV
+
+The file a manager drops on `/manager/reconciliation` is parsed by
+`src/lib/bank-statement-csv.ts` (in `src/lib/`, not in the route, so every case
+below is a unit test in `bank-statement-csv.test.ts`). It handles quoted fields
+with commas in them, doubled `""` inside a quoted field, `\r\n` and lone `\r`
+endings, a leading BOM, blank lines, and a last row with no newline after it.
+Dates are read day-first (`01/08/2026` is 1 August) or as ISO. Amounts go
+through `parseMoneyToCents`, so `$1,234.50` is fine.
+
+Three things are decided rather than obvious:
+
+- **The header row is the first row of the file**, and the import **refuses a
+  file whose Date, Amount or Description column it cannot find**, naming the
+  ones it could not. Every one of those is resolved by substring
+  (`transaction date` matches `date`), and a missing one used to import zero
+  rows and say "no credit transactions found", which reads exactly like a quiet
+  month. A bank that prints its account summary above the headings is the same
+  failure, so the message says to delete anything above them.
+- **A credit or deposit column wins over a plain amount column, and a debit or
+  withdrawal column is never the amount.** An export with `Debit Amount` beside
+  `Credit Amount` otherwise resolved to the debit one, and every card purchase
+  in the statement imported as money coming in.
+- **Only positive amounts are kept**, because only an incoming credit can pay a
+  membership. Reference is optional: when there is no reference column the
+  description carries the reference, which is what matching reads anyway.
+
 ## Paying an invoice
 
 The member sees everything they need to pay on `/membership` itself: a **How to

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -305,10 +305,11 @@ The file a manager drops on `/manager/reconciliation` is parsed by
 below is a unit test in `bank-statement-csv.test.ts`). It handles quoted fields
 with commas in them, doubled `""` inside a quoted field, `\r\n` and lone `\r`
 endings, a leading BOM, blank lines, and a last row with no newline after it.
-Dates are read day-first (`01/08/2026` is 1 August) or as ISO. Amounts go
-through `parseMoneyToCents`, so `$1,234.50` is fine.
+Dates are read day-first (`01/08/2026` is 1 August) or as ISO, with any time
+after them ignored. Amounts go through `parseMoneyToCents`, so `$1,234.50` is
+fine.
 
-Three things are decided rather than obvious:
+Four things are decided rather than obvious:
 
 - **The header row is the first row of the file**, and the import **refuses a
   file whose Date, Amount or Description column it cannot find**, naming the
@@ -317,13 +318,24 @@ Three things are decided rather than obvious:
   rows and say "no credit transactions found", which reads exactly like a quiet
   month. A bank that prints its account summary above the headings is the same
   failure, so the message says to delete anything above them.
-- **A credit or deposit column wins over a plain amount column, and a debit or
-  withdrawal column is never the amount.** An export with `Debit Amount` beside
-  `Credit Amount` otherwise resolved to the debit one, and every card purchase
-  in the statement imported as money coming in.
+- **A credit or deposit column wins over a plain amount column, and nothing
+  naming a debit, a withdrawal, a limit or a balance is ever the amount.** An
+  export with `Debit Amount` beside `Credit Amount` otherwise resolved to the
+  debit one, and every card purchase in the statement imported as money coming
+  in. The same rule keeps a `Debit/Credit` indicator column (which holds `DR` /
+  `CR`, not a sum) and a `Credit Limit` out of it.
+- **A date that is not a real calendar date is dropped, not passed on.** A
+  US-formatted export reads `08/13/2026` as day 8 of month 13, which clears the
+  row schema's regex and then kills the entire import at insert time on a raw
+  Postgres range error. The row keeps its amount and description and shows no
+  date, which is the same as any other date we cannot read. That means a wholly
+  US-formatted export imports dateless rather than being refused: worth
+  revisiting if one ever turns up.
 - **Only positive amounts are kept**, because only an incoming credit can pay a
-  membership. Reference is optional: when there is no reference column the
-  description carries the reference, which is what matching reads anyway.
+  membership. Reference is optional. The description is taken from the first of
+  `description`, `narrative`, `details`, `memo`, `reference` that the file has,
+  in that order rather than in column order, so a file carrying both a bare
+  reference and a human-readable narrative shows the narrative to the manager.
 
 ## Paying an invoice
 

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -323,7 +323,13 @@ Four things are decided rather than obvious:
   export with `Debit Amount` beside `Credit Amount` otherwise resolved to the
   debit one, and every card purchase in the statement imported as money coming
   in. The same rule keeps a `Debit/Credit` indicator column (which holds `DR` /
-  `CR`, not a sum) and a `Credit Limit` out of it.
+  `CR`, not a sum) and a `Credit Limit` out of it. A credit header only wins
+  when the rest of it agrees it is a money column, so `Credit Card Surcharge`
+  is a fee and loses to a plain `Amount`.
+- **When the direction lives in its own DR/CR column, that column is read.**
+  Some exports leave the amount unsigned and put `DR` / `CR` beside it. Rows
+  marked as going out are dropped; a cell we do not recognise leaves its row
+  alone, because dropping a credit is the more expensive mistake.
 - **A date that is not a real calendar date is dropped, not passed on.** A
   US-formatted export reads `08/13/2026` as day 8 of month 13, which clears the
   row schema's regex and then kills the entire import at insert time on a raw

--- a/src/lib/bank-statement-csv.test.ts
+++ b/src/lib/bank-statement-csv.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { detectStatementColumns, normalizeDate, parseCsv, toBankRows } from "./bank-statement-csv";
+import {
+  detectStatementColumns,
+  isDebitRow,
+  normalizeDate,
+  parseCsv,
+  toBankRows,
+} from "./bank-statement-csv";
 
 /**
  * These tests exist because a dropped or mis-read statement line is a member
@@ -204,6 +210,28 @@ describe("toBankRows", () => {
     );
   });
 
+  it("drops the rows a DR/CR column marks as money going out", () => {
+    // The amount is unsigned here: the direction lives in its own column, so
+    // without reading it every card purchase imports as a payment to the club.
+    const statement = [
+      "Date,Description,Amount,Debit/Credit,Balance",
+      "01/08/2026,EFTPOS COLES,45.50,DR,954.50",
+      "02/08/2026,OSKO UTS-0042,120.00,CR,1074.50",
+    ].join("\n");
+    expect(toBankRows(parseCsv(statement))).toEqual([
+      { posted_at: "2026-08-02", amount_cents: 12000, description: "OSKO UTS-0042", reference: "" },
+    ]);
+  });
+
+  it("keeps a row whose DR/CR cell it does not recognise, rather than dropping it", () => {
+    const statement = [
+      "Date,Description,Amount,Debit/Credit",
+      "02/08/2026,OSKO UTS-0042,120.00,",
+      "03/08/2026,OSKO UTS-0043,80.00,something else",
+    ].join("\n");
+    expect(toBankRows(parseCsv(statement)).map((r) => r.amount_cents)).toEqual([12000, 8000]);
+  });
+
   it("reads the credit column, not the debit one, when the export has both", () => {
     const statement = [
       "Date,Description,Debit Amount,Credit Amount",
@@ -225,7 +253,7 @@ describe("detectStatementColumns", () => {
   it("finds each column by substring, whatever the header is called around it", () => {
     expect(
       detectStatementColumns(["Transaction Date", "Narrative", "Amount", "Reference", "Balance"]),
-    ).toEqual({ dateIdx: 0, amountIdx: 2, descIdx: 1, refIdx: 3 });
+    ).toEqual({ dateIdx: 0, amountIdx: 2, descIdx: 1, refIdx: 3, debitFlagIdx: -1 });
   });
 
   it("reports -1 for a column the header row does not have", () => {
@@ -254,12 +282,43 @@ describe("detectStatementColumns", () => {
     expect(detectStatementColumns(["Date", "Closing Balance", "Amount"]).amountIdx).toBe(2);
   });
 
+  it("only prefers a credit header when the rest of it agrees it is a money column", () => {
+    // "Credit Card Surcharge" is a fee column. Letting the substring "credit"
+    // win it would drop every real credit in the file.
+    const header = ["Date", "Description", "Amount", "Credit Card Surcharge"];
+    expect(detectStatementColumns(header).amountIdx).toBe(2);
+    expect(detectStatementColumns(["Date", "Credit (AUD)", "Description"]).amountIdx).toBe(1);
+    expect(detectStatementColumns(["Date", "Total Credits", "Description"]).amountIdx).toBe(1);
+  });
+
+  it("finds a DR/CR indicator column, however the file spells it", () => {
+    expect(detectStatementColumns(["Date", "Amount", "Debit/Credit"]).debitFlagIdx).toBe(2);
+    expect(detectStatementColumns(["Date", "Amount", "DR/CR"]).debitFlagIdx).toBe(2);
+    expect(detectStatementColumns(["Date", "Amount", "Credit or Debit"]).debitFlagIdx).toBe(2);
+    expect(detectStatementColumns(["Date", "Amount", "Description"]).debitFlagIdx).toBe(-1);
+  });
+
   it("prefers a narrative over a reference for the description, whatever their order", () => {
     expect(detectStatementColumns(["Date", "Reference", "Narrative", "Amount"])).toEqual({
       dateIdx: 0,
       amountIdx: 3,
       descIdx: 2,
       refIdx: 1,
+      debitFlagIdx: -1,
     });
+  });
+});
+
+describe("isDebitRow", () => {
+  it("recognises how a statement spells money going out", () => {
+    for (const cell of ["DR", "dr", " Debit ", "D", "db", "W", "withdrawal", "-"]) {
+      expect(isDebitRow(cell)).toBe(true);
+    }
+  });
+
+  it("says no to anything it does not recognise, so a credit is never dropped", () => {
+    for (const cell of ["", "CR", "credit", "C", "+", "transfer"]) {
+      expect(isDebitRow(cell)).toBe(false);
+    }
   });
 });

--- a/src/lib/bank-statement-csv.test.ts
+++ b/src/lib/bank-statement-csv.test.ts
@@ -93,10 +93,25 @@ describe("normalizeDate", () => {
     expect(normalizeDate("03/04/2026")).toBe("2026-04-03");
   });
 
+  it("ignores a time printed after the date", () => {
+    expect(normalizeDate("01/08/2026 09:15 AM")).toBe("2026-08-01");
+    expect(normalizeDate("01/08/2026T09:15")).toBe("2026-08-01");
+  });
+
   it("returns an empty string for anything it cannot read", () => {
     expect(normalizeDate("")).toBe("");
     expect(normalizeDate("01 Aug 2026")).toBe("");
     expect(normalizeDate("not a date")).toBe("");
+  });
+
+  it("returns an empty string rather than an impossible date", () => {
+    // A US-formatted export: day 8 of month 13. Passing "2026-13-08" on would
+    // clear the row schema's regex and kill the whole import at insert time.
+    expect(normalizeDate("08/13/2026")).toBe("");
+    expect(normalizeDate("99/99/9999")).toBe("");
+    expect(normalizeDate("30/02/2026")).toBe("");
+    expect(normalizeDate("2026-02-30")).toBe("");
+    expect(normalizeDate("29/02/2028")).toBe("2028-02-29"); // a real leap day
   });
 });
 
@@ -227,5 +242,24 @@ describe("detectStatementColumns", () => {
     expect(detectStatementColumns(["Date", "Debit Amount"]).amountIdx).toBe(-1);
     expect(detectStatementColumns(["Date", "Withdrawal Amount"]).amountIdx).toBe(-1);
     expect(detectStatementColumns(["Date", "Debit Amount", "Credit Amount"]).amountIdx).toBe(2);
+  });
+
+  it("never picks a column that is not money moving: an indicator, a limit, a balance", () => {
+    // "Debit/Credit" holds DR/CR, "Credit Limit" is a ceiling, neither is a sum.
+    const indicator = ["Date", "Description", "Amount", "Debit/Credit"];
+    expect(detectStatementColumns(indicator).amountIdx).toBe(2);
+    expect(
+      detectStatementColumns(["Date", "Description", "Credit Limit", "Amount"]).amountIdx,
+    ).toBe(3);
+    expect(detectStatementColumns(["Date", "Closing Balance", "Amount"]).amountIdx).toBe(2);
+  });
+
+  it("prefers a narrative over a reference for the description, whatever their order", () => {
+    expect(detectStatementColumns(["Date", "Reference", "Narrative", "Amount"])).toEqual({
+      dateIdx: 0,
+      amountIdx: 3,
+      descIdx: 2,
+      refIdx: 1,
+    });
   });
 });

--- a/src/lib/bank-statement-csv.test.ts
+++ b/src/lib/bank-statement-csv.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { normalizeDate, parseCsv, toBankRows } from "./bank-statement-csv";
+import { detectStatementColumns, normalizeDate, parseCsv, toBankRows } from "./bank-statement-csv";
 
 /**
  * These tests exist because a dropped or mis-read statement line is a member
  * chased for money they already sent. So the failure paths matter more than the
  * happy one: what a file with the wrong column names does, what a preamble row
  * above the header does, what an export that puts debits in their own column
- * does. Where the answer today is wrong, the test says so and pins it anyway,
- * so the change that fixes it shows up as a change here.
+ * does. The four cases at the bottom used to pass silently and now refuse the
+ * file by name, which is the whole point of the exercise.
  */
 
 describe("parseCsv", () => {
@@ -152,36 +152,80 @@ describe("toBankRows", () => {
     ]);
   });
 
-  it("returns nothing for an empty file or a header with no rows under it", () => {
-    expect(toBankRows(parseCsv(""))).toEqual([]);
+  it("returns nothing for a header row with no transactions under it", () => {
     expect(toBankRows(parseCsv("Date,Description,Amount\n"))).toEqual([]);
   });
 
-  // ---- The failure paths. Today all three are silent. ----
-
-  it("BUG (#65): imports nothing, silently, when no column matches 'amount'", () => {
-    expect(toBankRows(parseCsv("Date,Description,Money In\n01/08/2026,PAY,10\n"))).toEqual([]);
+  it("refuses an empty file rather than calling it a statement with no credits", () => {
+    expect(() => toBankRows(parseCsv(""))).toThrow(/empty/i);
   });
 
-  it("BUG (#65): imports rows with no date, silently, when no column matches 'date'", () => {
-    expect(toBankRows(parseCsv("Posted,Description,Amount\n01/08/2026,PAY,10\n"))).toEqual([
-      { posted_at: "", amount_cents: 1000, description: "PAY", reference: "" },
-    ]);
+  // ---- The failure paths (#65). Each one used to be silent. ----
+
+  it("names the Amount column when no header matches it", () => {
+    expect(() => toBankRows(parseCsv("Date,Description,Money In\n01/08/2026,PAY,10\n"))).toThrow(
+      /could not find an Amount column/,
+    );
   });
 
-  it("BUG (#65): reads a preamble line as the header and imports nothing", () => {
+  it("names the Date column when no header matches it", () => {
+    expect(() => toBankRows(parseCsv("Posted,Description,Amount\n01/08/2026,PAY,10\n"))).toThrow(
+      /could not find a Date column/,
+    );
+  });
+
+  it("names the Description column when no header matches it", () => {
+    expect(() => toBankRows(parseCsv("Date,Amount\n01/08/2026,10\n"))).toThrow(
+      /could not find a Description column/,
+    );
+  });
+
+  it("lists every missing column, and says to delete a preamble above the headings", () => {
     const withPreamble = ["Account 12345678", "Date,Description,Amount", "01/08/2026,PAY,10"].join(
       "\n",
     );
-    expect(toBankRows(parseCsv(withPreamble))).toEqual([]);
+    expect(() => toBankRows(parseCsv(withPreamble))).toThrow(
+      /the Date, Amount and Description columns.*delete anything printed above them/s,
+    );
   });
 
-  it("BUG (#65): reads the debit column as the amount when it is named 'Debit Amount'", () => {
-    const rows = toBankRows(
-      parseCsv("Date,Description,Debit Amount,Credit Amount\n01/08/2026,EFTPOS COLES,45.50,\n"),
-    );
-    expect(rows).toEqual([
-      { posted_at: "2026-08-01", amount_cents: 4550, description: "EFTPOS COLES", reference: "" },
+  it("reads the credit column, not the debit one, when the export has both", () => {
+    const statement = [
+      "Date,Description,Debit Amount,Credit Amount",
+      "01/08/2026,EFTPOS COLES,45.50,",
+      "02/08/2026,OSKO UTS-0042,,120.00",
+    ].join("\n");
+    expect(toBankRows(parseCsv(statement))).toEqual([
+      {
+        posted_at: "2026-08-02",
+        amount_cents: 12000,
+        description: "OSKO UTS-0042",
+        reference: "",
+      },
     ]);
+  });
+});
+
+describe("detectStatementColumns", () => {
+  it("finds each column by substring, whatever the header is called around it", () => {
+    expect(
+      detectStatementColumns(["Transaction Date", "Narrative", "Amount", "Reference", "Balance"]),
+    ).toEqual({ dateIdx: 0, amountIdx: 2, descIdx: 1, refIdx: 3 });
+  });
+
+  it("reports -1 for a column the header row does not have", () => {
+    expect(detectStatementColumns(["Date", "Description", "Amount"]).refIdx).toBe(-1);
+    expect(detectStatementColumns([]).dateIdx).toBe(-1);
+  });
+
+  it("prefers a credit or deposit column over a plain amount one", () => {
+    expect(detectStatementColumns(["Date", "Amount", "Credit"]).amountIdx).toBe(2);
+    expect(detectStatementColumns(["Date", "Amount", "Deposits"]).amountIdx).toBe(2);
+  });
+
+  it("never picks a debit or withdrawal column as the amount", () => {
+    expect(detectStatementColumns(["Date", "Debit Amount"]).amountIdx).toBe(-1);
+    expect(detectStatementColumns(["Date", "Withdrawal Amount"]).amountIdx).toBe(-1);
+    expect(detectStatementColumns(["Date", "Debit Amount", "Credit Amount"]).amountIdx).toBe(2);
   });
 });

--- a/src/lib/bank-statement-csv.test.ts
+++ b/src/lib/bank-statement-csv.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import { normalizeDate, parseCsv, toBankRows } from "./bank-statement-csv";
+
+/**
+ * These tests exist because a dropped or mis-read statement line is a member
+ * chased for money they already sent. So the failure paths matter more than the
+ * happy one: what a file with the wrong column names does, what a preamble row
+ * above the header does, what an export that puts debits in their own column
+ * does. Where the answer today is wrong, the test says so and pins it anyway,
+ * so the change that fixes it shows up as a change here.
+ */
+
+describe("parseCsv", () => {
+  it("reads plain rows", () => {
+    expect(parseCsv("a,b,c\n1,2,3\n")).toEqual([
+      ["a", "b", "c"],
+      ["1", "2", "3"],
+    ]);
+  });
+
+  it("keeps commas inside a quoted field", () => {
+    expect(parseCsv('date,description\n2026-08-01,"OSKO PAYMENT, UTS-0042"\n')).toEqual([
+      ["date", "description"],
+      ["2026-08-01", "OSKO PAYMENT, UTS-0042"],
+    ]);
+  });
+
+  it('unescapes a doubled "" inside a quoted field', () => {
+    expect(parseCsv('a\n"she said ""hi"" twice"\n')).toEqual([["a"], ['she said "hi" twice']]);
+  });
+
+  it("keeps a newline inside a quoted field", () => {
+    expect(parseCsv('a,b\n"line one\nline two",x\n')).toEqual([
+      ["a", "b"],
+      ["line one\nline two", "x"],
+    ]);
+  });
+
+  it("handles CRLF and lone CR line endings", () => {
+    const expected = [
+      ["a", "b"],
+      ["1", "2"],
+    ];
+    expect(parseCsv("a,b\r\n1,2\r\n")).toEqual(expected);
+    expect(parseCsv("a,b\r1,2\r")).toEqual(expected);
+  });
+
+  it("reads the last row when the file has no trailing newline", () => {
+    expect(parseCsv("a,b\n1,2")).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ]);
+  });
+
+  it("drops blank and whitespace-only lines", () => {
+    expect(parseCsv("a,b\n\n1,2\n   ,  \n3,4\n")).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+      ["3", "4"],
+    ]);
+  });
+
+  it("returns nothing for an empty file", () => {
+    expect(parseCsv("")).toEqual([]);
+    expect(parseCsv("\n\n")).toEqual([]);
+  });
+
+  it("keeps a UTF-8 BOM on the first field (the header match trims it)", () => {
+    expect(parseCsv("﻿Date,Amount\n2026-08-01,10\n")[0]).toEqual(["﻿Date", "Amount"]);
+  });
+
+  it("keeps empty fields, including a quoted empty one", () => {
+    expect(parseCsv('a,b,c\n1,,""\n')).toEqual([
+      ["a", "b", "c"],
+      ["1", "", ""],
+    ]);
+  });
+});
+
+describe("normalizeDate", () => {
+  it("passes an ISO date through, with or without a time", () => {
+    expect(normalizeDate("2026-08-01")).toBe("2026-08-01");
+    expect(normalizeDate(" 2026-08-01T09:30:00+10:00 ")).toBe("2026-08-01");
+  });
+
+  it("reads AU day-first dates with any separator", () => {
+    expect(normalizeDate("01/08/2026")).toBe("2026-08-01");
+    expect(normalizeDate("1-8-2026")).toBe("2026-08-01");
+    expect(normalizeDate("1.8.26")).toBe("2026-08-01");
+  });
+
+  it("reads an ambiguous date day-first, as an Australian bank writes it", () => {
+    expect(normalizeDate("03/04/2026")).toBe("2026-04-03");
+  });
+
+  it("returns an empty string for anything it cannot read", () => {
+    expect(normalizeDate("")).toBe("");
+    expect(normalizeDate("01 Aug 2026")).toBe("");
+    expect(normalizeDate("not a date")).toBe("");
+  });
+});
+
+/** A statement the way a bank actually exports one, header row included. */
+const STATEMENT = [
+  "Date,Description,Amount,Balance",
+  '01/08/2026,"OSKO PAYMENT UTS-0042 SMITH",120.00,1000.00',
+  '02/08/2026,"EFTPOS COLES",-45.50,954.50',
+  '03/08/2026,"TRANSFER UTS-0043","1,234.50",2189.00',
+].join("\n");
+
+describe("toBankRows", () => {
+  it("keeps incoming credits only, with the date normalized", () => {
+    expect(toBankRows(parseCsv(STATEMENT))).toEqual([
+      {
+        posted_at: "2026-08-01",
+        amount_cents: 12000,
+        description: "OSKO PAYMENT UTS-0042 SMITH",
+        reference: "",
+      },
+      {
+        posted_at: "2026-08-03",
+        amount_cents: 123450,
+        description: "TRANSFER UTS-0043",
+        reference: "",
+      },
+    ]);
+  });
+
+  it("skips a zero-amount row", () => {
+    expect(toBankRows(parseCsv("Date,Description,Amount\n01/08/2026,NIL,0.00\n"))).toEqual([]);
+  });
+
+  it("matches header names whatever their case, spacing or BOM", () => {
+    const rows = toBankRows(parseCsv("﻿ Transaction Date , Narrative , Credit Amount \nX,Y,5\n"));
+    expect(rows).toEqual([{ posted_at: "", amount_cents: 500, description: "Y", reference: "" }]);
+  });
+
+  it("fills a missing trailing cell rather than throwing", () => {
+    expect(toBankRows(parseCsv("Date,Description,Amount,Reference\n01/08/2026,PAY,10"))).toEqual([
+      { posted_at: "2026-08-01", amount_cents: 1000, description: "PAY", reference: "" },
+    ]);
+  });
+
+  it("uses the reference column for the description when there is no description column", () => {
+    expect(toBankRows(parseCsv("Date,Reference,Amount\n01/08/2026,UTS-0042,10"))).toEqual([
+      {
+        posted_at: "2026-08-01",
+        amount_cents: 1000,
+        description: "UTS-0042",
+        reference: "UTS-0042",
+      },
+    ]);
+  });
+
+  it("returns nothing for an empty file or a header with no rows under it", () => {
+    expect(toBankRows(parseCsv(""))).toEqual([]);
+    expect(toBankRows(parseCsv("Date,Description,Amount\n"))).toEqual([]);
+  });
+
+  // ---- The failure paths. Today all three are silent. ----
+
+  it("BUG (#65): imports nothing, silently, when no column matches 'amount'", () => {
+    expect(toBankRows(parseCsv("Date,Description,Money In\n01/08/2026,PAY,10\n"))).toEqual([]);
+  });
+
+  it("BUG (#65): imports rows with no date, silently, when no column matches 'date'", () => {
+    expect(toBankRows(parseCsv("Posted,Description,Amount\n01/08/2026,PAY,10\n"))).toEqual([
+      { posted_at: "", amount_cents: 1000, description: "PAY", reference: "" },
+    ]);
+  });
+
+  it("BUG (#65): reads a preamble line as the header and imports nothing", () => {
+    const withPreamble = ["Account 12345678", "Date,Description,Amount", "01/08/2026,PAY,10"].join(
+      "\n",
+    );
+    expect(toBankRows(parseCsv(withPreamble))).toEqual([]);
+  });
+
+  it("BUG (#65): reads the debit column as the amount when it is named 'Debit Amount'", () => {
+    const rows = toBankRows(
+      parseCsv("Date,Description,Debit Amount,Credit Amount\n01/08/2026,EFTPOS COLES,45.50,\n"),
+    );
+    expect(rows).toEqual([
+      { posted_at: "2026-08-01", amount_cents: 4550, description: "EFTPOS COLES", reference: "" },
+    ]);
+  });
+});

--- a/src/lib/bank-statement-csv.ts
+++ b/src/lib/bank-statement-csv.ts
@@ -90,6 +90,8 @@ export type StatementColumns = {
   amountIdx: number;
   descIdx: number;
   refIdx: number;
+  /** A DR/CR column saying which way each row went, when the file has one. */
+  debitFlagIdx: number;
 };
 
 /** The three the import promises to read, in the words the screen uses. */
@@ -110,25 +112,72 @@ const DESCRIPTION_KEYS = ["description", "narrative", "details", "memo", "refere
 const NOT_AN_AMOUNT = ["debit", "withdrawal", "limit", "balance"];
 
 /**
+ * What may sit beside "credit" or "deposit" in a header and still leave it a
+ * money-in column. Anything else in there means the header is about something
+ * other than the money: "Credit Card Surcharge" is a fee, not a payment to us.
+ */
+const CREDIT_HEADER_WORDS = new Set([
+  "credit",
+  "credits",
+  "deposit",
+  "deposits",
+  "amount",
+  "amounts",
+  "money",
+  "in",
+  "total",
+  "aud",
+  "$",
+]);
+
+const CREDIT_WORDS = ["credit", "credits", "deposit", "deposits"];
+
+function isCreditColumn(header: string): boolean {
+  const words = header.split(/[^a-z$]+/).filter(Boolean);
+  if (!words.some((w) => CREDIT_WORDS.includes(w))) return false;
+  return words.every((w) => CREDIT_HEADER_WORDS.has(w));
+}
+
+/** A column saying which way the row went rather than how much: DR/CR. */
+function isDebitCreditFlag(header: string): boolean {
+  if (header.includes("debit") && header.includes("credit")) return true;
+  return /\b(dr|cr)\s*[/|-]\s*(dr|cr)\b/.test(header);
+}
+
+/** How such a column spells "this one went out". Anything else leaves the row alone. */
+const DEBIT_MARKERS = new Set(["d", "dr", "db", "debit", "w", "withdrawal", "-"]);
+
+/** True when this row's DR/CR cell says the money went out. */
+export function isDebitRow(flagCell: string): boolean {
+  return DEBIT_MARKERS.has(flagCell.trim().toLowerCase());
+}
+
+/**
  * Work out which column is which from the header row, by substring.
  *
- * The amount column is the one worth reading twice. Some exports put money out
- * in its own column beside money in ("Debit Amount", "Credit Amount"), and a
- * plain first-match on "amount" picks the debit one: every card purchase in the
- * statement would then import as an incoming credit, and the club would think
- * it had been paid. So nothing naming a debit, a withdrawal, a limit or a
- * balance is ever the amount (that also rules out a "Debit/Credit" indicator
- * column, which holds "DR"/"CR" rather than money), and among what is left a
- * header naming a credit or a deposit wins over a plain "amount".
+ * The amount column is the one worth reading twice, because getting it wrong
+ * means a card purchase imports as a payment to the club. Three shapes of
+ * export have to land right:
+ *
+ *   Amount (signed)                 -> the plain case, negatives dropped later
+ *   Debit Amount | Credit Amount    -> a first-match on "amount" picks the
+ *                                      DEBIT one, so nothing naming a debit, a
+ *                                      withdrawal, a limit or a balance is
+ *                                      ever the amount
+ *   Amount (unsigned) | Debit/Credit-> the sign lives in a separate DR/CR
+ *                                      column, so we find that column here and
+ *                                      `toBankRows` skips the rows it marks out
+ *
+ * Among what is left a header naming a credit or a deposit wins over a plain
+ * "amount", but only when the rest of the header agrees it is a money column:
+ * "Credit Card Surcharge" contains "credit" and is not one.
  */
 export function detectStatementColumns(headerRow: string[]): StatementColumns {
   const header = headerRow.map((h) => h.trim().toLowerCase());
   const find = (...keys: string[]) => header.findIndex((h) => keys.some((k) => h.includes(k)));
   const couldBeAmount = (h: string) => !NOT_AN_AMOUNT.some((k) => h.includes(k));
 
-  const creditIdx = header.findIndex(
-    (h) => couldBeAmount(h) && (h.includes("credit") || h.includes("deposit")),
-  );
+  const creditIdx = header.findIndex((h) => couldBeAmount(h) && isCreditColumn(h));
   const amountIdx =
     creditIdx >= 0 ? creditIdx : header.findIndex((h) => h.includes("amount") && couldBeAmount(h));
 
@@ -136,7 +185,13 @@ export function detectStatementColumns(headerRow: string[]): StatementColumns {
   // key that appears anywhere in the header wins.
   const descIdx = DESCRIPTION_KEYS.map((k) => find(k)).find((i) => i >= 0) ?? -1;
 
-  return { dateIdx: find("date"), amountIdx, descIdx, refIdx: find("reference") };
+  return {
+    dateIdx: find("date"),
+    amountIdx,
+    descIdx,
+    refIdx: find("reference"),
+    debitFlagIdx: header.findIndex(isDebitCreditFlag),
+  };
 }
 
 /** "a Date column" / "the Date and Amount columns" — for the error below. */
@@ -171,6 +226,8 @@ export function toBankRows(rows: string[][]): BankTxnRow[] {
 
   const out: BankTxnRow[] = [];
   for (const r of rows.slice(1)) {
+    // An unsigned amount beside a DR/CR column: the sign is over there.
+    if (columns.debitFlagIdx >= 0 && isDebitRow(r[columns.debitFlagIdx] ?? "")) continue;
     const cents = parseMoneyToCents(r[columns.amountIdx] ?? "");
     if (cents == null || cents <= 0) continue; // only incoming credits can pay a membership
     out.push({

--- a/src/lib/bank-statement-csv.ts
+++ b/src/lib/bank-statement-csv.ts
@@ -60,25 +60,90 @@ export function normalizeDate(value: string): string {
   return "";
 }
 
-/** Map parsed CSV into the bank-row shape, keeping only positive credits. */
-export function toBankRows(rows: string[][]): BankTxnRow[] {
-  if (rows.length < 2) return [];
-  const header = rows[0].map((h) => h.trim().toLowerCase());
+/**
+ * Which cell of a statement row holds what. `-1` means the header row named no
+ * column we could recognise as that one.
+ */
+export type StatementColumns = {
+  dateIdx: number;
+  amountIdx: number;
+  descIdx: number;
+  refIdx: number;
+};
+
+/** The three the import promises to read, in the words the screen uses. */
+const REQUIRED_COLUMNS = [
+  ["Date", "dateIdx"],
+  ["Amount", "amountIdx"],
+  ["Description", "descIdx"],
+] as const;
+
+/**
+ * Work out which column is which from the header row, by substring.
+ *
+ * The amount column is the one worth reading twice. Some exports put money out
+ * in its own column beside money in ("Debit Amount", "Credit Amount"), and a
+ * plain first-match on "amount" picks the debit one: every card purchase in the
+ * statement would then import as an incoming credit, and the club would think
+ * it had been paid. So a header naming credit or deposit wins outright, and a
+ * header naming debit or withdrawal is never the amount column.
+ */
+export function detectStatementColumns(headerRow: string[]): StatementColumns {
+  const header = headerRow.map((h) => h.trim().toLowerCase());
   const find = (...keys: string[]) => header.findIndex((h) => keys.some((k) => h.includes(k)));
-  const dateIdx = find("date");
-  const amountIdx = find("amount", "credit", "deposit");
-  const descIdx = find("description", "narrative", "details", "reference", "memo");
-  const refIdx = find("reference");
+  const moneyOut = (h: string) => h.includes("debit") || h.includes("withdrawal");
+
+  const creditIdx = find("credit", "deposit");
+  const amountIdx =
+    creditIdx >= 0 ? creditIdx : header.findIndex((h) => h.includes("amount") && !moneyOut(h));
+
+  return {
+    dateIdx: find("date"),
+    amountIdx,
+    descIdx: find("description", "narrative", "details", "reference", "memo"),
+    refIdx: find("reference"),
+  };
+}
+
+/** "a Date column" / "the Date and Amount columns" — for the error below. */
+function columnList(missing: string[]): string {
+  if (missing.length === 1)
+    return `${/^[AEIOU]/.test(missing[0]) ? "an" : "a"} ${missing[0]} column`;
+  const last = missing[missing.length - 1];
+  return `the ${missing.slice(0, -1).join(", ")} and ${last} columns`;
+}
+
+/**
+ * Map parsed CSV into the bank-row shape, keeping only positive credits.
+ *
+ * Throws when a column it needs is not in the header row. Returning nothing
+ * would be the quieter option and it is the wrong one: an export with columns
+ * named differently, or with the bank's account summary printed above the
+ * headings, then imports zero rows and reads as "nothing came in this month".
+ * Someone finds out weeks later, when a member who paid gets chased for it.
+ */
+export function toBankRows(rows: string[][]): BankTxnRow[] {
+  if (rows.length === 0) {
+    throw new Error("That file is empty. Export the statement from your bank again and try that.");
+  }
+  const columns = detectStatementColumns(rows[0]);
+  const missing = REQUIRED_COLUMNS.filter(([, key]) => columns[key] < 0).map(([label]) => label);
+  if (missing.length > 0) {
+    throw new Error(
+      `We could not find ${columnList(missing)} in that file. The first row has to be the column ` +
+        `headings from your bank, so delete anything printed above them and try again.`,
+    );
+  }
 
   const out: BankTxnRow[] = [];
   for (const r of rows.slice(1)) {
-    const cents = amountIdx >= 0 ? parseMoneyToCents(r[amountIdx] ?? "") : null;
+    const cents = parseMoneyToCents(r[columns.amountIdx] ?? "");
     if (cents == null || cents <= 0) continue; // only incoming credits can pay a membership
     out.push({
-      posted_at: dateIdx >= 0 ? normalizeDate(r[dateIdx] ?? "") : "",
+      posted_at: normalizeDate(r[columns.dateIdx] ?? ""),
       amount_cents: cents,
-      description: descIdx >= 0 ? (r[descIdx] ?? "").trim() : "",
-      reference: refIdx >= 0 ? (r[refIdx] ?? "").trim() : "",
+      description: (r[columns.descIdx] ?? "").trim(),
+      reference: columns.refIdx >= 0 ? (r[columns.refIdx] ?? "").trim() : "",
     });
   }
   return out;

--- a/src/lib/bank-statement-csv.ts
+++ b/src/lib/bank-statement-csv.ts
@@ -47,14 +47,35 @@ export function parseCsv(text: string): string[][] {
   return rows;
 }
 
-/** Normalize a date cell to YYYY-MM-DD (accepts ISO or AU dd/mm/yyyy). */
+/** True for a real calendar date, so an impossible one never leaves this file. */
+function isRealDate(year: number, month: number, day: number): boolean {
+  if (month < 1 || month > 12 || day < 1) return false;
+  return day <= new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+/**
+ * Normalize a date cell to YYYY-MM-DD (accepts ISO or AU dd/mm/yyyy), or "" for
+ * anything it cannot read as a real date.
+ *
+ * The range check is not fussiness. A US-formatted export reads `08/13/2026` as
+ * day 8 of month 13, and `2026-13-08` clears `bankTxnRowSchema`'s regex happily,
+ * so the whole import then dies at insert time on a raw Postgres range error
+ * with nothing on screen worth reading. An unreadable date costs the row its
+ * date; it must not cost the manager the import.
+ */
 export function normalizeDate(value: string): string {
   const t = value.trim();
-  if (/^\d{4}-\d{2}-\d{2}/.test(t)) return t.slice(0, 10);
-  const m = /^(\d{1,2})[/\-.](\d{1,2})[/\-.](\d{2,4})$/.exec(t);
+  const iso = /^(\d{4})-(\d{2})-(\d{2})/.exec(t);
+  if (iso) {
+    const [, y, mo, d] = iso;
+    return isRealDate(Number(y), Number(mo), Number(d)) ? t.slice(0, 10) : "";
+  }
+  // A day-first date, optionally followed by a time we have no use for.
+  const m = /^(\d{1,2})[/\-.](\d{1,2})[/\-.](\d{2,4})(?:[ T].*)?$/.exec(t);
   if (m) {
     const [, d, mo, y] = m;
     const year = y.length === 2 ? `20${y}` : y;
+    if (!isRealDate(Number(year), Number(mo), Number(d))) return "";
     return `${year}-${mo.padStart(2, "0")}-${d.padStart(2, "0")}`;
   }
   return "";
@@ -79,30 +100,43 @@ const REQUIRED_COLUMNS = [
 ] as const;
 
 /**
+ * Headers in the order we would rather read the description from. Reference is
+ * last on purpose: it is better than nothing, but a bank that gives us both
+ * wrote the narrative for a human to read and the reference for a machine.
+ */
+const DESCRIPTION_KEYS = ["description", "narrative", "details", "memo", "reference"];
+
+/** Never the amount, whatever else the header says. */
+const NOT_AN_AMOUNT = ["debit", "withdrawal", "limit", "balance"];
+
+/**
  * Work out which column is which from the header row, by substring.
  *
  * The amount column is the one worth reading twice. Some exports put money out
  * in its own column beside money in ("Debit Amount", "Credit Amount"), and a
  * plain first-match on "amount" picks the debit one: every card purchase in the
  * statement would then import as an incoming credit, and the club would think
- * it had been paid. So a header naming credit or deposit wins outright, and a
- * header naming debit or withdrawal is never the amount column.
+ * it had been paid. So nothing naming a debit, a withdrawal, a limit or a
+ * balance is ever the amount (that also rules out a "Debit/Credit" indicator
+ * column, which holds "DR"/"CR" rather than money), and among what is left a
+ * header naming a credit or a deposit wins over a plain "amount".
  */
 export function detectStatementColumns(headerRow: string[]): StatementColumns {
   const header = headerRow.map((h) => h.trim().toLowerCase());
   const find = (...keys: string[]) => header.findIndex((h) => keys.some((k) => h.includes(k)));
-  const moneyOut = (h: string) => h.includes("debit") || h.includes("withdrawal");
+  const couldBeAmount = (h: string) => !NOT_AN_AMOUNT.some((k) => h.includes(k));
 
-  const creditIdx = find("credit", "deposit");
+  const creditIdx = header.findIndex(
+    (h) => couldBeAmount(h) && (h.includes("credit") || h.includes("deposit")),
+  );
   const amountIdx =
-    creditIdx >= 0 ? creditIdx : header.findIndex((h) => h.includes("amount") && !moneyOut(h));
+    creditIdx >= 0 ? creditIdx : header.findIndex((h) => h.includes("amount") && couldBeAmount(h));
 
-  return {
-    dateIdx: find("date"),
-    amountIdx,
-    descIdx: find("description", "narrative", "details", "reference", "memo"),
-    refIdx: find("reference"),
-  };
+  // By key, not by column order: whichever of these the file has, the earliest
+  // key that appears anywhere in the header wins.
+  const descIdx = DESCRIPTION_KEYS.map((k) => find(k)).find((i) => i >= 0) ?? -1;
+
+  return { dateIdx: find("date"), amountIdx, descIdx, refIdx: find("reference") };
 }
 
 /** "a Date column" / "the Date and Amount columns" — for the error below. */

--- a/src/lib/bank-statement-csv.ts
+++ b/src/lib/bank-statement-csv.ts
@@ -1,0 +1,85 @@
+// Reading a bank statement export.
+//
+// This is the path money recognition runs through. Payments are manual bank
+// transfers, so a statement CSV is how the club learns who has paid: a row that
+// is dropped here is a member who gets chased for money they already sent.
+//
+// It lives in `src/lib/` rather than in `/manager/reconciliation` for one
+// reason: real exports vary far more than they look (quoted fields, `\r\n`,
+// a BOM, `DD/MM/YYYY` versus ISO dates, thousands separators, debits in their
+// own column), and the only way to be sure about any of that is to import the
+// functions and test them directly. Keep it free of React, server and Supabase
+// imports so it stays that way, mirroring `validation.ts`.
+
+import { parseMoneyToCents, type BankTxnRow } from "@/lib/validation";
+
+/** Minimal RFC-4180-ish CSV parser (handles quoted fields and commas). */
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else inQuotes = false;
+      } else field += c;
+    } else if (c === '"') inQuotes = true;
+    else if (c === ",") {
+      row.push(field);
+      field = "";
+    } else if (c === "\n" || c === "\r") {
+      if (c === "\r" && text[i + 1] === "\n") i++;
+      row.push(field);
+      field = "";
+      if (row.some((v) => v.trim() !== "")) rows.push(row);
+      row = [];
+    } else field += c;
+  }
+  if (field !== "" || row.length) {
+    row.push(field);
+    if (row.some((v) => v.trim() !== "")) rows.push(row);
+  }
+  return rows;
+}
+
+/** Normalize a date cell to YYYY-MM-DD (accepts ISO or AU dd/mm/yyyy). */
+export function normalizeDate(value: string): string {
+  const t = value.trim();
+  if (/^\d{4}-\d{2}-\d{2}/.test(t)) return t.slice(0, 10);
+  const m = /^(\d{1,2})[/\-.](\d{1,2})[/\-.](\d{2,4})$/.exec(t);
+  if (m) {
+    const [, d, mo, y] = m;
+    const year = y.length === 2 ? `20${y}` : y;
+    return `${year}-${mo.padStart(2, "0")}-${d.padStart(2, "0")}`;
+  }
+  return "";
+}
+
+/** Map parsed CSV into the bank-row shape, keeping only positive credits. */
+export function toBankRows(rows: string[][]): BankTxnRow[] {
+  if (rows.length < 2) return [];
+  const header = rows[0].map((h) => h.trim().toLowerCase());
+  const find = (...keys: string[]) => header.findIndex((h) => keys.some((k) => h.includes(k)));
+  const dateIdx = find("date");
+  const amountIdx = find("amount", "credit", "deposit");
+  const descIdx = find("description", "narrative", "details", "reference", "memo");
+  const refIdx = find("reference");
+
+  const out: BankTxnRow[] = [];
+  for (const r of rows.slice(1)) {
+    const cents = amountIdx >= 0 ? parseMoneyToCents(r[amountIdx] ?? "") : null;
+    if (cents == null || cents <= 0) continue; // only incoming credits can pay a membership
+    out.push({
+      posted_at: dateIdx >= 0 ? normalizeDate(r[dateIdx] ?? "") : "",
+      amount_cents: cents,
+      description: descIdx >= 0 ? (r[descIdx] ?? "").trim() : "",
+      reference: refIdx >= 0 ? (r[refIdx] ?? "").trim() : "",
+    });
+  }
+  return out;
+}

--- a/src/routes/_authenticated/manager.reconciliation.tsx
+++ b/src/routes/_authenticated/manager.reconciliation.tsx
@@ -4,7 +4,8 @@ import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { formatCents, isUnpaid, parseMoneyToCents, type BankTxnRow } from "@/lib/validation";
+import { formatCents, isUnpaid } from "@/lib/validation";
+import { parseCsv, toBankRows } from "@/lib/bank-statement-csv";
 import {
   importBankStatement,
   listBankTransactions,
@@ -22,77 +23,6 @@ export const Route = createFileRoute("/_authenticated/manager/reconciliation")({
 
 type Membership = Awaited<ReturnType<typeof listMemberships>>[number];
 type BankTxn = Awaited<ReturnType<typeof listBankTransactions>>[number];
-
-/** Minimal RFC-4180-ish CSV parser (handles quoted fields and commas). */
-function parseCsv(text: string): string[][] {
-  const rows: string[][] = [];
-  let row: string[] = [];
-  let field = "";
-  let inQuotes = false;
-  for (let i = 0; i < text.length; i++) {
-    const c = text[i];
-    if (inQuotes) {
-      if (c === '"') {
-        if (text[i + 1] === '"') {
-          field += '"';
-          i++;
-        } else inQuotes = false;
-      } else field += c;
-    } else if (c === '"') inQuotes = true;
-    else if (c === ",") {
-      row.push(field);
-      field = "";
-    } else if (c === "\n" || c === "\r") {
-      if (c === "\r" && text[i + 1] === "\n") i++;
-      row.push(field);
-      field = "";
-      if (row.some((v) => v.trim() !== "")) rows.push(row);
-      row = [];
-    } else field += c;
-  }
-  if (field !== "" || row.length) {
-    row.push(field);
-    if (row.some((v) => v.trim() !== "")) rows.push(row);
-  }
-  return rows;
-}
-
-/** Normalize a date cell to YYYY-MM-DD (accepts ISO or AU dd/mm/yyyy). */
-function normalizeDate(value: string): string {
-  const t = value.trim();
-  if (/^\d{4}-\d{2}-\d{2}/.test(t)) return t.slice(0, 10);
-  const m = /^(\d{1,2})[/\-.](\d{1,2})[/\-.](\d{2,4})$/.exec(t);
-  if (m) {
-    const [, d, mo, y] = m;
-    const year = y.length === 2 ? `20${y}` : y;
-    return `${year}-${mo.padStart(2, "0")}-${d.padStart(2, "0")}`;
-  }
-  return "";
-}
-
-/** Map parsed CSV into the bank-row shape, keeping only positive credits. */
-function toBankRows(rows: string[][]): BankTxnRow[] {
-  if (rows.length < 2) return [];
-  const header = rows[0].map((h) => h.trim().toLowerCase());
-  const find = (...keys: string[]) => header.findIndex((h) => keys.some((k) => h.includes(k)));
-  const dateIdx = find("date");
-  const amountIdx = find("amount", "credit", "deposit");
-  const descIdx = find("description", "narrative", "details", "reference", "memo");
-  const refIdx = find("reference");
-
-  const out: BankTxnRow[] = [];
-  for (const r of rows.slice(1)) {
-    const cents = amountIdx >= 0 ? parseMoneyToCents(r[amountIdx] ?? "") : null;
-    if (cents == null || cents <= 0) continue; // only incoming credits can pay a membership
-    out.push({
-      posted_at: dateIdx >= 0 ? normalizeDate(r[dateIdx] ?? "") : "",
-      amount_cents: cents,
-      description: descIdx >= 0 ? (r[descIdx] ?? "").trim() : "",
-      reference: refIdx >= 0 ? (r[refIdx] ?? "").trim() : "",
-    });
-  }
-  return out;
-}
 
 function ReconciliationPage() {
   const navigate = useNavigate();

--- a/src/routes/_authenticated/manager.reconciliation.tsx
+++ b/src/routes/_authenticated/manager.reconciliation.tsx
@@ -130,8 +130,8 @@ function ReconciliationPage() {
           <CardHeader>
             <CardTitle>Import a statement</CardTitle>
             <CardDescription>
-              Export your account transactions as CSV. We read the date, amount and description
-              columns and keep incoming credits only.
+              Export your account transactions as CSV, with the column headings in the first row. We
+              read the date, amount and description columns and keep incoming credits only.
             </CardDescription>
           </CardHeader>
           <CardContent>


### PR DESCRIPTION
Closes #65

## What the user will feel

This is the manager, on a laptop, importing a bank statement on `/manager/reconciliation`. Nothing changes for a file that already worked.

What changes is the file that did not. Before, an export whose columns are named differently, or that prints the account summary above the headings, imported zero rows and said "No credit transactions found in that file." That reads exactly like a quiet month, and the table underneath then says everything imported has been matched. Now the import stops and says which column it could not find, and to delete anything printed above the headings.

Some imports that used to look successful now correctly import less. An export with a `Debit Amount` column beside a `Credit Amount` one was reading the **debit** column as money in, so every card purchase imported as an incoming payment; so did an export that leaves the amount unsigned and puts `DR`/`CR` in its own column. Anyone who has imported either shape will have junk credits sitting in the unmatched list.

The message arrives in the existing import failure toast. That screen's error surfaces are #54's work, so nothing about its loading or error states is touched here.

## The commits

1. **Preparatory refactor** (`fdacab1`) — `parseCsv`, `normalizeDate` and `toBankRows` move out of the route into `src/lib/bank-statement-csv.ts`, verbatim. No behaviour change.
2. **Tests** (`847005d`) — 24 cases pinning what the parser actually does: quoted fields with commas, an escaped `""` inside quotes, CRLF and lone-CR endings, a BOM, no trailing newline, blank lines, an empty file, short rows, day-first AU dates against ISO. The last four pin the failure paths as they behaved, so the fix shows up as a change to those assertions.
3. **The fix** (`6ef585e`) — see below.
4. **Review fixes** (`104a523`) — three more holes, found by running `/review` over the first three commits.
5. **More review fixes** (`4ab737a`) — two more, found by a second, independent review.

## Bugs the tests uncovered

All four passed as written in commit 2, which is how they were confirmed real.

| | Before | After |
| --- | --- | --- |
| No column matching `amount` | imports nothing, silently | refuses the file, names the Amount column |
| No column matching `date` | imports rows with no date, silently | refuses the file, names the Date column |
| A preamble line above the headings | reads it as the header, imports nothing | refuses the file, says to delete anything above the headings |
| `Debit Amount` beside `Credit Amount` | reads the **debit** column as the credit | reads the credit column |

The last one is the one that costs money in the wrong direction. The first three are the issue's item 3.

Required columns are Date, Amount and Description, because those are the three the import card promises to read and because auto-matching runs on the description text. Reference stays optional. An empty file is refused rather than reported as a statement with no credits.

## What the two reviews then found

Each was reproduced by calling the functions before being fixed.

| | Before | After |
| --- | --- | --- |
| A `Debit/Credit` indicator column (holds `DR`/`CR`) | won the amount column, every row parsed to null, back to "no credit transactions found" | never the amount, along with anything naming a limit or a balance |
| A US-formatted date, `08/13/2026` | became `2026-13-08`, cleared the row schema's regex, killed the whole import at insert time on a raw Postgres range error | dropped, so the row keeps its amount and description and shows no date |
| `Reference` sitting left of `Narrative` | reference won, the human-readable narrative was discarded | keys are tried in their own order, reference last |
| A `Credit Card Surcharge` column beside `Amount` | the bare substring "credit" won it, and a real $120 payment imported as zero rows | a credit header only wins when every other word in it agrees it is a money column |
| An unsigned `Amount` with the direction in a separate `DR`/`CR` column | nothing read that column, so a $45.50 card purchase marked `DR` imported as $45.50 paid to the club | rows marked as going out are dropped; an unrecognised cell leaves its row alone, since dropping a credit is the costlier mistake |

The first review also flagged, correctly, that the refusal message reaches the manager only as a toast that fades, with the file input cleared behind it and nothing left to press. That is deliberately **not** fixed here: this screen's error surfaces are being reworked in #54, and a competing rewrite of them in this PR would just be a merge conflict. Worth confirming it lands there.

## Deliberately not in this change

- **No header sniffing.** A file with a preamble is refused with a message that says what to do, rather than the parser guessing which row is the header. Worth revisiting if a real export turns out to need it.
- **No new key synonyms** for column names (`Posted`, `Money In`). Those files now fail loudly instead of quietly, which is the point of the issue; widening the vocabulary is a separate judgement call against real exports.
- **A wholly US-formatted export imports dateless** rather than being refused. Same reasoning: refusing it needs a rule about what the file as a whole looks like, not about one cell.
- **No anonymised real bank export fixture** (issue item 2). I do not have one from the club's bank. The `Debit Amount` / `Credit Amount` and `DR`/`CR` cases are modelled on common AU export shapes, and a real file is worth adding to the suite when someone can supply one.

## Verified

`bun run deps`, then `bun run lint`, `bun run typecheck`, `bun run test` (2066 passing, 40 of them new) and `bun run build`, all green. `bun.lock` untouched.