### PR TITLE
Docs: give each fact one owner, cut the paraphrases

### DIFF
--- a/.claude/skills/uts-manager-agent/SKILL.md
+++ b/.claude/skills/uts-manager-agent/SKILL.md
@@ -385,7 +385,7 @@ scripts/agent.sh file_waiver '{
 > - **It never approves, emails, or verifies.** Filing is not approving:
 >   approval is what promotes the record onto the person's profile, unlocks
 >   their login, **emails them that their account is active**, and **assigns
->   the free trial**.
+>   the free trial** (`docs/waivers.md`, rule 6).
 >   `file_waiver` does none of that — every row lands pending, exactly like a
 >   manager's own upload. Approving hundreds of migrated people would email all
 >   of them and hand out that many trials; that decision belongs to the manager

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,20 +330,16 @@ Core tables:
   `public`; the server resolves emails via the service-role-only
   `user_id_by_email` / `user_emails` RPCs. A person = a (possibly **locked**,
   i.e. banned/no-credentials) auth user + their profile, created at waiver
-  submission (interest registrations are leads only — just rows). A **manager
-  approving a waiver** copies the submission's details onto the profile, lifts
-  the ban, emails them that their account is active, and assigns the free trial. The funnel phase
-  (`lead | applicant | visitor | member | lapsed`) is always derived
-  (`deriveLifecycleStatus`). There is no self-serve sign-up.
+  submission (interest registrations are leads only — just rows). The funnel
+  phase (`lead | applicant | visitor | member | lapsed`) is always derived
+  (`deriveLifecycleStatus`). What a manager's approval does to a person, and why
+  there is no self-serve sign-up: `docs/waivers.md`, rules 6 and 9.
 - `waivers` — frozen submissions: the person fields **as submitted** (email
   included, as evidence), plus `user_id` (→ profiles), `pdf_path`,
   `template_version`, `signer_ip` + `signer_meta` (real IP + browser context,
-  forensic record), approval fields, timestamps. No `full_name` (composed on
-  read), no stored signatures/acknowledgements (they live in the PDF). Signing
-  is public (no login, email required), unlimited, and runs through the
-  service-role client. The displayed pending/active/superseded status is
-  derived (latest approved per person = active). Product flows:
-  `docs/waivers.md`.
+  forensic record), approval fields, timestamps. Signing is public (no login,
+  email required), unlimited, and runs through the service-role client. Product
+  flows: `docs/waivers.md`.
 - `waiver_templates` — versioned markdown templates; a partial unique index
   enforces exactly one `is_current = true`. Body uses `{{placeholder}}` tokens.
   Manager-only insert/update.
@@ -356,32 +352,20 @@ Core tables:
   `/kb/<slug>` that members read and annotate, grouped into ordered sections.
   **Signed-in only**, reached from the member area: `/kb` redirects a signed-out
   visitor to `/auth`, `canReadArticle` refuses them every article, and article
-  `visibility` is `members | managers` with no public level. That order (section
-  `position`, then article `position`) is the single source of the sidebar, the
-  index page and the previous/next links, so it is the onboarding path members
-  walk. Versioning copies `waiver_templates` (save writes a new version and
-  promotes it; one `is_current` per article). Annotations are anchored to a
-  **block** by a hash of that block's text, not its position, so editing one
-  passage detaches only its own comments. Annotation `visibility` is `private`
-  (readable by its author alone, **managers included**) or `shared` (a thread).
-  An article row carrying `link_path` is not an article at all but a sidebar
-  **link entry** pointing at a page elsewhere on the site (`/first-class`,
-  `/faq`), with no versions of its own. `kb_article_reads` is one row per person
-  per article recording which version they read, so the sidebar can tick off the
-  path; it is owner-scoped and **no manager screen reads it**. Managers edit all
-  of this at `/manager/kb` or through the manager agent API, which do the same
-  things to the same data. Product flows: `docs/knowledge-base.md`.
+  `visibility` is `members | managers` with no public level. Versioning copies
+  `waiver_templates` (save writes a new version and promotes it; one
+  `is_current` per article). Managers edit all of this at `/manager/kb` or
+  through the manager agent API, which do the same things to the same data.
+  Product flows: `docs/knowledge-base.md`.
 - `notifications` / `notification_preferences` / `notification_tokens` — the
   `/notifications` page, the sidebar badge and the emails behind them. One
   `notifications` row per person per event drives **both** the in-app list
   (`read_at`) and the email (`emailed_at`), so there is no separate outbox, and
   a unique index on `(user_id, kind, subject_id)` makes every writer safe to
   call twice. The manager "needs attention" items are **not** stored: they stay
-  derived from `membership_plans` and clear by being fixed, which is why they
-  have no read state. Preferences are **nullable booleans** on purpose (NULL =
-  "never chose", resolved against `NOTIFICATION_DEFAULTS`) and govern **email
-  only** — every row is written regardless. A **private** `kb_annotation`
-  notifies nobody, managers included. Product flows: `docs/notifications.md`.
+  derived and clear by being fixed, which is why they have no read state.
+  Preferences govern **email only** — every row is written regardless. Product
+  flows: `docs/notifications.md`.
 - `user_roles` — role assignments; managed by managers / service role.
 - `manager_api_tokens` — manager-issued bearer tokens for the manager agent API
   (`/api/manager/agent`); stores only a SHA-256 hash + display prefix,
@@ -443,11 +427,9 @@ owner/manager policies (`20260727120000_waiver_storage_policies.sql`).
     `decodeDataUrlPng`). This is the highest-value suite: it pins the honeypot,
     signature-required, and minor/guardian rules.
   - `src/lib/utils.test.ts` — the `cn()` class-merge helper.
-  - `scripts/copy-voice.test.ts` — the two mechanical copy rules from
-    `AGENTS.md` (no em dash in prose, and the two banned constructions),
-    checked against every file under `src/`. It parses rather than greps, so
-    comments and the placeholder-glyph exception are not flagged; the exempt
-    files and the reasoning are in `scripts/copy-voice.ts`.
+  - `scripts/copy-voice.test.ts` — the two mechanical copy rules, checked
+    against every file under `src/`. What it does and does not catch:
+    `AGENTS.md`, "Two of these rules are checked, not trusted".
   - `src/components/ui/button.test.tsx` — a Testing Library smoke test proving
     the jsdom/component setup works (render, variants, click, `asChild`).
 - **Where to add tests:** pure logic belongs in `src/lib/` modules (import and
@@ -491,56 +473,20 @@ owner/manager policies (`20260727120000_waiver_storage_policies.sql`).
   was walked (the form filled in, the confirmation, the manager approving it)
   rather than a set of pages photographed cold. `scripts/e2e-gallery.ts` lays
   the run out as one page, the workflow publishes it to **GitHub Pages** under
-  `pr-<n>/`, and one sticky PR comment embeds the flow strips inline. The full
-  spec is in **`docs/e2e-tests.md`**; the things that are not guessable:
+  `pr-<n>/`, and one sticky PR comment embeds the flow strips inline. Full spec:
+  **`docs/e2e-tests.md`**. The three things that bite from outside that file:
   - **Screenshots only exist where a spec uses the suite's own `test` object and
-    its `step`** (`e2e/support/test.ts`). `scripts/e2e-conventions.test.ts`
-    fails the unit suite if a spec imports `test` from `@playwright/test` or
-    calls the bare `test.step`, because the run would still be green and the
-    screen would just quietly stop appearing.
-  - The **signed-in** pages the tour walks are **derived from the route files**
-    (`scripts/site-pages.ts`): everything under `src/routes/_authenticated/`
-    and `src/routes/kb/`, walked as the manager for `/manager/*` and as the
-    member for the rest. **A new member or manager screen is covered the moment
-    its route file exists.** A dynamic route (`$userId`) needs an id in the
-    seed's manifest, and one that has none fails the run rather than leaving a
-    gap nobody notices.
-  - The **public** pages cannot be derived the same way: they are
-    `PUBLIC_PAGES` plus `PUBLIC_NOINDEX_PATHS` in `src/lib/public-pages.ts`
-    (`/waiver`, `/auth`, `/reset-password`, `/thank-you`, `/app`). The second
-    list is `noindex`, and `seo.test.ts` fails if a `noindex` page is added to
-    `PUBLIC_PAGES` — so **a new public noindex page has to be added there by
-    hand**. `/update-password`, `/email-settings/$token` and `/blog/$slug` are
-    deliberately not walked; each needs a token only its own email carries.
-  - Signing in uses an admin-generated **magic link**, so the session is stored
-    exactly as a real one is. It needs no redirect configuration: GoTrue accepts
-    any loopback redirect without consulting its allow list, so `E2E_PORT` can
-    move on its own. **Do not add an `[auth]` block to `supabase/config.toml`**
+    its `step`** (`e2e/support/test.ts`), which `scripts/e2e-conventions.test.ts`
+    enforces — otherwise the run stays green and the screen quietly stops
+    appearing.
+  - The **signed-in** pages the tour walks are **derived from the route files**,
+    so **a new member or manager screen is covered the moment its route file
+    exists**. The **public** ones cannot be derived that way: they are
+    `PUBLIC_PAGES` plus `PUBLIC_NOINDEX_PATHS` in `src/lib/public-pages.ts`, and
+    **a new public noindex page has to be added there by hand** (see SEO below).
+  - Signing in uses an admin-generated **magic link**, which needs no redirect
+    configuration. **Do not add an `[auth]` block to `supabase/config.toml`**
     for it — `supabase config push` would apply that to the live project.
-  - Walking the site **mutates the fixture**: opening `/notifications` marks the
-    member's unread ones read, opening a manager inbox stamps its "seen"
-    watermark. `restoreSeenState` (`e2e/support/club-state.ts`) puts those back
-    after each pass, and it is a **known list** — a new screen that marks
-    something read on open has to be added to it, or its unread state will only
-    ever appear in the desktop gallery.
-  - A page that returns an error status, or that renders the router's error/404
-    boundary (both arrive inside an ordinary 200, which is why those boundaries
-    carry `data-page-state`), fails the tour. **It does not catch a route that
-    handles its own loader error** and renders a card in place of its content —
-    `/blog` and `/waiver` do exactly that, so a green run means every route
-    rendered, not that every route has its data.
-  - The gallery shows **seeded fixture content**: `/blog`, `/pricing` and the
-    calendar are the local club, not what is on `jitsu.au` today. That is the
-    trade for a run that is identical on every branch and every fork.
-  - Publishing is **GitHub Pages serving the `gh-pages` branch directly**, so
-    the run's push IS the publish — no deployment step, no environment. The
-    branch is rewritten as a single orphan commit each time (screenshots are
-    large; history would keep every version forever) with `--force-with-lease`
-    so a racing run retries rather than overwriting, and
-    `pr-gallery-cleanup.yml` removes a pull request's directory when it closes.
-    A fork's pull request gets a read-only token whatever the workflow asks for,
-    so it neither publishes nor comments: its gallery is the artifact on the
-    run's own page.
 - **Migration drift and live client grants: no CI job.** Both compare the
   **live** database against the repo (every migration applied; the grants `anon`
   / `authenticated` hold matching `supabase/lint/client-grants-expected.txt`),
@@ -699,10 +645,12 @@ served by two routes whose filenames escape the dot so the router does not read
 it as a path separator (`robots[.]txt.ts` → `/robots.txt`,
 `sitemap[.]xml.ts` → `/sitemap.xml`).
 
-**Adding a public page? Add it to `PUBLIC_PAGES` in `src/lib/seo.ts`.**
+**Adding a public page? Add it to `src/lib/public-pages.ts`** — `PUBLIC_PAGES`
+if it is indexable, `PUBLIC_NOINDEX_PATHS` if it sets `robots: noindex`.
 `src/lib/seo.test.ts` reads the route files and fails if an indexable page is
-missing from the sitemap (or a `noindex` one is listed), so this is enforced,
-not just documented.
+missing from the sitemap (or a `noindex` one is listed), so the first list is
+enforced. The second cannot be derived from anything, so a new noindex page has
+to be added there by hand or nothing ever looks at it.
 
 Two non-obvious rules:
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -242,10 +242,10 @@ A person = an **auth user** (their email lives on `auth.users`, the ONLY email
 store) + a **`profiles` row keyed by that user id** (the person fields; no
 email column anywhere in `public`). An applicant is a **locked** auth user
 (banned, no credentials) created at first waiver submission; a manager's
-**approval** copies the submission's details onto the profile, lifts the ban,
-and emails them that their account is active (see `docs/waivers.md`). A waiver is a **frozen
-submission**: exactly what was typed, the signed PDF, template version, real
-signer IP and signing context, and its approval state.
+**approval** promotes the submission onto the profile and opens the account
+(`docs/waivers.md`, rule 6, is where what approval does is written down). A
+waiver is a **frozen submission**: exactly what was typed, the signed PDF,
+template version, real signer IP and signing context, and its approval state.
 
 - **Signing is public**: no login; only an email is required. Submissions are
   unlimited; the person's **active** waiver is the latest approved one
@@ -1456,7 +1456,8 @@ behaviour it already had.
 The person's one identity record, managed by Supabase Auth (not in our
 migrations) — **the only place any email lives**. An applicant's auth user is
 created **locked** (banned, no credentials) by waiver submission; approval
-lifts the ban. There is no self-serve sign-up. Two triggers fire:
+lifts the ban. There is no self-serve sign-up (`docs/waivers.md`, rules 6 and
+9). Two triggers fire:
 
 - `handle_new_user_role` — grants `manager` to a confirmed whitelisted address.
 - `ensure_profile` — inserts the `profiles` row for every new auth user, with a

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -125,10 +125,10 @@ actually gets done.
   above.
 - **`expectPageRendered` catches a page that rendered a failure boundary.** Both
   the router's error boundary and its 404 arrive inside an ordinary 200
-  response, so a status check alone would call a site-wide "This page didn't
-  load" a clean run. It does **not** catch a route that handles its own loader
-  error and renders a card in place of its content — assert on the content the
-  flow needs.
+  response (which is why both carry `data-page-state`), so a status check alone
+  would call a site-wide "This page didn't load" a clean run. It does **not**
+  catch a route that handles its own loader error and renders a card in place of
+  its content — assert on the content the flow needs.
 - **Import `test` from `../support/test`, not from `@playwright/test`, and use
   `step` instead of `test.step`.** That is what photographs the flow;
   `scripts/e2e-conventions.test.ts` fails the unit suite if a spec reaches past
@@ -173,6 +173,15 @@ pages nothing can derive) and the signed-in ones from the route files themselves
 (`scripts/site-pages.ts`), so a new manager screen is covered the moment its file
 exists. It runs as two projects, `tour` and `tour-mobile`, because a screen that
 breaks on a phone is a broken screen.
+
+A dynamic route (`$userId`) needs an id in the seed's manifest, and one that has
+none fails the run rather than leaving a gap nobody notices.
+`/update-password`, `/email-settings/$token` and `/blog/$slug` are deliberately
+not walked: each needs a token only its own email carries.
+
+What the gallery shows is **seeded fixture content** — `/blog`, `/pricing` and
+the calendar are the local club, not what is on `jitsu.au` today. That is the
+trade for a run that is identical on every branch and every fork.
 
 Walking the site is not read-only — `/notifications` marks the member's unread
 ones read, a manager inbox stamps its "seen" watermark — so `restoreSeenState`

--- a/docs/knowledge-base.md
+++ b/docs/knowledge-base.md
@@ -238,10 +238,10 @@ From the member area: the sidebar's first item, and a card at the top of
 
 The waiver-confirmation email **mentions** the knowledge base and deliberately
 does not link to it. Whoever is reading that email cannot sign in yet: their
-account is created locked, and a manager approving the waiver is what opens it.
-A link there would land a brand-new person on a sign-in screen they have no
-account for. The **account-activated** email sent at approval does link it, by
-which point they can get in.
+account is created locked, and a manager approving the waiver is what opens it
+(`docs/waivers.md`, rule 6). A link there would land a brand-new person on a
+sign-in screen they have no account for. The **account-activated** email sent at
+approval does link it, by which point they can get in.
 
 ## Private notes and shared threads
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -89,9 +89,9 @@ manager presses the button, which is why it sits at the top of the queue (see
 
 The waiver item's body says what approving leads to before the manager gets
 anywhere near the button: it activates the person's account, emails them to say
-so, and assigns the free trial. That is outward-facing and cannot be taken back
-quietly, and "anything irreversible gets a confirm that says what will happen"
-is the club's own UX rule.
+so, and assigns the free trial (`docs/waivers.md`, rule 6). That is
+outward-facing and cannot be taken back quietly, and "anything irreversible gets
+a confirm that says what will happen" is the club's own UX rule.
 
 Counted from `waivers.approval_status = 'pending'`, which is the stored fact.
 The waivers screen's third state, `superseded`, is derived from a person's other

--- a/docs/waivers.md
+++ b/docs/waivers.md
@@ -104,6 +104,15 @@ system. (The contact form stores a message, not a person.)
    form filled in at the gym may not be approved until hours or days later.
    Approving late never costs anyone a session either way — a trial is a
    balance of credits and no date gates it at check-in (`docs/check-in.md`).
+
+   **Rule 6 is where what approval does is written down.** Six other places
+   lean on it and cite it rather than own it: `CLAUDE.md` (the `profiles`
+   bullet), `docs/database.md` (the schema it writes), `docs/notifications.md`
+   (the manager's confirm copy), `docs/knowledge-base.md` (why the waiver email
+   carries no knowledge base link), `docs/manager-agent-api.md` and
+   `.claude/skills/uts-manager-agent/SKILL.md` (`file_waiver` never approves).
+   Change this rule and re-read those six.
+
 7. **Full name is never stored**; it is composed from first/middle/last. The
    optional **preferred name** is stored separately (on the submission and, once
    approved, on the profile). One rule governs it everywhere: **address a person


### PR DESCRIPTION
**This is a docs-only change.** No code, no schema, no behaviour, no user-visible
effect. Seven markdown files, of which -89 lines are in `CLAUDE.md`.

Closes #14

> **Rebuilt on current `main`.** `main` retired the migration-drift workflow
> while this branch was open, so an earlier version of it would have reinstated
> documentation for a workflow that no longer exists. Rather than merge and
> resolve, the branch is **restarted from `main`** whenever `main` moves, and
> every edit re-derived against `main`'s current text. It carries one commit.
> `migration-drift` reference counts are byte-identical to `main`'s
> (`CLAUDE.md` 2, `docs/database-changes.md` 3, `docs/database.md` 0), and
> nothing `main` has gained since is touched: `docs/fonts.md`,
> `docs/erasing-personal-data.md`, the Security headers section, the enquiry
> erasure line, the client-grants replay sub-bullet, and the copy-voice test
> (see the one exception below).

## What moved where

| Passage | Was | Now |
| --- | --- | --- |
| `profiles` bullet's "manager approving a waiver copies… lifts the ban… emails… assigns the trial" | `CLAUDE.md` | one line pointing at `docs/waivers.md` rules 6 and 9 |
| `waivers` bullet's "no `full_name`, no stored signatures, status derived" | `CLAUDE.md` | already owned by `docs/database.md` (`waivers` "Not stored here", and line 256) and `docs/waivers.md` rules 3/5/7 |
| KB bullet's reading order, annotation anchoring, `link_path`, `kb_article_reads` (~13 lines) | `CLAUDE.md` | already owned by `docs/knowledge-base.md` and `docs/database.md` (`kb_article_reads`: "no manager screen and no agent action reads this table") |
| Notifications bullet's nullable preferences and private-annotation rule | `CLAUDE.md` | already owned by `docs/notifications.md` rules 5 and 9 |
| PR-screenshot sub-list, 8 bullets → 3 (~35 lines) | `CLAUDE.md` | already owned by `docs/e2e-tests.md`, which the bullet itself called "the full spec" |
| Dynamic routes needing a seed manifest id; the three pages the tour skips; the gallery showing fixture content; the `data-page-state` contract | `CLAUDE.md` only | **moved into** `docs/e2e-tests.md` (not dropped) |
| "Approval promotes, unlocks, emails, assigns the trial" | paraphrased in `docs/database.md`, `docs/notifications.md`, `docs/knowledge-base.md`, the manager-agent skill | each now cites `docs/waivers.md` rule 6 |
| The copy-voice scan's "parses not greps / comments not flagged / exempt files" explanation | both `CLAUDE.md` and `AGENTS.md` (landed in #77) | `AGENTS.md` owns it; the `CLAUDE.md` test-inventory entry points at that section |

`docs/waivers.md` rule 6 gains a short note naming the **six** places that lean
on it (`CLAUDE.md`, `docs/database.md`, `docs/notifications.md`,
`docs/knowledge-base.md`, `docs/manager-agent-api.md` and the manager-agent
skill), so the next change to approval knows what to re-read. That is the
lightweight version of the "Keep these in sync" pattern the issue points at; a
CI guard pinning these facts would be a code change and is left for a follow-up.

**Two stale copies fixed on the way**, both the failure mode the issue describes
— the same fact written twice, one copy drifted:

- The SEO section said `PUBLIC_PAGES` lives in `src/lib/seo.ts`. It is in
  `src/lib/public-pages.ts`.
- That section also told you to add any new public page to `PUBLIC_PAGES`, but
  `seo.test.ts` fails if a `noindex` page appears there — those go in
  `PUBLIC_NOINDEX_PATHS`, and nothing derives that list. The section now owns
  the split, which is what the condensed e2e bullet points at.

## Deliberately left duplicated

Each of these is a warning repeated at the point of use, not redundancy:

- **The `[auth]` / `supabase/config.toml` warning stays in `CLAUDE.md`** even
  though the rest of that sub-list went to `docs/e2e-tests.md`. Getting it wrong
  pushes config to the live project, and the person about to do it is editing
  `supabase/`, not reading the e2e doc.
- **"There is no self-serve sign-up" stays in `docs/passwords.md`,
  `docs/pwa.md` and `docs/memberships.md`.** All three use it as the premise for
  their own local rule ("so a password is a convenience", "so a signed-out
  launch goes to the home page", "so the pricing CTA reads who is looking").
  Removing it would leave the conclusion unexplained.
- **The manager-agent skill's `file_waiver` warning keeps the full enumeration**
  of what approval does. It guards a bulk migration that would otherwise email
  hundreds of people; a reader must not have to leave the page to learn that. It
  now carries the rule-6 citation as well, so a future change has a sync point.
- **`docs/database.md`'s `setWaiverApproval` "Written by" bullet** keeps its
  detail. That is schema-level (which columns the patch sets, and the
  `media_consent` omit rule) and genuinely belongs to the schema doc.
- **`docs/knowledge-base.md`'s waiver-email paragraph** keeps its reasoning and
  only gains the citation. The issue flagged this coupling as invisible; the link
  makes it visible without moving product reasoning out of the doc it belongs to.
- **`AGENTS.md` is not cut at all.** It is 91 lines and its "Plans you show the
  user are product-level" entry is already a three-line pointer at `CLAUDE.md`,
  so issue item 2 was done before this branch. The one edit in its direction is
  the `CLAUDE.md` side of the copy-voice duplication above.

## How silent loss was ruled out

The risk with a long-lived docs branch is that a deletion applies cleanly to a
passage `main` has since rewritten. Restarting from `main` removes that class of
error: every edit is applied as an exact single-match replacement against
`main`'s current text, so drift fails loudly rather than merging quietly. On top
of that, each deleted phrase was grepped in `docs/` to confirm it still has an
owner. Two had no verbatim match and were checked by hand — "no `full_name`
(composed on read)" is `docs/database.md` lines 256-257 and 319-320, and
"no manager screen reads it" is `docs/database.md`'s `kb_article_reads` RLS
paragraph.

## Verification

`bun run deps`, then `bun run lint`, `bun run typecheck`, `bun run test`
(134 files, 2332 tests, all passing) and `bun run build` all pass on this head.
`bun run format` reports no change beyond the edited passages, and no passage I
did not change was reflowed. No test or skill references a heading that moved;
the `CLAUDE.md` headings cited from code and workflows ("Lock file strategy",
"Environment variables", "Supabase clients", "Where to add tests", "Plans you
show the user are product-level") are all intact.