### PR TITLE
Fix the em dashes and AI-prose copy the pre-launch review found

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,3 +74,18 @@ scan the diff for em dashes before committing.
 
 This rule is about **copy**. Code comments, commit messages, PR bodies and the
 files under `docs/` are internal writing and are not held to it.
+
+## Two of these rules are checked, not trusted
+
+`bun run test` fails on an em dash in copy, and on the "whether you're X or Y"
+and "it's not just X, it's Y" constructions, anywhere under `src/`. The scan is
+`scripts/copy-voice.test.ts`; it parses each file and looks only at string
+literals, template literals and JSX text, so comments are never flagged, and it
+knows both exceptions above. Two files are exempt because their text is
+addressed to a coding agent rather than to a person, and they are listed with
+their reasons in `scripts/copy-voice.ts`.
+
+Everything else on this page is still a judgement call. Hollow hype, mechanical
+rule-of-three lists, and error text that describes the system rather than the
+next step are things a reviewer catches and a regex does not, so a green test
+run is not evidence that the copy is any good.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,6 +422,11 @@ owner/manager policies (`20260727120000_waiver_storage_policies.sql`).
     `decodeDataUrlPng`). This is the highest-value suite: it pins the honeypot,
     signature-required, and minor/guardian rules.
   - `src/lib/utils.test.ts` — the `cn()` class-merge helper.
+  - `scripts/copy-voice.test.ts` — the two mechanical copy rules from
+    `AGENTS.md` (no em dash in prose, and the two banned constructions),
+    checked against every file under `src/`. It parses rather than greps, so
+    comments and the placeholder-glyph exception are not flagged; the exempt
+    files and the reasoning are in `scripts/copy-voice.ts`.
   - `src/components/ui/button.test.tsx` — a Testing Library smoke test proving
     the jsdom/component setup works (render, variants, click, `asChild`).
 - **Where to add tests:** pure logic belongs in `src/lib/` modules (import and

--- a/scripts/copy-voice.test.ts
+++ b/scripts/copy-voice.test.ts
@@ -1,0 +1,152 @@
+// Guards two of the copy rules in AGENTS.md across everything under src/.
+//
+// The scan itself, why it reads syntax rather than lines, and why only these
+// two rules are mechanical, are documented at the top of scripts/copy-voice.ts.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  EXEMPT_FILES,
+  findBannedConstructions,
+  findCopyViolations,
+  findEmDashesInSource,
+  isCopyScanned,
+} from "./copy-voice";
+
+const ROOT = resolve(process.cwd());
+
+/** Every scanned source file, repo-relative and sorted. Vitest runs at the repo root. */
+function scannedFiles(): string[] {
+  return readdirSync(join(ROOT, "src"), { recursive: true })
+    .map((entry) => `src/${String(entry).split("\\").join("/")}`)
+    .filter(isCopyScanned)
+    .sort();
+}
+
+describe("findEmDashesInSource", () => {
+  it("flags an em dash in a string literal", () => {
+    const found = findEmDashesInSource("x.ts", `const t = "Free trial — no gear needed";`);
+    expect(found).toEqual([{ line: 1, rule: "em dash", snippet: "Free trial — no gear needed" }]);
+  });
+
+  it("flags an em dash in a template literal, including after a substitution", () => {
+    const found = findEmDashesInSource("x.ts", "const t = `Upvote — ${n} upvotes`;");
+    expect(found).toHaveLength(1);
+  });
+
+  it("flags an em dash in JSX text", () => {
+    const found = findEmDashesInSource("x.tsx", `const el = <p>Draft — not signed</p>;`);
+    expect(found).toHaveLength(1);
+  });
+
+  it("allows an em dash in a comment, which is internal writing", () => {
+    const source = [
+      "// honeypot — must stay empty",
+      "/* also fine — a block comment */",
+      "const el = <p>{/* and a JSX one — fine too */}</p>;",
+    ].join("\n");
+    expect(findEmDashesInSource("x.tsx", source)).toEqual([]);
+  });
+
+  it("allows the placeholder glyph for an empty value", () => {
+    const source = [
+      `export const EMPTY = "—";`,
+      `const el = <td>{value || "—"}</td>;`,
+      `const also = <span>—</span>;`,
+    ].join("\n");
+    expect(findEmDashesInSource("x.tsx", source)).toEqual([]);
+  });
+
+  it("allows an en dash in a numeric range", () => {
+    expect(findEmDashesInSource("x.ts", `const t = "5:30 – 7:00pm";`)).toEqual([]);
+  });
+
+  it("allows a console log, which is not copy", () => {
+    const source = `console.warn("[email] LOVABLE_API_KEY not set — skipping emails");`;
+    expect(findEmDashesInSource("x.ts", source)).toEqual([]);
+  });
+
+  it("reports the line the dash is on", () => {
+    const source = ["const a = 1;", "", `const t = "Two sentences — one dash";`].join("\n");
+    expect(findEmDashesInSource("x.ts", source)[0].line).toBe(3);
+  });
+});
+
+describe("findBannedConstructions", () => {
+  it('flags "whether you\'re X or Y"', () => {
+    const source = `const t = "Our classes suit everyone, whether you're new or experienced.";`;
+    expect(findBannedConstructions("x.ts", source)).toHaveLength(1);
+  });
+
+  it("flags it across a line wrap in JSX", () => {
+    const source = [
+      "const el = (",
+      "  <p>",
+      "    Come along, whether",
+      "    you are new or not.",
+      "  </p>",
+      ");",
+    ].join("\n");
+    expect(findBannedConstructions("x.tsx", source)).toHaveLength(1);
+  });
+
+  it(`flags "it's not just X, it's Y"`, () => {
+    const source = `const t = "It's not just a workout, it's a skill you keep.";`;
+    expect(findBannedConstructions("x.ts", source)).toHaveLength(1);
+  });
+
+  it("leaves ordinary sentences alone", () => {
+    const source = [
+      `const a = "Everyone trains together, whatever they have done before.";`,
+      `const b = "Bring a water bottle. You do not need a Gi for your first class.";`,
+      `const c = "Filling this in is what unlocks the student rate for them.";`,
+    ].join("\n");
+    expect(findBannedConstructions("x.ts", source)).toEqual([]);
+  });
+});
+
+describe("isCopyScanned", () => {
+  it("skips generated files and tests, which quote copy in order to pin it", () => {
+    expect(isCopyScanned("src/routes/routeTree.gen.ts")).toBe(false);
+    expect(isCopyScanned("src/integrations/supabase/types.ts")).toBe(false);
+    expect(isCopyScanned("src/lib/faq.test.ts")).toBe(false);
+    expect(isCopyScanned("src/components/site/WaiverDocument.test.tsx")).toBe(false);
+    expect(isCopyScanned("src/styles.css")).toBe(false);
+  });
+
+  it("scans ordinary source", () => {
+    expect(isCopyScanned("src/lib/faq.ts")).toBe(true);
+    expect(isCopyScanned("src/routes/about.tsx")).toBe(true);
+  });
+
+  it("skips the agent-facing files, and only those", () => {
+    for (const file of EXEMPT_FILES) expect(isCopyScanned(file)).toBe(false);
+    expect(EXEMPT_FILES).toHaveLength(2);
+  });
+});
+
+describe("the copy under src/", () => {
+  const files = scannedFiles();
+
+  it("gives the scan something to read", () => {
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  it("breaks neither rule", () => {
+    const offences: string[] = [];
+    for (const file of files) {
+      const source = readFileSync(join(ROOT, file), "utf8");
+      for (const v of findCopyViolations(file, source)) {
+        offences.push(`${file}:${v.line}  [${v.rule}]  ${v.snippet}`);
+      }
+    }
+    // An em dash: split into two sentences, or use a comma, colon, parentheses,
+    // or "and"/"but". A banned construction: say the specific thing instead.
+    // Both rules, and their exceptions, are in AGENTS.md under "Writing style
+    // for website copy".
+    expect(offences).toEqual([]);
+  });
+});

--- a/scripts/copy-voice.test.ts
+++ b/scripts/copy-voice.test.ts
@@ -69,6 +69,20 @@ describe("findEmDashesInSource", () => {
     expect(findEmDashesInSource("x.ts", source)).toEqual([]);
   });
 
+  it("flags an em dash written as an HTML entity, which renders the same", () => {
+    expect(
+      findEmDashesInSource("x.tsx", `const el = <p>Draft &mdash; not signed</p>;`),
+    ).toHaveLength(1);
+    expect(
+      findEmDashesInSource("x.tsx", `const el = <p>Draft &#8212; not signed</p>;`),
+    ).toHaveLength(1);
+  });
+
+  it("reports each dash once, not again for the sentence around it", () => {
+    const source = "const t = `Upvote — ${n} times — again`;";
+    expect(findEmDashesInSource("x.ts", source)).toHaveLength(2);
+  });
+
   it("reports the line the dash is on", () => {
     const source = ["const a = 1;", "", `const t = "Two sentences — one dash";`].join("\n");
     expect(findEmDashesInSource("x.ts", source)[0].line).toBe(3);
@@ -98,11 +112,30 @@ describe("findBannedConstructions", () => {
     expect(findBannedConstructions("x.ts", source)).toHaveLength(1);
   });
 
+  it("reads through an interpolation, which splits the phrase in two", () => {
+    const template = "const t = `Come along, whether you're ${level} or not.`;";
+    expect(findBannedConstructions("x.ts", template)).toHaveLength(1);
+
+    const jsx = `const el = <p>It's not just {sport}, it's a skill you keep.</p>;`;
+    expect(findBannedConstructions("x.tsx", jsx)).toHaveLength(1);
+  });
+
+  it("reads through a nested element, and reports the phrase once", () => {
+    const source = `const el = <p>Come along, <strong>whether you're</strong> new or not.</p>;`;
+    expect(findBannedConstructions("x.tsx", source)).toHaveLength(1);
+  });
+
+  it("counts a curly apostrophe, which reads identically", () => {
+    const source = `const t = "Come along, whether you’re new or not.";`;
+    expect(findBannedConstructions("x.ts", source)).toHaveLength(1);
+  });
+
   it("leaves ordinary sentences alone", () => {
     const source = [
       `const a = "Everyone trains together, whatever they have done before.";`,
       `const b = "Bring a water bottle. You do not need a Gi for your first class.";`,
       `const c = "Filling this in is what unlocks the student rate for them.";`,
+      `const d = "We ask whether you have trained before, but not just for the record.";`,
     ].join("\n");
     expect(findBannedConstructions("x.ts", source)).toEqual([]);
   });

--- a/scripts/copy-voice.ts
+++ b/scripts/copy-voice.ts
@@ -74,12 +74,28 @@ const EM_DASH = "—";
 
 /**
  * The two constructions AGENTS.md bans by name. Both are matched on
- * whitespace-collapsed text, so wrapping across lines does not hide them.
+ * whitespace-collapsed text with substitutions standing in as `{}`, so neither
+ * a line wrap nor an interpolated name hides one. Either apostrophe counts:
+ * a curly one is what a word processor produces and reads identically.
  */
 const BANNED_CONSTRUCTIONS: readonly { rule: string; pattern: RegExp }[] = [
-  { rule: `"whether you're X or Y"`, pattern: /whether (you're|you are|you'?re)\b/i },
-  { rule: `"it's not just X, it's Y"`, pattern: /not just .{1,60}?,? (it'?s|but) /i },
+  { rule: `"whether you're X or Y"`, pattern: /\bwhether you(?:['’]re| are)\b/i },
+  { rule: `"it's not just X, it's Y"`, pattern: /\bnot just\b.{1,60}?(?:,\s*it['’]s|\bbut)\b/i },
 ];
+
+/** What an interpolation is replaced by when a template or an element is read as one string. */
+const SUBSTITUTION = "{}";
+
+/**
+ * JSX text is raw source: `&mdash;` in a page renders as an em dash and would
+ * otherwise scan clean. Only the entities that matter to these two rules are
+ * decoded, since nothing else here reads the text as HTML.
+ */
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&(?:mdash|#8212|#x2014);/gi, EM_DASH)
+    .replace(/&(?:rsquo|apos|#39|#8217|#x2019);/gi, "'");
+}
 
 /** The placeholder-glyph exception: the whole string is the dash. */
 function isPlaceholderGlyph(text: string): boolean {
@@ -110,19 +126,30 @@ function collapse(text: string): string {
   return text.replace(/\s+/g, " ").trim();
 }
 
+/** One piece of text a person reads. */
+type CopyText = {
+  text: string;
+  line: number;
+  /**
+   * True for a sentence read across its interpolations (a template literal, or
+   * an element's children). The em dash rule ignores these, because it has
+   * already seen each piece on its own and would otherwise report twice; the
+   * construction rule needs them, because a phrase broken by `${name}` matches
+   * in neither half.
+   */
+  joined: boolean;
+};
+
 /**
- * Calls back with every piece of text a person reads: string literals, the
- * text chunks of template literals, and JSX text. Comments never appear,
- * because the parser keeps them out of the tree.
+ * Every piece of text a person reads: string literals, the text chunks of
+ * template literals, and JSX text, plus each template and each text-carrying
+ * element read as one sentence. Comments never appear, because the parser
+ * keeps them out of the tree.
  *
  * `fileName` only decides how the source is parsed (`.tsx` enables JSX), so a
  * caller testing a snippet can pass any name with the right extension.
  */
-function forEachCopyText(
-  fileName: string,
-  source: string,
-  visitText: (text: string, line: number) => void,
-): void {
+function copyTexts(fileName: string, source: string): CopyText[] {
   const sourceFile = ts.createSourceFile(
     fileName,
     source,
@@ -131,47 +158,91 @@ function forEachCopyText(
     fileName.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
   );
 
-  function take(node: ts.Node, text: string): void {
+  const texts: CopyText[] = [];
+
+  function take(node: ts.Node, text: string, joined: boolean): void {
     if (isInsideConsoleCall(node)) return;
     const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
-    visitText(text, line + 1);
+    texts.push({ text: decodeEntities(text), line: line + 1, joined });
+  }
+
+  /** `Upvote ${n} times` read as "Upvote {} times". */
+  function readTemplate(node: ts.TemplateExpression): string {
+    return (
+      node.head.text + node.templateSpans.map((span) => SUBSTITUTION + span.literal.text).join("")
+    );
+  }
+
+  /** An element's children read as one sentence, nested elements flattened in. */
+  function readJsxChild(child: ts.JsxChild): string {
+    if (ts.isJsxText(child)) return child.text;
+    if (ts.isJsxExpression(child)) {
+      // `{" "}` is Prettier's line-wrap filler and carries real words often
+      // enough to matter; anything else stands in as a substitution.
+      const inner = child.expression;
+      return inner && ts.isStringLiteral(inner) ? inner.text : SUBSTITUTION;
+    }
+    if (ts.isJsxElement(child) || ts.isJsxFragment(child)) {
+      return child.children.map(readJsxChild).join("");
+    }
+    return SUBSTITUTION;
+  }
+
+  /**
+   * Only elements with words of their own are read whole. An outer `<div>` of
+   * nothing but other elements would otherwise repeat every sentence below it.
+   */
+  function carriesWords(children: readonly ts.JsxChild[]): boolean {
+    return children.some((child) => ts.isJsxText(child) && child.text.trim().length > 0);
   }
 
   function visit(node: ts.Node): void {
     if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
-      take(node, node.text);
+      take(node, node.text, false);
     } else if (ts.isTemplateHead(node) || ts.isTemplateMiddle(node) || ts.isTemplateTail(node)) {
-      take(node, node.text);
+      take(node, node.text, false);
     } else if (ts.isJsxText(node)) {
-      take(node, node.text);
+      take(node, node.text, false);
+    } else if (ts.isTemplateExpression(node)) {
+      take(node, readTemplate(node), true);
+    } else if ((ts.isJsxElement(node) || ts.isJsxFragment(node)) && carriesWords(node.children)) {
+      take(node, node.children.map(readJsxChild).join(""), true);
     }
     ts.forEachChild(node, visit);
   }
 
   visit(sourceFile);
+  return texts;
 }
 
 /** Every em dash in something a person reads, in one file's source. */
 export function findEmDashesInSource(fileName: string, source: string): CopyViolation[] {
   const violations: CopyViolation[] = [];
-  forEachCopyText(fileName, source, (text, line) => {
-    if (!text.includes(EM_DASH)) return;
-    if (isPlaceholderGlyph(text)) return;
+  for (const { text, line, joined } of copyTexts(fileName, source)) {
+    if (joined) continue;
+    if (!text.includes(EM_DASH)) continue;
+    if (isPlaceholderGlyph(text)) continue;
     violations.push({ line, rule: "em dash", snippet: snippet(text) });
-  });
+  }
   return violations;
 }
 
 /** Every banned construction in something a person reads, in one file's source. */
 export function findBannedConstructions(fileName: string, source: string): CopyViolation[] {
-  const violations: CopyViolation[] = [];
-  forEachCopyText(fileName, source, (text, line) => {
+  // One sentence is read both in pieces and whole, and a nested element is read
+  // again by its parent, so the same phrase arrives several times. Keyed on the
+  // matched words, each is reported once; the parser walks outermost first, so
+  // the last one to arrive is the tightest piece of text around it.
+  const byPhrase = new Map<string, CopyViolation>();
+  for (const { text, line } of copyTexts(fileName, source)) {
     const flat = collapse(text);
     for (const { rule, pattern } of BANNED_CONSTRUCTIONS) {
-      if (pattern.test(flat)) violations.push({ line, rule, snippet: snippet(text) });
+      const match = flat.match(pattern);
+      if (!match) continue;
+      byPhrase.set(`${rule}|${match[0].toLowerCase()}`, { line, rule, snippet: snippet(text) });
     }
-  });
-  return violations;
+  }
+  return [...byPhrase.values()].sort((a, b) => a.line - b.line);
 }
 
 /** Both rules at once, in source order. */

--- a/scripts/copy-voice.ts
+++ b/scripts/copy-voice.ts
@@ -1,0 +1,183 @@
+// The copy rules from AGENTS.md, made mechanical.
+//
+// "Do not use the em dash (—) in prose" is the easiest rule in this repo to
+// break by accident: the character is invisible in review, it survives a
+// copy-paste from anywhere, and nothing about a build or a test run notices it.
+// Two of them sat in the generated waiver PDF and its on-screen twin for months
+// (issue #62), which is the document people sign. The banned constructions
+// (issue #68) go the same way: "whether you're a complete beginner or ..." read
+// as ordinary marketing prose to everyone who reviewed it.
+//
+// So the rules are checked rather than trusted. The scan reads real syntax via
+// the TypeScript parser rather than grepping lines, because these rules are
+// about COPY and not about the file: an em dash in a code comment is internal
+// writing and explicitly allowed, while the same character in a string literal,
+// a template literal or JSX text is something a person reads on screen.
+//
+// What is deliberately NOT flagged:
+//
+//   - comments of every kind, including JSX `{/* … */}` (internal writing),
+//   - a string that is exactly "—", the placeholder glyph for an empty value
+//     (AGENTS.md exempts it; `src/lib/dates.ts` EMPTY is the canonical one),
+//   - the en dash "–" in a numeric range such as `5:30 – 7:00pm` (a different
+//     character, and also exempt),
+//   - anything passed to `console.*`, which is a server log, not copy,
+//   - the files in EXEMPT_FILES below.
+//
+// Only the two mechanical rules live here. The rest of the voice (hollow hype,
+// rule-of-three lists, telling someone what to do next rather than what broke)
+// is a judgement call a checker would get wrong more often than a reviewer
+// does: "unlocks the student rate" is concrete and fine, and no regex can tell
+// it apart from "unlock your potential".
+
+import ts from "typescript";
+
+/** One thing a person reads that breaks a rule in AGENTS.md. */
+export type CopyViolation = {
+  /** 1-based, so it pastes straight into an editor as `file:line`. */
+  line: number;
+  /** Which rule: the em dash, or the construction that was matched. */
+  rule: string;
+  /** The text it was found in, trimmed and shortened for the failure message. */
+  snippet: string;
+};
+
+/**
+ * Files whose "copy" is not copy: text addressed to an API client or a coding
+ * agent rather than to a member, a manager or a visitor. Issue #62 made this
+ * call explicitly for the manifest, and the token page's prompt is the same
+ * text in the same voice.
+ *
+ * Paths are repo-relative and compared exactly. Keep this list short, and say
+ * why here rather than in a commit message nobody will find.
+ */
+export const EXEMPT_FILES: readonly string[] = [
+  // AGENT_MANIFEST: the manager agent API's own protocol documentation, served
+  // as JSON to whatever client is calling it. Never rendered on a screen.
+  "src/lib/manager-agent.ts",
+  // buildAgentPrompt: the prompt a manager copies into their coding agent. It
+  // is displayed, but it is addressed to the agent, and it is the manifest's
+  // voice, not the club's.
+  "src/lib/manager-api-tokens.ts",
+];
+
+/** Generated files, and tests (which quote copy in order to pin it). */
+export function isCopyScanned(repoRelativePath: string): boolean {
+  if (!/\.tsx?$/.test(repoRelativePath)) return false;
+  if (/\.(test|spec)\.tsx?$/.test(repoRelativePath)) return false;
+  if (repoRelativePath.startsWith("src/integrations/supabase/")) return false;
+  if (repoRelativePath.endsWith(".gen.ts")) return false;
+  return !EXEMPT_FILES.includes(repoRelativePath);
+}
+
+const EM_DASH = "—";
+
+/**
+ * The two constructions AGENTS.md bans by name. Both are matched on
+ * whitespace-collapsed text, so wrapping across lines does not hide them.
+ */
+const BANNED_CONSTRUCTIONS: readonly { rule: string; pattern: RegExp }[] = [
+  { rule: `"whether you're X or Y"`, pattern: /whether (you're|you are|you'?re)\b/i },
+  { rule: `"it's not just X, it's Y"`, pattern: /not just .{1,60}?,? (it'?s|but) /i },
+];
+
+/** The placeholder-glyph exception: the whole string is the dash. */
+function isPlaceholderGlyph(text: string): boolean {
+  return text.trim() === EM_DASH;
+}
+
+/** A log line is internal writing, wherever in the argument list it sits. */
+function isInsideConsoleCall(node: ts.Node): boolean {
+  for (let n = node.parent; n; n = n.parent) {
+    if (
+      ts.isCallExpression(n) &&
+      ts.isPropertyAccessExpression(n.expression) &&
+      ts.isIdentifier(n.expression.expression) &&
+      n.expression.expression.text === "console"
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function snippet(text: string): string {
+  const flat = collapse(text);
+  return flat.length > 120 ? `${flat.slice(0, 117)}...` : flat;
+}
+
+function collapse(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Calls back with every piece of text a person reads: string literals, the
+ * text chunks of template literals, and JSX text. Comments never appear,
+ * because the parser keeps them out of the tree.
+ *
+ * `fileName` only decides how the source is parsed (`.tsx` enables JSX), so a
+ * caller testing a snippet can pass any name with the right extension.
+ */
+function forEachCopyText(
+  fileName: string,
+  source: string,
+  visitText: (text: string, line: number) => void,
+): void {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    fileName.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+
+  function take(node: ts.Node, text: string): void {
+    if (isInsideConsoleCall(node)) return;
+    const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+    visitText(text, line + 1);
+  }
+
+  function visit(node: ts.Node): void {
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      take(node, node.text);
+    } else if (ts.isTemplateHead(node) || ts.isTemplateMiddle(node) || ts.isTemplateTail(node)) {
+      take(node, node.text);
+    } else if (ts.isJsxText(node)) {
+      take(node, node.text);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+}
+
+/** Every em dash in something a person reads, in one file's source. */
+export function findEmDashesInSource(fileName: string, source: string): CopyViolation[] {
+  const violations: CopyViolation[] = [];
+  forEachCopyText(fileName, source, (text, line) => {
+    if (!text.includes(EM_DASH)) return;
+    if (isPlaceholderGlyph(text)) return;
+    violations.push({ line, rule: "em dash", snippet: snippet(text) });
+  });
+  return violations;
+}
+
+/** Every banned construction in something a person reads, in one file's source. */
+export function findBannedConstructions(fileName: string, source: string): CopyViolation[] {
+  const violations: CopyViolation[] = [];
+  forEachCopyText(fileName, source, (text, line) => {
+    const flat = collapse(text);
+    for (const { rule, pattern } of BANNED_CONSTRUCTIONS) {
+      if (pattern.test(flat)) violations.push({ line, rule, snippet: snippet(text) });
+    }
+  });
+  return violations;
+}
+
+/** Both rules at once, in source order. */
+export function findCopyViolations(fileName: string, source: string): CopyViolation[] {
+  return [
+    ...findEmDashesInSource(fileName, source),
+    ...findBannedConstructions(fileName, source),
+  ].sort((a, b) => a.line - b.line);
+}

--- a/src/components/site/WaiverDocument.test.tsx
+++ b/src/components/site/WaiverDocument.test.tsx
@@ -264,7 +264,7 @@ describe("WaiverDocument", () => {
 
   it("shows the draft watermark and hides the signed footer when draft", () => {
     render(<WaiverDocument {...base} draft />);
-    expect(screen.getByText(/Draft — not signed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Draft, not signed/i)).toBeInTheDocument();
     expect(screen.getByText("Draft preview")).toBeInTheDocument();
     expect(screen.queryByText(/Electronically signed on/)).not.toBeInTheDocument();
   });
@@ -272,7 +272,7 @@ describe("WaiverDocument", () => {
   it("shows the signed footer when not a draft", () => {
     render(<WaiverDocument {...base} />);
     expect(screen.getByText(/Electronically signed on/)).toBeInTheDocument();
-    expect(screen.queryByText(/Draft — not signed/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Draft, not signed/i)).not.toBeInTheDocument();
   });
 
   it("renders the guardian block only for minors", () => {

--- a/src/components/site/WaiverDocument.tsx
+++ b/src/components/site/WaiverDocument.tsx
@@ -212,7 +212,7 @@ export function WaiverDocument(props: WaiverDocumentProps) {
           className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center overflow-hidden"
         >
           <span className="-rotate-[30deg] select-none whitespace-nowrap text-4xl font-black uppercase tracking-widest text-slate-200/70 sm:text-5xl">
-            Draft — not signed
+            Draft, not signed
           </span>
         </div>
       ) : null}

--- a/src/integrations/lovable/appUserConnectorClient.ts
+++ b/src/integrations/lovable/appUserConnectorClient.ts
@@ -33,7 +33,7 @@ export async function connectAppUser(opts: {
     return {
       success: false,
       connectorId,
-      error: e instanceof Error ? e.message : "Failed to start OAuth",
+      error: e instanceof Error ? e.message : "Could not start the connection. Try again.",
     };
   }
   popup.location.href = authorizationUrl;

--- a/src/lib/faq.ts
+++ b/src/lib/faq.ts
@@ -15,7 +15,7 @@ export const faqItems: FaqItem[] = [
   {
     id: "trial-offer",
     q: "Is there a trial offer?",
-    a: "Absolutely. Your first two sessions are on us. It's a great opportunity to experience our training firsthand and see if it's the right fit.",
+    a: "Yes. Your first two sessions are free. Come along and see what you think.",
   },
   {
     id: "equipment",
@@ -30,7 +30,7 @@ export const faqItems: FaqItem[] = [
   {
     id: "experience",
     q: "Do I need prior martial arts experience?",
-    a: "Not at all. Our training is structured for every skill level, from complete beginner to experienced practitioner. We support your progress at your own pace.",
+    a: "No. Plenty of our members had never done a martial art before they walked in. You will be shown the basics from the start.",
   },
   {
     id: "vs-other-martial-arts",

--- a/src/lib/google-drive.functions.ts
+++ b/src/lib/google-drive.functions.ts
@@ -373,7 +373,8 @@ export const uploadWaiverToDrive = createServerFn({ method: "POST" })
     const { data: pdfBlob, error: dlErr } = await supabaseAdmin.storage
       .from("waivers")
       .download(waiver.pdf_path);
-    if (dlErr || !pdfBlob) throw new Error(dlErr?.message ?? "Failed to download PDF.");
+    if (dlErr || !pdfBlob)
+      throw new Error(dlErr?.message ?? "Could not download the PDF. Try again.");
     const pdfBytes = new Uint8Array(await pdfBlob.arrayBuffer());
 
     let folderId = conn.metadata.folderId as string | undefined;

--- a/src/lib/google-picker.ts
+++ b/src/lib/google-picker.ts
@@ -82,7 +82,10 @@ function loadScript(src: string): Promise<void> {
     script.src = src;
     script.async = true;
     script.onload = () => resolve();
-    script.onerror = () => reject(new Error(`Failed to load ${src}`));
+    script.onerror = () =>
+      reject(
+        new Error("Could not load Google's folder picker. Check your connection and try again."),
+      );
     document.head.appendChild(script);
   });
 }
@@ -235,7 +238,7 @@ export async function pickDriveFolder(clientId: string): Promise<PickedDriveFold
         .build();
       picker.setVisible(true);
     } catch (e) {
-      reject(e instanceof Error ? e : new Error("Failed to open Google Picker"));
+      reject(e instanceof Error ? e : new Error("Could not open the folder picker. Try again."));
     }
   });
 }

--- a/src/lib/google-picker.ts
+++ b/src/lib/google-picker.ts
@@ -72,6 +72,12 @@ const GIS_SRC = "https://accounts.google.com/gsi/client";
 const GAPI_SRC = "https://apis.google.com/js/api.js";
 const DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive.file";
 
+// Every way Google's own scripts can fail to arrive reads the same to the
+// manager: the button did nothing. The URL that failed is the useful part for
+// us and means nothing to them, so it goes to the console and the toast gets
+// the sentence with a way out.
+const LOAD_FAILED = "Could not load Google's folder picker. Check your connection and try again.";
+
 function loadScript(src: string): Promise<void> {
   return new Promise((resolve, reject) => {
     if (document.querySelector(`script[src="${src}"]`)) {
@@ -82,23 +88,23 @@ function loadScript(src: string): Promise<void> {
     script.src = src;
     script.async = true;
     script.onload = () => resolve();
-    script.onerror = () =>
-      reject(
-        new Error("Could not load Google's folder picker. Check your connection and try again."),
-      );
+    script.onerror = () => {
+      console.warn(`[google-picker] script did not load: ${src}`);
+      reject(new Error(LOAD_FAILED));
+    };
     document.head.appendChild(script);
   });
 }
 
 async function loadPickerLibrary(): Promise<void> {
   await loadScript(GAPI_SRC);
-  if (!window.gapi) throw new Error("Google API script did not load");
+  if (!window.gapi) throw new Error(LOAD_FAILED);
   await new Promise<void>((resolve) => window.gapi!.load("picker", () => resolve()));
 }
 
 async function requestAccessToken(clientId: string): Promise<string> {
   await loadScript(GIS_SRC);
-  if (!window.google) throw new Error("Google Identity Services did not load");
+  if (!window.google) throw new Error(LOAD_FAILED);
   const google = window.google;
   return new Promise((resolve, reject) => {
     const client = google.accounts.oauth2.initTokenClient({
@@ -204,7 +210,7 @@ export function readPickerResponse(
 export async function pickDriveFolder(clientId: string): Promise<PickedDriveFolder | null> {
   const [, token] = await Promise.all([loadPickerLibrary(), requestAccessToken(clientId)]);
   const google = window.google;
-  if (!google) throw new Error("Google Identity Services did not load");
+  if (!google) throw new Error(LOAD_FAILED);
 
   return new Promise((resolve, reject) => {
     try {

--- a/src/lib/waiver-approval.test.ts
+++ b/src/lib/waiver-approval.test.ts
@@ -109,11 +109,13 @@ describe("approvalFailureMessage", () => {
   });
 
   it("falls back for a thrown non-Error", () => {
-    expect(approvalFailureMessage("boom")).toBe("Failed to update approval");
+    expect(approvalFailureMessage("boom")).toBe("Could not update the approval. Try again.");
   });
 
   it("falls back rather than showing a blank toast", () => {
-    expect(approvalFailureMessage(new Error("   "))).toBe("Failed to update approval");
+    expect(approvalFailureMessage(new Error("   "))).toBe(
+      "Could not update the approval. Try again.",
+    );
   });
 });
 

--- a/src/lib/waiver-approval.ts
+++ b/src/lib/waiver-approval.ts
@@ -76,7 +76,7 @@ export async function runApproval({
 
 /** The approval itself failed, so nothing was written. */
 export function approvalFailureMessage(e: unknown): string {
-  return reason(e) ?? "Failed to update approval";
+  return reason(e) ?? "Could not update the approval. Try again.";
 }
 
 /**

--- a/src/lib/waiver-pdf.ts
+++ b/src/lib/waiver-pdf.ts
@@ -468,7 +468,7 @@ export async function renderWaiverPdf(data: WaiverPdfData): Promise<Uint8Array> 
   // DRAFT watermark on every page
   if (data.draft) {
     for (const p of pages) {
-      p.drawText("DRAFT — NOT SIGNED", {
+      p.drawText("DRAFT: NOT SIGNED", {
         x: 60,
         y: 380,
         size: 60,

--- a/src/routes/_authenticated/account.tsx
+++ b/src/routes/_authenticated/account.tsx
@@ -810,7 +810,7 @@ function WaiversCard() {
       const { url } = await getUrl({ data: { id } });
       window.open(url, "_blank", "noopener");
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to get PDF");
+      toast.error(e instanceof Error ? e.message : "Could not open the PDF. Try again.");
     }
   }
 
@@ -983,7 +983,7 @@ function GoogleDriveCard() {
       toast.success(saved.email ? `Connected as ${saved.email}` : "Google Drive connected");
       await refresh();
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to connect");
+      toast.error(e instanceof Error ? e.message : "Could not connect Google Drive. Try again.");
     } finally {
       setBusy(false);
     }
@@ -996,7 +996,7 @@ function GoogleDriveCard() {
       toast.success("Google Drive disconnected");
       await refresh();
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to disconnect");
+      toast.error(e instanceof Error ? e.message : "Could not disconnect Google Drive. Try again.");
     } finally {
       setBusy(false);
     }
@@ -1012,7 +1012,7 @@ function GoogleDriveCard() {
       setSavedFolderName(result.folderName);
       toast.success(`Waivers will save to "${result.folderName}"`);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to set the Drive folder");
+      toast.error(e instanceof Error ? e.message : "Could not save the folder name. Try again.");
     } finally {
       setFolderBusy(false);
     }
@@ -1034,7 +1034,11 @@ function GoogleDriveCard() {
       setFolderNameInput(result.folderName);
       toast.success(`Waivers will save to "${result.folderName}"`);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to pick a folder");
+      toast.error(
+        e instanceof Error
+          ? e.message
+          : "Could not open the folder picker. Type the folder name instead.",
+      );
     } finally {
       setPickerBusy(false);
     }

--- a/src/routes/_authenticated/manager.blog-comments.tsx
+++ b/src/routes/_authenticated/manager.blog-comments.tsx
@@ -342,7 +342,7 @@ function BlogCommentsPage() {
                 <p className="text-sm text-amber-600 dark:text-amber-500">
                   This comment has {hideTargetReplyCount}{" "}
                   {hideTargetReplyCount === 1 ? "reply" : "replies"}. Hiding it also removes{" "}
-                  {hideTargetReplyCount === 1 ? "that reply" : "those replies"} from the post — they
+                  {hideTargetReplyCount === 1 ? "that reply" : "those replies"} from the post. They
                   stay marked visible, they just have nowhere left to show.
                 </p>
               )}
@@ -376,9 +376,9 @@ function BlogCommentsPage() {
           <DialogHeader>
             <DialogTitle>Block {blockTarget?.author_name} from commenting?</DialogTitle>
             <DialogDescription>
-              This is the extreme option — it stops them commenting anywhere on the blog from now
-              on. It does not hide comments they've already posted (use "Hide" on this row for just
-              this one).
+              This is the extreme option. It stops them commenting anywhere on the blog from now on.
+              It does not hide comments they've already posted (use "Hide" on this row for just this
+              one).
             </DialogDescription>
           </DialogHeader>
           <div>

--- a/src/routes/_authenticated/manager.settings.tsx
+++ b/src/routes/_authenticated/manager.settings.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { ClubAccountDetails } from "@/components/site/ClubAccountDetails";
 import { getClubSettings, saveClubSettings } from "@/lib/membership.functions";
 import { invoiceMarkdownComponents } from "@/lib/invoice-markdown";
+import { describeLoadError } from "@/lib/load-error";
 import { clubPaymentDetailsSchema, formatBsb } from "@/lib/validation";
 import type { ClubPaymentDetails } from "@/lib/validation";
 import { useAuth, useRoles } from "@/hooks/useAuth";
@@ -108,7 +109,7 @@ function SettingsPage() {
         // unpublished one; swallowing that here would put the empty form back on
         // screen and hand a manager the overwrite it was protecting them from.
         setLoadFailed(true);
-        toast.error(e instanceof Error ? e.message : "Failed to load settings");
+        toast.error(describeLoadError(e, "Could not load the club's settings"));
       })
       .finally(() => setLoading(false));
   }, [isManager, fetchSettings]);

--- a/src/routes/_authenticated/manager.users_.$userId.tsx
+++ b/src/routes/_authenticated/manager.users_.$userId.tsx
@@ -524,7 +524,7 @@ function ManagerUserPage() {
           ...prev,
           [waiver.id]: {
             at: Date.now(),
-            error: e instanceof Error ? e.message : "Failed to load the PDF",
+            error: e instanceof Error ? e.message : "Could not load the PDF. Try again.",
           },
         }));
       } finally {
@@ -641,7 +641,7 @@ function ManagerUserPage() {
       setPdfs((prev) => ({ ...prev, [id]: { url, at: Date.now() } }));
       window.open(url, "_blank", "noopener");
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to get PDF");
+      toast.error(e instanceof Error ? e.message : "Could not open the PDF. Try again.");
     }
   }
 

--- a/src/routes/_authenticated/manager.waivers.tsx
+++ b/src/routes/_authenticated/manager.waivers.tsx
@@ -103,7 +103,7 @@ function WaiversPage() {
       const { url } = await getUrl({ data: { id } });
       window.open(url, "_blank", "noopener");
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to get PDF");
+      toast.error(e instanceof Error ? e.message : "Could not open the PDF. Try again.");
     }
   }
 

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -27,7 +27,7 @@ const pillars = [
   },
   {
     title: "An inclusive community",
-    body: "Our classes cater to individuals of all levels, whether you're a complete beginner or have previous martial arts experience. We encourage questions and create an environment where everyone progresses at their own pace.",
+    body: "Everyone trains together, whatever they have done before. Ask questions, go at your own pace.",
   },
   {
     title: "Fitness through martial arts",

--- a/src/routes/blog/$slug.tsx
+++ b/src/routes/blog/$slug.tsx
@@ -151,8 +151,8 @@ function UpvoteButton({
       aria-pressed={upvoted}
       aria-label={
         upvoted
-          ? `Remove your upvote — ${comment.upvote_count} upvotes`
-          : `Upvote — ${comment.upvote_count} upvotes`
+          ? `Remove your upvote (${comment.upvote_count} upvotes)`
+          : `Upvote (${comment.upvote_count} upvotes)`
       }
       className={cn(
         "flex min-h-8 items-center gap-1 rounded-md border px-2.5 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "include": [
     "src/**/*.ts",
     "src/**/*.tsx",
+    "scripts/**/*.ts",
     "vite.config.ts",
     "vitest.config.ts",
     "vitest.setup.ts",


### PR DESCRIPTION
Closes #62
Closes #68

Two copy issues, done together because they edit the same files. Every reworded
string is listed below so it can be corrected here: the wording is a judgement
call, and it is the club's voice, not mine.

## What the user will feel

Almost nothing changes for anyone mid-flow. No new steps, no emails, nothing
deleted, nothing slower.

- **Someone signing a waiver** sees the draft watermark read `DRAFT: NOT SIGNED`
  instead of `DRAFT — NOT SIGNED`, both on screen and in the PDF. **This is a
  legal document.** It only ever appears on the *draft* preview, never on a
  signed waiver, and the words carry the same meaning. But it is baked into the
  file at render time, so waivers already stored keep the old watermark and
  every new draft carries the new one. Worth a look before merging.
- **Someone on a screen reader**, on a blog post, hears "Upvote (3 upvotes)"
  rather than "Upvote — 3 upvotes".
- **A prospective member** on `/faq`, `/about` or the home page reads two FAQ
  answers and one About pillar in plainer words. Same facts, fewer of them.
- **A manager** hiding a comment or blocking a commenter reads the same warning
  in two sentences instead of one.
- **Anyone who hits an error doing something** (opening a waiver PDF,
  connecting Google Drive, approving a waiver) is told what to try next rather
  than that something "failed".

## Every string reworded

### Em dashes (#62)

| Where | Was | Now |
|---|---|---|
| Waiver PDF watermark | `DRAFT — NOT SIGNED` | `DRAFT: NOT SIGNED` |
| On-screen waiver watermark | `Draft — not signed` | `Draft, not signed` |
| Comment upvote `aria-label` | `Remove your upvote — 3 upvotes` | `Remove your upvote (3 upvotes)` |
| Comment upvote `aria-label` | `Upvote — 3 upvotes` | `Upvote (3 upvotes)` |
| Hide-comment confirm | `... from the post — they stay marked visible ...` | `... from the post. They stay marked visible ...` |
| Block-user confirm | `This is the extreme option — it stops them ...` | `This is the extreme option. It stops them ...` |

Both documented exceptions are untouched: the en dash in a time range, and the
em dash as the placeholder glyph for an empty value.

### Voice (#68)

| Where | Was | Now |
|---|---|---|
| FAQ `trial-offer` | "Absolutely. Your first two sessions are on us. It's a great opportunity to experience our training firsthand and see if it's the right fit." | "Yes. Your first two sessions are free. Come along and see what you think." |
| FAQ `experience` (the second answer the issue mentions) | "Not at all. Our training is structured for every skill level, from complete beginner to experienced practitioner. We support your progress at your own pace." | "No. Plenty of our members had never done a martial art before they walked in. You will be shown the basics from the start." |
| `/about`, "An inclusive community" | "Our classes cater to individuals of all levels, whether you're a complete beginner or have previous martial arts experience. We encourage questions and create an environment where everyone progresses at their own pace." | "Everyone trains together, whatever they have done before. Ask questions, go at your own pace." |

Both FAQ answers show on `/faq` **and** in the "Common questions" block on the
home page.

Two things to look at: the About pillar is now noticeably shorter than the two
cards beside it, which may or may not read well in that row; and the
prior-experience answer claims members arrive with no martial arts background,
which is only worth saying if it is true of this club.

### Error copy (#68, item 3)

| Was | Now |
|---|---|
| `Failed to get PDF` (member account, manager waivers, manager member page) | `Could not open the PDF. Try again.` |
| `Failed to load the PDF` (waiver preview panel) | `Could not load the PDF. Try again.` |
| `Failed to connect` | `Could not connect Google Drive. Try again.` |
| `Failed to disconnect` | `Could not disconnect Google Drive. Try again.` |
| `Failed to set the Drive folder` | `Could not save the folder name. Try again.` |
| `Failed to pick a folder` | `Could not open the folder picker. Type the folder name instead.` |
| `Failed to update approval` | `Could not update the approval. Try again.` |
| `Failed to start OAuth` | `Could not start the connection. Try again.` |
| `Failed to download PDF.` | `Could not download the PDF. Try again.` |
| `Failed to load <script url>` and `... did not load` (Drive picker) | `Could not load Google's folder picker. Check your connection and try again.` |
| `Failed to open Google Picker` | `Could not open the folder picker. Try again.` |
| `Failed to load settings` | `Could not load the club's settings` |

#68 sequenced this item after #54, since the fix for a failed load is an error
that stays on screen rather than better toast wording. **#54 landed on `main`
while this branch was open**, so the branch now carries that merge and the one
`Failed to load ...` string it left behind is fixed here, through the same
`describeLoadError` helper and in the same house wording the other screens use.

The Drive picker's message no longer names the script URL that failed, so that
now goes to the console, where it helps us and not the manager.

The only `Failed to ...` string left in the app is the YouTube API loader's,
which the embed swallows and nobody ever reads. `Failed to fetch` in tests is
the browser's own message, not our copy.

## So it cannot come back

`scripts/copy-voice.test.ts` (new) fails `bun run test` on an em dash in copy,
and on the "whether you're X or Y" and "it's not just X, it's Y" constructions,
anywhere under `src/`.

It parses each file with the TypeScript parser instead of grepping lines,
because the rule is about copy and not about the file: comments of every kind
(including JSX `{/* … */}`) are internal writing and are never flagged, while
the same character in a string, a template literal or JSX text is something a
person reads. It knows both documented exceptions, skips `console.*` (a server
log is not copy), decodes `&mdash;` (raw JSX source renders it as a dash),
reads a template or an element as one sentence so an interpolation cannot split
a banned phrase in half, and exempts two files whose text is addressed to a
coding agent rather than a person, with the reasons written next to the list
rather than in a commit message.

Checked against the code as it was: the scan finds exactly the six em dashes
#62 lists and the `/about` construction #68 lists, and nothing else. It is also
clean against everything that landed on `main` in the meantime.

Nothing else in the voice is mechanised, and `AGENTS.md` now says so: hollow
hype, rule-of-three lists and error text that describes the system are things a
reviewer catches and a regex does not. "Unlocks the student rate" is concrete
and fine, and no pattern tells it apart from "unlock your potential".

**One line outside the two issues:** `tsconfig.json` now includes
`scripts/**/*.ts`. Without it `bun run typecheck` reads none of the new scan
(nor any other repo script); the tree is clean with it on, and a deliberate
type error in `scripts/` now fails as it should.

## Scope

Other sessions own `src/routes/pricing.tsx` (#58, #63) and the class schedule
(#51), so I did not read or touch them. Nothing else outside the two issues was
changed.

## Docs

- `AGENTS.md` gains a short section saying which two rules are now checked, and
  that the rest is still a judgement call.
- `CLAUDE.md`'s "What's covered today" list gains the new suite.

## Verified

`bun run deps`, then `bun run lint`, `bun run typecheck`, `bun run test`
(131 files, 2303 tests) and `bun run build`, all green after merging `main`.
`bun.lock` untouched.
