### PR TITLE
Give the dark destructive button an ink it can carry (2.75:1 to 6.72:1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -616,6 +616,26 @@ invisible to `bun run build`.
   carry it only because they are generated that way). That rule has to stay in
   the base layer — layer order, not specificity, is what lets a `cursor-*`
   utility still win over it.
+- **Changing a colour token? The pairs are contrast-checked.**
+  `src/lib/color-contrast.test.ts` reads `styles.css`, converts every
+  `oklch()` token to sRGB and asserts each foreground/background pair clears
+  WCAG AA (4.5:1) in **both** themes, so a palette tweak that makes a label
+  unreadable fails the unit suite rather than shipping. Two things are worth
+  knowing before you move one:
+  - `--destructive` does two jobs. It is the fill behind
+    `text-destructive-foreground` on every delete/revoke button, and it is
+    `text-destructive`, the colour of every form error and failed-submit panel
+    on the page. In dark mode there is no lightness that serves both against a
+    near-white ink, which is why the dark `--destructive-foreground` is a near
+    black (`oklch(0.16 0.05 22)`) while every other dark `-foreground` on a
+    tinted surface is `oklch(0.15 0.03 220)`. Darkening the red instead would
+    fix the buttons and break the error text.
+  - Keep a token inside the sRGB gamut if you care about the number. Out of
+    gamut, the test clips per channel and a browser reduces chroma instead, so
+    the two stop agreeing; `isSrgbGamut` says which side a value is on.
+  - A pair that is knowingly below AA goes on `KNOWN_BELOW_AA` in that file
+    with its reason and its exact current ratio, so it cannot get worse
+    unnoticed and cannot be forgotten. It is an acknowledgement, not a pardon.
 - **SEO:** every public page sets its own `head()` meta (title/description/og)
   **and its own `rel="canonical"`**; manager and other private pages set
   `robots: noindex`. Match the existing pattern when adding pages, and see the

--- a/src/lib/color-contrast.test.ts
+++ b/src/lib/color-contrast.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  contrastRatio,
+  isSrgbGamut,
+  oklchContrast,
+  oklchToRgb,
+  parseOklch,
+  relativeLuminance,
+  rgbToHex,
+  type Oklch,
+} from "./color-contrast";
+
+describe("parseOklch", () => {
+  it("reads the three-component form the theme uses", () => {
+    expect(parseOklch("oklch(0.58 0.24 27)")).toEqual({ l: 0.58, c: 0.24, h: 27 });
+    expect(parseOklch("  oklch( 1 0 0 )  ")).toEqual({ l: 1, c: 0, h: 0 });
+    expect(parseOklch("oklch(70% 0.19 22deg)")).toEqual({ l: 0.7, c: 0.19, h: 22 });
+  });
+
+  // A translucent token has no fixed contrast, so it must not be mistaken for
+  // one. `--border` and `--input` are written this way in the dark theme.
+  it("refuses the alpha form and anything that is not oklch", () => {
+    expect(parseOklch("oklch(1 0 0 / 10%)")).toBeNull();
+    expect(parseOklch("#008eaa")).toBeNull();
+    expect(parseOklch("var(--primary)")).toBeNull();
+  });
+});
+
+describe("contrast maths", () => {
+  it("matches the WCAG anchor points", () => {
+    expect(contrastRatio([1, 1, 1], [0, 0, 0])).toBeCloseTo(21, 5);
+    expect(contrastRatio([1, 1, 1], [1, 1, 1])).toBeCloseTo(1, 5);
+    expect(relativeLuminance([1, 1, 1])).toBeCloseTo(1, 5);
+    expect(relativeLuminance([0, 0, 0])).toBeCloseTo(0, 5);
+  });
+
+  it("converts oklch to the sRGB a browser would paint", () => {
+    // The two brand colours are written as hex in `@theme inline`, so they are
+    // an independent check that the conversion lands where it should.
+    expect(rgbToHex(oklchToRgb({ l: 0.58, c: 0.11, h: 220 }))).toBe("#0089a7"); // teal
+    expect(rgbToHex(oklchToRgb({ l: 1, c: 0, h: 0 }))).toBe("#ffffff");
+  });
+
+  it("reports the ratio the issue computed for the old dark destructive pair", () => {
+    const wasRed: Oklch = { l: 0.7, c: 0.19, h: 22 };
+    const wasWhite: Oklch = { l: 0.98, c: 0, h: 0 };
+    expect(oklchContrast(wasRed, wasWhite)).toBe(2.75);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The theme tokens themselves.
+//
+// This is the half of the file that earns its keep. `styles.css` is the source
+// of truth, so it is read rather than duplicated: a palette tweak that drops a
+// pair below AA fails here instead of shipping.
+
+const THEME_CSS = readFileSync(join(import.meta.dirname, "..", "styles.css"), "utf8");
+
+/** Custom properties declared in one selector block of `styles.css`. */
+function tokensIn(selector: string): Record<string, string> {
+  const start = THEME_CSS.indexOf(`\n${selector} {`);
+  expect(start, `${selector} block missing from styles.css`).toBeGreaterThan(-1);
+  const body = THEME_CSS.slice(start, THEME_CSS.indexOf("\n}", start));
+  const declared: Record<string, string> = {};
+  for (const [, name, value] of body.matchAll(/^\s*--([a-z-]+):\s*([^;]+);/gm)) {
+    declared[name] = value.trim();
+  }
+  return declared;
+}
+
+const LIGHT = tokensIn(":root");
+// `.dark` only restates what changes, so it inherits the rest from `:root` —
+// exactly as the cascade does.
+const DARK = { ...LIGHT, ...tokensIn(".dark") };
+const THEMES = { light: LIGHT, dark: DARK } as const;
+
+const AA_NORMAL = 4.5;
+const AA_LARGE = 3;
+
+/**
+ * Every foreground/background pair the app actually paints together. The first
+ * group is the `-foreground` pairings (a filled surface with its own ink); the
+ * second is the tokens used as text ON a page surface, which is most of what
+ * `--destructive` and `--muted-foreground` do.
+ */
+const PAIRS: ReadonlyArray<readonly [background: string, foreground: string]> = [
+  ["background", "foreground"],
+  ["card", "card-foreground"],
+  ["popover", "popover-foreground"],
+  ["primary", "primary-foreground"],
+  ["secondary", "secondary-foreground"],
+  ["muted", "muted-foreground"],
+  ["accent", "accent-foreground"],
+  ["destructive", "destructive-foreground"],
+  ["sidebar", "sidebar-foreground"],
+  ["sidebar-primary", "sidebar-primary-foreground"],
+  ["sidebar-accent", "sidebar-accent-foreground"],
+  ["background", "muted-foreground"],
+  ["card", "muted-foreground"],
+  ["background", "destructive"],
+  ["card", "destructive"],
+];
+
+/**
+ * Pairs that are below AA today and are NOT this file's to fix.
+ *
+ * This is an acknowledgement, not a pardon: the recorded ratio is asserted
+ * exactly, so the pair cannot quietly get worse, and an entry that starts
+ * passing fails the suite so it gets removed. Nothing may be added here to get
+ * a red build green without the same reasoning written down.
+ */
+const KNOWN_BELOW_AA: Record<string, { ratio: number; why: string }> = {
+  "light:primary/primary-foreground": {
+    ratio: 3.99,
+    why: "UTS Sport Teal #008eaa carrying white. Passes AA large (3:1) only. Fixing it means moving the club's brand colour, which is a decision for the club, not a palette tweak.",
+  },
+  "light:sidebar-primary/sidebar-primary-foreground": {
+    ratio: 3.99,
+    why: "The same teal, same call.",
+  },
+};
+
+describe("theme token contrast", () => {
+  const cases = (["light", "dark"] as const).flatMap((theme) =>
+    PAIRS.map(([background, foreground]) => ({
+      theme,
+      background,
+      foreground,
+      key: `${theme}:${background}/${foreground}`,
+    })),
+  );
+
+  it.each(cases)("$key", ({ theme, background, foreground, key }) => {
+    const tokens = THEMES[theme];
+    const bg = parseOklch(tokens[background] ?? "");
+    const fg = parseOklch(tokens[foreground] ?? "");
+    expect(bg, `--${background} is not an opaque oklch value in ${theme}`).not.toBeNull();
+    expect(fg, `--${foreground} is not an opaque oklch value in ${theme}`).not.toBeNull();
+
+    const ratio = oklchContrast(bg!, fg!);
+    const known = KNOWN_BELOW_AA[key];
+    if (known) {
+      expect(ratio, `${key} changed; re-check whether it still belongs on the list`).toBe(
+        known.ratio,
+      );
+      expect(
+        ratio,
+        `${key} is allowed below AA but must still clear AA large`,
+      ).toBeGreaterThanOrEqual(AA_LARGE);
+      return;
+    }
+    expect(
+      ratio,
+      `${key} is ${ratio}:1 (${rgbToHex(oklchToRgb(bg!))} on ${rgbToHex(oklchToRgb(fg!))}), below WCAG AA for normal text`,
+    ).toBeGreaterThanOrEqual(AA_NORMAL);
+  });
+
+  it("has no stale entries on the below-AA list", () => {
+    for (const key of Object.keys(KNOWN_BELOW_AA)) {
+      expect(
+        cases.some((c) => c.key === key),
+        `${key} is not a pair this file checks`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("the destructive pair", () => {
+  // The regression this file was written for: `bg-destructive` +
+  // `text-destructive-foreground` on every delete/revoke button in the app.
+  it("carries its own label in both themes", () => {
+    expect(
+      oklchContrast(parseOklch(LIGHT.destructive)!, parseOklch(LIGHT["destructive-foreground"])!),
+    ).toBe(4.65);
+    expect(
+      oklchContrast(parseOklch(DARK.destructive)!, parseOklch(DARK["destructive-foreground"])!),
+    ).toBe(6.72);
+  });
+
+  // The other half of the token's job, and the reason the dark red itself was
+  // left alone: `text-destructive` is how every form error and failed-submit
+  // panel is coloured, on the page and inside a card.
+  it("stays readable as error text on both surfaces", () => {
+    for (const [theme, tokens] of Object.entries(THEMES)) {
+      const red = parseOklch(tokens.destructive)!;
+      for (const surface of ["background", "card"] as const) {
+        expect(
+          oklchContrast(parseOklch(tokens[surface])!, red),
+          `--destructive on --${surface} in ${theme}`,
+        ).toBeGreaterThanOrEqual(AA_NORMAL);
+      }
+    }
+  });
+
+  // Out-of-gamut oklch is clipped here and gamut-mapped by a browser, so the
+  // two only agree while the colours fit in sRGB. The dark pair is the one this
+  // change chose, so it is the one held to that.
+  it("is inside the sRGB gamut, so the computed ratio is the painted one", () => {
+    expect(isSrgbGamut(parseOklch(DARK.destructive)!)).toBe(true);
+    expect(isSrgbGamut(parseOklch(DARK["destructive-foreground"])!)).toBe(true);
+  });
+});

--- a/src/lib/color-contrast.test.ts
+++ b/src/lib/color-contrast.test.ts
@@ -37,9 +37,12 @@ describe("contrast maths", () => {
   });
 
   it("converts oklch to the sRGB a browser would paint", () => {
-    // The two brand colours are written as hex in `@theme inline`, so they are
-    // an independent check that the conversion lands where it should.
-    expect(rgbToHex(oklchToRgb({ l: 0.58, c: 0.11, h: 220 }))).toBe("#0089a7"); // teal
+    // Pinned values, so a change to the matrices has to be deliberate. Note
+    // `--primary` lands on #0089a7 and the brand teal in `@theme inline` is
+    // #008eaa: the token approximates the brand colour by hand, it is not
+    // derived from it, so this is the conversion being pinned, not the two
+    // being reconciled.
+    expect(rgbToHex(oklchToRgb({ l: 0.58, c: 0.11, h: 220 }))).toBe("#0089a7");
     expect(rgbToHex(oklchToRgb({ l: 1, c: 0, h: 0 }))).toBe("#ffffff");
   });
 

--- a/src/lib/color-contrast.ts
+++ b/src/lib/color-contrast.ts
@@ -1,0 +1,105 @@
+// WCAG contrast maths for the theme tokens in `src/styles.css`.
+//
+// This exists because a contrast ratio is computable and was not being
+// computed. The dark-mode destructive pair shipped at 2.75:1 (below even the
+// 3:1 large-text floor) because the red was lightened by eye to sit well on a
+// dark ground while its foreground stayed near-white. Nobody could have caught
+// that by looking: both colours are individually fine, it is the pair that
+// fails, and the failure is a number.
+//
+// The tokens are written in `oklch()`, which no test runner can resolve on its
+// own (jsdom does not do colour conversion), so the whole path is here:
+// oklch -> OKLab -> linear sRGB -> gamma-encoded sRGB -> relative luminance.
+// The OKLab matrices are Björn Ottosson's published constants; the luminance
+// and ratio formulae are WCAG 2.1 §1.4.3.
+//
+// One deliberate simplification: an out-of-sRGB-gamut oklch value is clipped
+// per channel, where a browser gamut-maps by reducing chroma. Keep the tokens
+// inside sRGB (`isSrgbGamut` says whether one is) and the two agree.
+
+/** An oklch colour: lightness 0-1, chroma, hue in degrees. */
+export type Oklch = { l: number; c: number; h: number };
+
+/** sRGB channels, each 0-1, gamma-encoded (i.e. what a `#rrggbb` holds). */
+export type Rgb = [number, number, number];
+
+const OKLCH_PATTERN = /^oklch\(\s*([\d.]+%?)\s+([\d.]+%?)\s+([\d.]+)(?:deg)?\s*\)$/i;
+
+/**
+ * Parse an `oklch(L C H)` string. Returns null for anything else, including the
+ * `oklch(1 0 0 / 10%)` alpha form: a translucent token has no fixed contrast
+ * (it depends what is behind it), so callers must not treat one as a colour.
+ */
+export function parseOklch(value: string): Oklch | null {
+  const match = OKLCH_PATTERN.exec(value.trim());
+  if (!match) return null;
+  const number = (raw: string) =>
+    raw.endsWith("%") ? Number.parseFloat(raw) / 100 : Number.parseFloat(raw);
+  return { l: number(match[1]), c: number(match[2]), h: Number.parseFloat(match[3]) };
+}
+
+/** oklch -> linear-light sRGB, unclamped, so out-of-gamut values stay visible. */
+function toLinearSrgb({ l, c, h }: Oklch): Rgb {
+  const radians = (h * Math.PI) / 180;
+  const a = c * Math.cos(radians);
+  const b = c * Math.sin(radians);
+
+  const lCone = (l + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+  const mCone = (l - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+  const sCone = (l - 0.0894841775 * a - 1.291485548 * b) ** 3;
+
+  return [
+    4.0767416621 * lCone - 3.3077115913 * mCone + 0.2309699292 * sCone,
+    -1.2684380046 * lCone + 2.6097574011 * mCone - 0.3413193965 * sCone,
+    -0.0041960863 * lCone - 0.7034186147 * mCone + 1.707614701 * sCone,
+  ];
+}
+
+const encode = (u: number) => (u <= 0.0031308 ? 12.92 * u : 1.055 * u ** (1 / 2.4) - 0.055);
+const decode = (u: number) => (u <= 0.04045 ? u / 12.92 : ((u + 0.055) / 1.055) ** 2.4);
+const clamp = (u: number) => Math.min(1, Math.max(0, u));
+
+/** True when the colour survives the trip to sRGB without a channel clipping. */
+export function isSrgbGamut(colour: Oklch, tolerance = 0.001): boolean {
+  return toLinearSrgb(colour).every((u) => {
+    const encoded = encode(u);
+    return encoded >= -tolerance && encoded <= 1 + tolerance;
+  });
+}
+
+/** oklch -> gamma-encoded sRGB, clipped into range. */
+export function oklchToRgb(colour: Oklch): Rgb {
+  return toLinearSrgb(colour).map((u) => clamp(encode(u))) as Rgb;
+}
+
+/** `#rrggbb`, for putting a real colour in a failure message. */
+export function rgbToHex(rgb: Rgb): string {
+  return `#${rgb
+    .map((v) =>
+      Math.round(v * 255)
+        .toString(16)
+        .padStart(2, "0"),
+    )
+    .join("")}`;
+}
+
+/** WCAG 2.1 relative luminance. */
+export function relativeLuminance(rgb: Rgb): number {
+  const [r, g, b] = rgb.map(decode);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** WCAG 2.1 contrast ratio, 1 (identical) to 21 (black on white). */
+export function contrastRatio(a: Rgb, b: Rgb): number {
+  const first = relativeLuminance(a);
+  const second = relativeLuminance(b);
+  const lighter = Math.max(first, second);
+  const darker = Math.min(first, second);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** Contrast ratio between two oklch tokens, rounded to two decimals. */
+export function oklchContrast(background: Oklch, foreground: Oklch): number {
+  const ratio = contrastRatio(oklchToRgb(background), oklchToRgb(foreground));
+  return Math.round(ratio * 100) / 100;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -95,7 +95,14 @@
   --accent: oklch(0.78 0.13 200);
   --accent-foreground: oklch(0.15 0.03 220);
   --destructive: oklch(0.7 0.19 22);
-  --destructive-foreground: oklch(0.98 0 0);
+  /* Dark ink, not the near-white the other dark tokens use. This red is
+     lightened (L 0.70 against light mode's 0.58) so that `text-destructive`
+     stays readable on the dark page, which is most of what the token does:
+     every form error, every failed-submit panel. White on top of that red is
+     2.75:1, below even the 3:1 large-text floor, so the pair that has to give
+     is the foreground. Near-black on vivid red still reads as danger, and
+     `color-contrast.test.ts` holds both roles above 4.5:1. */
+  --destructive-foreground: oklch(0.16 0.05 22);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.72 0.12 210);


### PR DESCRIPTION
Closes #60

## What the user will feel

A manager on a laptop in dark mode, between classes, about to press **Delete post** or **Revoke token**: the label on that button is currently pale and hard to read, and those are the buttons where misreading the label costs the most. After this it reads cleanly.

The button is still obviously red, so it still reads as "careful". What changes is the label on it: white before, near-black now. Nothing moves, nothing is added to any flow, and light mode is pixel-identical. Error text (`text-destructive`) is unchanged everywhere.

## The numbers

The fix is one token: dark mode's `--destructive-foreground`.

| | Fill | Ink | Ratio | AA normal (4.5:1) |
|---|---|---|---|---|
| Dark, before | `oklch(0.7 0.19 22)` `#ff6367` | `oklch(0.98 0 0)` `#f8f8f8` | **2.75:1** | fail (fails AA large too) |
| Dark, after | `oklch(0.7 0.19 22)` `#ff6367` | `oklch(0.16 0.05 22)` `#1e0304` | **6.72:1** | pass |
| Light (untouched) | `oklch(0.58 0.24 27)` `#e60016` | `oklch(0.99 0 0)` `#fcfcfc` | 4.65:1 | pass |

Hover (`bg-destructive/90`) lands at 5.65:1 over a card and 5.58:1 over the page; the badge's `/80` hover at 4.71:1. All clear AA.

## Why the foreground and not the red

The issue offered both options. Only one of them works here, because `--destructive` does two jobs:

- the **fill** behind `text-destructive-foreground` (buttons, badges, the WIP banner)
- **`text-destructive`** itself, which is how every form error, every failed-submit panel and every validation message on `/waiver` is coloured. That is the larger share of the usages.

Darkening the red fixes the first and breaks the second. Sweeping the fill's lightness at chroma 0.19:

| Fill L | white ink on fill | `text-destructive` on `--card` |
|---|---|---|
| 0.56 | 4.85 | 3.35 |
| 0.58 | 4.45 | 3.65 |
| 0.60 | 4.10 | 3.96 |
| 0.70 (today) | 2.75 | 5.91 |

There is no lightness where both clear 4.5:1 - they cross at about 4.2. So the foreground is the half that had to give, and the red keeps the 6.65:1 (page) / 5.91:1 (card) it already had as error text.

The ink is a near-black in the destructive hue rather than the `oklch(0.15 0.03 220)` the theme's other dark foregrounds use, for one practical reason: that value is marginally outside sRGB, so a browser gamut-maps it and the computed ratio stops being the painted one. `oklch(0.16 0.05 22)` is inside the gamut, renders indistinguishably, and the test asserts it stays there.

## Looked at it

Not just computed. Rendered the real compiled `styles.css` with the real class strings from `button.tsx` and `badge.tsx` in Chromium, both themes, at rest and on hover, alongside the error panel and a confirm card. Then rendered five ink candidates in dark mode as a strip, with the current broken state and the light theme as reference rows.

What that showed:

- The fill is unchanged, so it stays unmistakably red. No muddy pink.
- Next to the 2.75:1 row, the near-black label is plainly more legible; the white one looks washed into the fill.
- The maroon candidates (6.09:1 and 5.68:1) do start to muddy against the red, so they were dropped in favour of the near-black.
- Dark ink on a tinted fill is already this theme's convention: the primary "Save" button in dark mode is dark ink on teal. Destructive now matches it.

The PR's e2e gallery photographs the real screens carrying these buttons (`/manager/blog`, `/manager/api-tokens`, `/manager/calendar`) in the light theme; the dark-mode reading above is the browser render described here.

## The regression check

`src/lib/color-contrast.ts` is the maths, in its own pure module: `oklch` -> OKLab -> linear sRGB -> gamma-encoded sRGB -> WCAG luminance and ratio. It exists because no test runner resolves `oklch()` on its own, and because a contrast ratio is computable and simply was not being computed.

`src/lib/color-contrast.test.ts` reads `src/styles.css` (rather than duplicating the palette), builds the light and dark token sets the way the cascade does, and asserts 15 foreground/background pairs per theme. Reverting the token in a scratch copy fails it with the issue's own number:

```
AssertionError: dark:destructive/destructive-foreground is 2.75:1
(#ff6367 on #f8f8f8), below WCAG AA for normal text
```

## The other token with the same problem (reported, not fixed)

Checked every pair in both themes, as the issue asked. `--warning` and a success token do not exist in this palette, so nothing to check there. Everything else clears AA except one colour, in light mode only:

| Pair | Ratio |
|---|---|
| `--primary` / `--primary-foreground` | **3.99:1** |
| `--sidebar-primary` / `--sidebar-primary-foreground` | **3.99:1** |

Both are the same colour: UTS Sport Teal `#008eaa` carrying white. It passes AA large (3:1) but not AA normal, and it is the main call-to-action on every public page, so it is worth a decision. It is not fixed here because fixing it means moving the club's brand colour, which is a call for the club and not a palette tweak - and because other branches are open against this file.

Rather than leave it as prose in a PR body nobody rereads, both pairs are recorded in `KNOWN_BELOW_AA` in the new test with their reason and their **exact** current ratio, so they cannot quietly get worse, and an entry that starts passing fails the suite so it gets removed.

## Scope

`src/styles.css` is shared with other open branches, so the diff there is the one dark `--destructive-foreground` line plus its comment. Also updated the Styling section of `CLAUDE.md`, which owns this, with the two-jobs constraint and the gamut caveat.

## Verified

`bun run deps`, then `bun run lint`, `bun run typecheck`, `bun run test` (2065 passed, 109 files), `bun run build`. `bun.lock` is unmodified.