### PR TITLE
Make the honeypot required so omitting the field is not a bypass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,13 +204,21 @@ Read `src/routes/README.md` before touching routes. Key points:
   top-level `import` `client.server.ts` (service-role key) from them. Instead
   lazy-load inside the handler:
   `const { supabaseAdmin } = await import("@/integrations/supabase/client.server")`.
-- Forms include a honeypot field `hp` (a hidden input that must stay empty).
-  The schema for it is `honeypot` in `src/lib/validation.ts` and it is
-  **required**, not optional: a browser always sends `""` because the form
-  carries the input, so a request that omits the field never came from the
-  form and fails validation outright. Handlers early-return a fake success on
-  a _filled_ `hp`. Every form that writes must send `hp` or it cannot submit at
-  all.
+- Forms include a honeypot field `hp`, a decoy input a person never sees and
+  that must therefore arrive empty. Its schema is `honeypot` in
+  `src/lib/validation.ts` (`z.string().max(0)`), spelled once and used by all
+  seven write paths, and it is **required**: a browser always sends `""`
+  because the form carries the input, so a request that omits the field never
+  came from a form, and both that and a _filled_ `hp` fail validation. The
+  `if (data.hp)` early-returns in the handlers are therefore unreachable today
+  and stay only as a net if the schema is ever loosened. Two rules keep the
+  trap working, and both were broken in places before 2026-08-21:
+  - **Every form that writes must send `hp`**, or it cannot submit at all.
+  - **The input has to be one a form-filler would actually fill**: a
+    `type="text"` field hidden with `className="hidden"` and kept out of the
+    tab order with `tabIndex={-1}`, whose value is read into the payload. A
+    `type="hidden"` input, or a payload that hardcodes `hp: ""`, is a honeypot
+    that can never catch anything. `register-interest.tsx` is the pattern.
 
 ## Supabase clients — pick the right one
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,8 +204,13 @@ Read `src/routes/README.md` before touching routes. Key points:
   top-level `import` `client.server.ts` (service-role key) from them. Instead
   lazy-load inside the handler:
   `const { supabaseAdmin } = await import("@/integrations/supabase/client.server")`.
-- Forms include a honeypot field `hp` (a hidden input that must stay empty);
-  handlers early-return on a filled `hp`.
+- Forms include a honeypot field `hp` (a hidden input that must stay empty).
+  The schema for it is `honeypot` in `src/lib/validation.ts` and it is
+  **required**, not optional: a browser always sends `""` because the form
+  carries the input, so a request that omits the field never came from the
+  form and fails validation outright. Handlers early-return a fake success on
+  a _filled_ `hp`. Every form that writes must send `hp` or it cannot submit at
+  all.
 
 ## Supabase clients — pick the right one
 

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -108,9 +108,9 @@ same `createServerFn` pattern used everywhere else in the app — not something
 only reachable through the web UI. `postComment` checks, in order: the post is
 published, the commenter isn't in `blog_blocked_commenters`, and — for a
 reply — the parent comment belongs to the same post and is itself top-level.
-A honeypot field (`hp`) silently no-ops a submission a bot filled in, and a
-request that omits the field is refused outright, the same convention as every
-other form that writes (see `honeypot` in `src/lib/validation.ts`).
+A honeypot field (`hp`) refuses a submission that filled the decoy in, and
+equally one that omits the field, the same convention as every other form that
+writes (see `honeypot` in `src/lib/validation.ts`).
 
 ### A manager writes and publishes a post
 

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -108,8 +108,9 @@ same `createServerFn` pattern used everywhere else in the app — not something
 only reachable through the web UI. `postComment` checks, in order: the post is
 published, the commenter isn't in `blog_blocked_commenters`, and — for a
 reply — the parent comment belongs to the same post and is itself top-level.
-A honeypot field (`hp`) silently no-ops a submission a bot filled in, the same
-convention as every other public form.
+A honeypot field (`hp`) silently no-ops a submission a bot filled in, and a
+request that omits the field is refused outright, the same convention as every
+other form that writes (see `honeypot` in `src/lib/validation.ts`).
 
 ### A manager writes and publishes a post
 

--- a/src/lib/honeypot.test.ts
+++ b/src/lib/honeypot.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The honeypot only works if the form actually carries it, so this walks the
+ * route files rather than trusting the convention to be followed.
+ *
+ * Four of the seven honeypots were inert before 2026-08-21: `/waiver` and
+ * `/code-of-conduct` rendered `<input type="hidden" name="hp" value="" />` and
+ * then hardcoded `hp: ""` in the payload, so the field they rendered was never
+ * read and a form-filler would not have filled a hidden input anyway. Nothing
+ * failed, no test went red, and the trap simply never fired. That is exactly
+ * the kind of defect a source-reading test is for (`seo.test.ts` and
+ * `scripts/e2e-conventions.test.ts` are the same idea).
+ */
+const ROUTES_DIR = join(process.cwd(), "src/routes");
+
+/**
+ * Screens that send `hp` with no decoy input on purpose. Both are behind the
+ * auth gate, where an attacker has to hold a real session before the honeypot
+ * would ever be reached, so the field is carried only to satisfy the schema.
+ * Adding a decoy to either is fine; adding a new entry here needs a reason.
+ */
+const NO_DECOY_INPUT = new Set(["_authenticated/membership.tsx", "kb/$slug.tsx"]);
+
+function routeFiles(dir: string, prefix = ""): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) out.push(...routeFiles(join(dir, entry.name), rel));
+    else if (entry.name.endsWith(".tsx")) out.push(rel);
+  }
+  return out;
+}
+
+/** The whole `<input ... />` element that carries `name="hp"`, or null. */
+function decoyInput(source: string): string | null {
+  const at = source.indexOf('name="hp"');
+  if (at === -1) return null;
+  const open = source.lastIndexOf("<input", at);
+  const close = source.indexOf("/>", at);
+  if (open === -1 || close === -1) return null;
+  return source.slice(open, close + 2);
+}
+
+describe("honeypot wiring across the route files", () => {
+  const files = routeFiles(ROUTES_DIR).map((rel) => ({
+    rel,
+    source: readFileSync(join(ROUTES_DIR, rel), "utf8"),
+  }));
+
+  const senders = files.filter((f) => /\bhp[,:]/.test(f.source) || f.source.includes('name="hp"'));
+
+  it("finds the forms that carry a honeypot", () => {
+    // A sanity check on the walk itself: if this drops to zero the rest of the
+    // suite would pass by testing nothing.
+    expect(senders.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it.each(senders.map((f) => f.rel))("%s does not hardcode an empty honeypot", (rel) => {
+    const { source } = senders.find((f) => f.rel === rel)!;
+    if (NO_DECOY_INPUT.has(rel)) return;
+    // `hp: ""` in a payload means the field the form renders is never read, so
+    // filling the decoy in changes nothing about what the server receives.
+    expect(source).not.toContain('hp: ""');
+  });
+
+  it.each(senders.map((f) => f.rel))("%s renders a fillable decoy", (rel) => {
+    const { source } = senders.find((f) => f.rel === rel)!;
+    if (NO_DECOY_INPUT.has(rel)) return;
+    const input = decoyInput(source);
+    expect(input, `${rel} sends hp but renders no name="hp" input`).not.toBeNull();
+    // A `type="hidden"` field is not a honeypot: something filling a form in
+    // wholesale fills the visible-in-the-DOM text fields, not hidden ones.
+    expect(input).toContain('type="text"');
+    // Out of the tab order and out of a password manager's way, so nobody
+    // reaches it by keyboard or has it filled for them.
+    expect(input).toContain("tabIndex={-1}");
+    expect(input).toContain('autoComplete="off"');
+    // Hidden from sight one way or the other: `hidden` takes it out of the
+    // layout, `sr-only` keeps it in the DOM but off screen. Either is fine, a
+    // decoy nobody can see is the point.
+    expect(input).toMatch(/className="(hidden|sr-only)"/);
+  });
+});

--- a/src/lib/membership.test.ts
+++ b/src/lib/membership.test.ts
@@ -423,12 +423,16 @@ describe("buildPaymentReference", () => {
 
 describe("startMembershipSchema", () => {
   it("accepts a non-student selection without a student number", () => {
-    const r = startMembershipSchema.safeParse({ plan_code: "semester", is_student: false });
+    const r = startMembershipSchema.safeParse({
+      plan_code: "semester",
+      is_student: false,
+      hp: "",
+    });
     expect(r.success).toBe(true);
   });
 
   it("requires a UTS student number when taking the student rate", () => {
-    const r = startMembershipSchema.safeParse({ plan_code: "semester", is_student: true });
+    const r = startMembershipSchema.safeParse({ plan_code: "semester", is_student: true, hp: "" });
     expect(r.success).toBe(false);
   });
 
@@ -437,6 +441,7 @@ describe("startMembershipSchema", () => {
       plan_code: "semester",
       is_student: true,
       uts_student_number: "12345678",
+      hp: "",
     });
     expect(r.success).toBe(true);
   });
@@ -447,6 +452,13 @@ describe("startMembershipSchema", () => {
       is_student: false,
       hp: "bot",
     });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a selection that omits the honeypot", () => {
+    // `hp` is required, so a request that never had a form behind it fails
+    // here rather than starting a membership.
+    const r = startMembershipSchema.safeParse({ plan_code: "semester", is_student: false });
     expect(r.success).toBe(false);
   });
 });

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1747,9 +1747,9 @@ describe("codeOfConductAcceptSchema", () => {
     // handler at all. An agreement from somebody who did not agree is not
     // evidence of anything.
     expect(codeOfConductAcceptSchema.safeParse({ ...valid, agree: false }).success).toBe(false);
-    expect(codeOfConductAcceptSchema.safeParse({ signature_name: "Ada", version: 1 }).success).toBe(
-      false,
-    );
+    expect(
+      codeOfConductAcceptSchema.safeParse({ signature_name: "Ada", version: 1, hp: "" }).success,
+    ).toBe(false);
   });
 
   it("requires a signature", () => {
@@ -1760,7 +1760,7 @@ describe("codeOfConductAcceptSchema", () => {
 
   it("requires the version that was read", () => {
     expect(
-      codeOfConductAcceptSchema.safeParse({ agree: true, signature_name: "Ada" }).success,
+      codeOfConductAcceptSchema.safeParse({ agree: true, signature_name: "Ada", hp: "" }).success,
     ).toBe(false);
     expect(codeOfConductAcceptSchema.safeParse({ ...valid, version: 0 }).success).toBe(false);
   });

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -208,18 +208,24 @@ describe("blogCommentSchema", () => {
   const postId = "11111111-1111-1111-1111-111111111111";
 
   it("accepts a plain top-level comment", () => {
-    const parsed = blogCommentSchema.parse({ post_id: postId, body: "Great post!" });
+    const parsed = blogCommentSchema.parse({ post_id: postId, body: "Great post!", hp: "" });
     expect(parsed.parent_comment_id).toBeUndefined();
   });
 
   it("rejects an empty body", () => {
-    expect(() => blogCommentSchema.parse({ post_id: postId, body: "" })).toThrow();
+    expect(() => blogCommentSchema.parse({ post_id: postId, body: "", hp: "" })).toThrow();
   });
 
   it("rejects a filled honeypot", () => {
     expect(() =>
       blogCommentSchema.parse({ post_id: postId, body: "Great post!", hp: "spam" }),
     ).toThrow();
+  });
+
+  it("rejects a comment that leaves the honeypot out altogether", () => {
+    // The bypass this schema used to have. A hand-rolled POST omits a field it
+    // cannot see, and while `hp` was optional that sailed straight through.
+    expect(() => blogCommentSchema.parse({ post_id: postId, body: "Great post!" })).toThrow();
   });
 });
 
@@ -777,9 +783,12 @@ describe("decodeDataUrlPng", () => {
 });
 
 describe("interestSchema", () => {
+  // Mirrors what the form actually posts, honeypot included: `hp` is required,
+  // so a fixture without it is not a submission any browser could make.
   const valid = {
     name: "Sam Trainee",
     email: "sam@example.com",
+    hp: "",
   };
 
   it("accepts a minimal valid submission", () => {
@@ -818,6 +827,14 @@ describe("interestSchema", () => {
     expect(interestSchema.safeParse({ ...valid, hp: "bot" }).success).toBe(false);
   });
 
+  it("rejects a submission that omits the honeypot", () => {
+    // A browser always sends `hp`, empty, because the form has the input in it.
+    // A script posting JSON by hand does not, which is the request the trap is
+    // for. This case passed before `hp` became required.
+    const { hp: _hp, ...withoutHp } = valid;
+    expect(interestSchema.safeParse(withoutHp).success).toBe(false);
+  });
+
   it("allows an empty honeypot", () => {
     expect(interestSchema.safeParse({ ...valid, hp: "" }).success).toBe(true);
   });
@@ -849,10 +866,22 @@ describe("contactSchema", () => {
     name: "Sam",
     email: "sam@example.com",
     message: "Hello, when do beginner classes run?",
+    hp: "",
   };
 
   it("accepts a valid message", () => {
     expect(contactSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects a filled honeypot", () => {
+    expect(contactSchema.safeParse({ ...valid, hp: "bot" }).success).toBe(false);
+  });
+
+  it("rejects a message that omits the honeypot", () => {
+    // Contact fans out to every manager's inbox, so the cheap-script path is
+    // the one worth closing. Omitting `hp` used to be a clean pass.
+    const { hp: _hp, ...withoutHp } = valid;
+    expect(contactSchema.safeParse(withoutHp).success).toBe(false);
   });
 
   it("requires a non-empty message", () => {
@@ -1254,6 +1283,7 @@ describe("waiverSubmitSchema", () => {
     emergency_contact_phone: "0400000001",
     health_answers: noConcerns,
     signature_name: "Ada Lovelace",
+    hp: "",
   };
 
   it("accepts a valid adult waiver with a typed signature", () => {
@@ -1574,6 +1604,14 @@ describe("waiverSubmitSchema", () => {
   it("rejects a filled honeypot", () => {
     expect(waiverSubmitSchema.safeParse({ ...validAdult, hp: "bot" }).success).toBe(false);
   });
+
+  it("rejects a waiver that omits the honeypot", () => {
+    // The most expensive endpoint on the site: each accepted submission makes
+    // an auth user, renders a PDF and sends mail. Omitting `hp` used to reach
+    // all of that.
+    const { hp: _hp, ...withoutHp } = validAdult;
+    expect(waiverSubmitSchema.safeParse(withoutHp).success).toBe(false);
+  });
 });
 
 describe("saveTemplateSchema", () => {
@@ -1692,7 +1730,7 @@ describe("managerEmailChangeSchema", () => {
 });
 
 describe("codeOfConductAcceptSchema", () => {
-  const valid = { agree: true as const, signature_name: "Ada Lovelace", version: 1 };
+  const valid = { agree: true as const, signature_name: "Ada Lovelace", version: 1, hp: "" };
 
   it("accepts an agreement signed with a typed name", () => {
     const r = codeOfConductAcceptSchema.safeParse({ ...valid, token: " tok " });
@@ -1736,11 +1774,21 @@ describe("codeOfConductAcceptSchema", () => {
       email: "someone@example.com",
       user_id: "11111111-1111-1111-1111-111111111111",
     });
-    expect(r.success && Object.keys(r.data).sort()).toEqual(["agree", "signature_name", "version"]);
+    expect(r.success && Object.keys(r.data).sort()).toEqual([
+      "agree",
+      "hp",
+      "signature_name",
+      "version",
+    ]);
   });
 
   it("drops a submission with the honeypot filled", () => {
     expect(codeOfConductAcceptSchema.safeParse({ ...valid, hp: "bot" }).success).toBe(false);
+  });
+
+  it("drops a submission that omits the honeypot", () => {
+    const { hp: _hp, ...withoutHp } = valid;
+    expect(codeOfConductAcceptSchema.safeParse(withoutHp).success).toBe(false);
   });
 });
 
@@ -2481,7 +2529,7 @@ describe("knowledge base schemas", () => {
   });
 
   it("createAnnotationSchema requires a visibility and a body", () => {
-    const base = { slug, article_version: 1, body: "Worth clarifying." };
+    const base = { slug, article_version: 1, body: "Worth clarifying.", hp: "" };
     expect(createAnnotationSchema.safeParse({ ...base, visibility: "private" }).success).toBe(true);
     expect(createAnnotationSchema.safeParse({ ...base, visibility: "shared" }).success).toBe(true);
     expect(createAnnotationSchema.safeParse(base).success).toBe(false);
@@ -2498,6 +2546,7 @@ describe("knowledge base schemas", () => {
       article_version: 2,
       visibility: "shared",
       body: "Reads well overall.",
+      hp: "",
     });
     expect(parsed.block_id).toBeUndefined();
   });
@@ -2513,8 +2562,19 @@ describe("knowledge base schemas", () => {
     expect(createAnnotationSchema.safeParse(input).success).toBe(false);
   });
 
+  it("createAnnotationSchema rejects an annotation that omits the honeypot", () => {
+    expect(
+      createAnnotationSchema.safeParse({
+        slug,
+        article_version: 1,
+        visibility: "shared" as const,
+        body: "Reads well.",
+      }).success,
+    ).toBe(false);
+  });
+
   it("createAnnotationSchema requires a positive version, so an anchor is never versionless", () => {
-    const base = { slug, visibility: "shared" as const, body: "b" };
+    const base = { slug, visibility: "shared" as const, body: "b", hp: "" };
     expect(createAnnotationSchema.safeParse({ ...base, article_version: 0 }).success).toBe(false);
     expect(createAnnotationSchema.safeParse(base).success).toBe(false);
   });

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -382,6 +382,25 @@ export function decodeDataUrlPng(dataUrl: string): Uint8Array | null {
  */
 export const clientSubmissionId = z.string().uuid().optional().or(z.literal(""));
 
+/**
+ * The hidden field every write-from-a-form path carries, spelled once here so
+ * all seven agree.
+ *
+ * **Required, not optional.** A browser always sends it, empty, because the
+ * form has the input in it. A script hand-rolling a POST against the endpoint
+ * has no reason to invent a field it cannot see, so it omits `hp` entirely —
+ * and while this was `.optional()`, omitting it was a clean pass through the
+ * trap. That is the exact shape of request the honeypot exists to catch, and
+ * it was the only one getting through. Requiring the field means the lazy
+ * script fails validation and only a bot that fills the form in faithfully
+ * reaches a handler, which is what the `if (data.hp)` early-returns are for.
+ *
+ * Nothing about the browser's side changes: `""` still passes, and every call
+ * site already sends it. Keep it that way — a new form that forgets `hp` is a
+ * form that cannot be submitted at all.
+ */
+export const honeypot = z.string().max(0);
+
 // ---- Interest registration ----
 
 export const interestSchema = z.object({
@@ -392,7 +411,7 @@ export const interestSchema = z.object({
   email: z.string().trim().email().max(255),
   phone: z.string().trim().max(30).optional().or(z.literal("")),
   message: z.string().trim().max(1000).optional().or(z.literal("")),
-  hp: z.string().max(0).optional(), // honeypot — must stay empty
+  hp: honeypot,
 });
 
 // ---- Contact message ----
@@ -411,7 +430,7 @@ export const contactSchema = z.object({
   email: z.string().trim().email().max(255),
   subject: z.string().trim().max(150).regex(singleLine).optional().or(z.literal("")),
   message: z.string().trim().min(1).max(2000),
-  hp: z.string().max(0).optional(), // honeypot
+  hp: honeypot,
 });
 
 /**
@@ -541,7 +560,7 @@ export const waiverSubmitSchema = z
     // person record is created already verified. Never required, and never
     // trusted for anything beyond that: it is re-checked server-side.
     vt: z.string().trim().max(120).optional().or(z.literal("")),
-    hp: z.string().max(0).optional(),
+    hp: honeypot,
   })
   .refine(
     (d) =>
@@ -778,7 +797,7 @@ export const codeOfConductAcceptSchema = z.object({
   // rule the waiver applies to its template version.
   version: z.number().int().positive(),
   client_meta: waiverClientMetaSchema.optional(),
-  hp: z.string().max(0).optional(), // honeypot
+  hp: honeypot,
 });
 export type CodeOfConductAcceptInput = z.infer<typeof codeOfConductAcceptSchema>;
 
@@ -1772,7 +1791,7 @@ export const startMembershipSchema = z
     // same payment reference). The server makes its own call from the
     // member's current cover — a member with none cannot turn this off.
     include_insurance: z.boolean().optional().default(false),
-    hp: z.string().max(0).optional(), // honeypot — must stay empty
+    hp: honeypot,
   })
   .refine((d) => !d.is_student || Boolean(d.uts_student_number && d.uts_student_number.trim()), {
     message: "A UTS student number is required to take the student rate.",
@@ -2917,7 +2936,7 @@ export const createAnnotationSchema = z.object({
   /** Set to reply to an existing shared annotation. */
   parent_id: z.string().uuid().optional(),
   body: z.string().trim().min(1).max(5000),
-  hp: z.string().max(0).optional().or(z.literal("")),
+  hp: honeypot,
 });
 export type CreateAnnotationInput = z.infer<typeof createAnnotationSchema>;
 
@@ -3043,7 +3062,7 @@ export const blogCommentSchema = z.object({
   post_id: z.string().uuid(),
   parent_comment_id: z.string().uuid().optional(),
   body: z.string().trim().min(1).max(2000),
-  hp: z.string().max(0).optional(), // honeypot — must stay empty
+  hp: honeypot,
 });
 export type BlogCommentInput = z.infer<typeof blogCommentSchema>;
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -391,13 +391,19 @@ export const clientSubmissionId = z.string().uuid().optional().or(z.literal(""))
  * has no reason to invent a field it cannot see, so it omits `hp` entirely —
  * and while this was `.optional()`, omitting it was a clean pass through the
  * trap. That is the exact shape of request the honeypot exists to catch, and
- * it was the only one getting through. Requiring the field means the lazy
- * script fails validation and only a bot that fills the form in faithfully
- * reaches a handler, which is what the `if (data.hp)` early-returns are for.
+ * it was the only one getting through.
+ *
+ * So both a filled `hp` and an absent one are refused here, at the validator.
+ * The `if (data.hp)` early-returns in the seven handlers are therefore
+ * unreachable: `.max(0)` has already thrown by the time a handler runs. They
+ * are left in place as the net if this ever loosens, not because they fire.
  *
  * Nothing about the browser's side changes: `""` still passes, and every call
  * site already sends it. Keep it that way — a new form that forgets `hp` is a
- * form that cannot be submitted at all.
+ * form that cannot be submitted at all. `honeypot.test.ts` reads the route
+ * files and holds the other half of the bargain: that the decoy each form
+ * renders is one something filling in a form would actually fill, and that its
+ * value reaches the payload instead of a hardcoded `""`.
  */
 export const honeypot = z.string().max(0);
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -398,6 +398,23 @@ export const clientSubmissionId = z.string().uuid().optional().or(z.literal(""))
  * Nothing about the browser's side changes: `""` still passes, and every call
  * site already sends it. Keep it that way — a new form that forgets `hp` is a
  * form that cannot be submitted at all.
+ *
+ * **Why all seven, including the ones behind a login.** Three of these
+ * (`startMembershipSchema`, `createAnnotationSchema`, `blogCommentSchema`) are
+ * only reachable with a session, where an anonymous bot cannot get to them at
+ * all, so the trap catches nothing there. They carry it anyway, because the
+ * alternative is a rule with an exception list: every future schema would need
+ * someone to decide which side of the line it falls on, and the way to get that
+ * wrong is to call a public form authenticated. A uniform rule fails safe; a
+ * remembered one does not.
+ *
+ * The cost that would argue the other way is a non-browser caller failing on a
+ * field it cannot see. That cannot happen through the manager agent API, which
+ * has its own schemas for the same operations and no honeypot on any of them
+ * (`createMembershipSchema`, `paperWaiverUploadSchema`, and the rest in
+ * `manager-agent.ts`). Anything machine-to-machine belongs on that seam, not on
+ * a form schema. If a genuine non-browser caller for one of these seven ever
+ * appears, that is the signal to give it its own schema, not to loosen this one.
  */
 export const honeypot = z.string().max(0);
 

--- a/src/routes/code-of-conduct.tsx
+++ b/src/routes/code-of-conduct.tsx
@@ -48,6 +48,10 @@ function CodeOfConduct() {
   const [agreed, setAgreed] = useState(false);
   const [signatureName, setSignatureName] = useState("");
   const [saving, setSaving] = useState(false);
+  // The honeypot's live value. A person never touches it (it is display:none
+  // and out of the tab order), so anything in it came from something filling
+  // the form in wholesale.
+  const [hp, setHp] = useState("");
   const [justSigned, setJustSigned] = useState<string | null>(null);
 
   // Wait for auth to settle before asking: the session's bearer token is what
@@ -94,7 +98,7 @@ function CodeOfConduct() {
             platform: navigator.platform ?? "",
             languages: [...(navigator.languages ?? [])].slice(0, 10),
           },
-          hp: "",
+          hp,
         },
       });
       setJustSigned(res.accepted_at ?? new Date().toISOString());
@@ -147,7 +151,15 @@ function CodeOfConduct() {
             />
           ) : (
             <form onSubmit={onSubmit} className="space-y-5 rounded-2xl border bg-card p-6 md:p-8">
-              <input type="hidden" name="hp" value="" />
+              <input
+                type="text"
+                name="hp"
+                tabIndex={-1}
+                autoComplete="off"
+                className="hidden"
+                value={hp}
+                onChange={(e) => setHp(e.target.value)}
+              />
               <div>
                 <h2 className="text-xl font-bold">Agree to the code</h2>
                 <p className="mt-1 text-sm text-muted-foreground">

--- a/src/routes/waiver.tsx
+++ b/src/routes/waiver.tsx
@@ -197,6 +197,9 @@ function Waiver() {
    * drops off the list instead of waiting for another press to be re-checked.
    */
   const [attemptedSubmit, setAttemptedSubmit] = useState(false);
+  // The honeypot's live value. Deliberately not part of the saved draft: a
+  // person never types in it, so there is nothing to bring back.
+  const [hp, setHp] = useState("");
 
   const fullName = useMemo(
     () =>
@@ -689,7 +692,7 @@ function Waiver() {
             // by this submission. Re-checked server-side against the email
             // actually submitted, so editing the email field forfeits it.
             vt: verificationToken ?? "",
-            hp: "",
+            hp,
           },
         });
         // Only the server gets to say this is signed. The old code showed a
@@ -850,7 +853,15 @@ function Waiver() {
             noValidate
             className="space-y-6 rounded-2xl border bg-card p-6 md:p-8"
           >
-            <input type="hidden" name="hp" value="" />
+            <input
+              type="text"
+              name="hp"
+              tabIndex={-1}
+              autoComplete="off"
+              className="hidden"
+              value={hp}
+              onChange={(e) => setHp(e.target.value)}
+            />
 
             {restored && (
               <p className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">


### PR DESCRIPTION
Refs #52. This ships **half** the issue: the honeypot. Rate limiting is not in
this PR, and the reasoning (with a recommendation, and the one question only you
can answer) is at the bottom.

## What the user will feel

Nothing, and that is the intent. A prospective member registering interest, a
person signing a waiver in the gym on their phone, a member starting a
membership or leaving a comment: every one of those forms submits exactly as it
does today, at exactly the same speed, with the same screens. The two forms that
gained a decoy field render it invisibly, out of the tab order and out of a
password manager's way, so nobody sees or reaches it.

The only requests that behave differently are ones that never had a person
behind them. No screen, no copy, no email and no stored data changes.

## Two ways the honeypot could be walked past

**1. Omit the field.** Every honeypot was declared
`z.string().max(0).optional()`, and every handler gates on `if (data.hp)`. A
browser posts `hp: ""`, which is falsy, so real people pass. But a script that
**omits** `hp` also passed: `.optional()` accepts `undefined`, and
`if (undefined)` is false. Omitting a field you cannot see is the default for
anyone hand-rolling a request against a JSON endpoint, so the trap was catching
only the bots that bothered to fill the form in faithfully, and waving through
the lazy ones.

**2. Four of the seven traps could not fire at all.** This one turned up in
review of the first commit, and it is the worse of the two. `/waiver` and
`/code-of-conduct` rendered a `type="hidden"` decoy input and then hardcoded
`hp: ""` in the payload: the field they rendered was never read, and a hidden
input is not something a form-filler fills anyway. So a bot that filled in every
visible field on `/waiver` reached `submitWaiverWithPdf` untouched. That is the
unauthenticated endpoint the issue singles out, the one that creates an
`auth.users` row, renders a PDF and sends mail.

Once this repo is public the shape of all of this is readable by anyone.

## The change

`hp` is spelled once now, as an exported `honeypot` schema in
`src/lib/validation.ts` (`z.string().max(0)`, **required**), used at all seven
sites: interest, contact, waiver submit, code-of-conduct accept, start
membership, KB annotation, blog comment. Three slightly different spellings had
drifted apart across those seven; they agree now.

`/waiver` and `/code-of-conduct` now follow the `register-interest.tsx` pattern:
a `type="text"` input hidden with `className="hidden"`, `tabIndex={-1}`,
`autoComplete="off"`, whose value actually reaches the payload.

`/kb/$slug` and `/membership` still send a literal `hp: ""` and render no decoy.
Both sit behind the auth gate, where an attacker needs a real session before the
honeypot would ever be reached, so the field is there only to satisfy the
schema. Left alone deliberately, and recorded as such rather than left looking
like an oversight.

**Nothing changes for a real submission.** I checked every call site before
touching the schema: all seven already send `hp`, so `""` still passes exactly
as before, and there is no client that omits it. The e2e specs fill forms by
label, and the decoy has none, so they do not touch it.

What this buys, honestly: it closes the cheap bypasses. A bot that renders the
page, fills the visible fields and leaves the invisible one alone still gets
through. That is what rate limiting is for.

### Tests

- One case per schema asserting an omitted `hp` is **rejected**, all seven of
  which passed (wrongly) before this change. `contactSchema` had no honeypot
  coverage at all and now has both cases, filled and absent.
- `src/lib/honeypot.test.ts` reads the route files and pins the form side of the
  convention, the same idea as `seo.test.ts` and
  `scripts/e2e-conventions.test.ts`: no route may hardcode `hp: ""`, and every
  decoy must be a fillable, hidden, untabbable text input. Verified it fails on
  the old wiring. Nothing in the existing suite caught the inert honeypots,
  which is exactly why it went unnoticed.
- Existing fixtures gained `hp: ""` so they mirror what the forms actually post.
  Two `codeOfConductAcceptSchema` negative assertions built their input inline
  and had started failing on the honeypot rather than on the missing
  `agree` / `version` they exist to pin; both fixed.

`bun run lint`, `bun run typecheck`, `bun run test` (2201 passing) and
`bun run build` are all green locally, after merging `main`.

### Docs

The docs claimed a filled `hp` gets a silent fake success. It does not, and did
not before this branch either: `.max(0)` rejects it at the validator, so the
`if (data.hp)` early-returns in all seven handlers are unreachable. `CLAUDE.md`,
`docs/blog.md` and the schema's own comment now say that, and the guards stay as
the net if the schema is ever loosened. `CLAUDE.md` also records the form-side
rule, since that is the half that was quietly broken.

## Rate limiting: options, and what I recommend

I did not pick one of these unilaterally, because the choice has cost and
ownership consequences that are yours, not mine. Nothing here is implemented.

The stakes, restated from the issue: the expensive damage is not spam volume, it
is **sender reputation**. Account-activation and magic-link email leave the same
domain as the interest/contact notifications, and a send failure is currently
caught into `console.error` and shows on no screen.

**1. Cloudflare rate limiting rules (WAF, dashboard).** Zero code, zero deploy,
minutes to set up, and it stops the flood at the edge before a Worker ever runs,
which is the only option that does. Keyed on IP, matched on the server-function
path prefix. The catch is entirely non-technical: it lives in the Cloudflare
dashboard for the `jitsu.au` zone, so **it depends on whether that zone is in
your Cloudflare account or Lovable's**. It is also invisible to this repo, so
nobody reviewing the code can tell whether it is on, and it does not survive a
change of host. The free plan includes one rule; more needs a paid plan.

**2. Cloudflare Workers primitives in code** (the native rate-limiting binding,
or KV / Durable Objects). Correct for the platform and reviewable in the repo,
but it needs bindings in a wrangler config, and there is no `wrangler.toml`
here: Nitro generates `.output/server/wrangler.json` at build time and Lovable
owns the deploy. Taking ownership of that config to add a binding is a real
change to how this project deploys, and the binding does not exist in dev or in
the e2e run (which serves the built app locally), so every path needs a no-op
fallback. Not small, and it pulls the repo into a fight with Lovable's
deployment.

**3. A Postgres-backed counter.** A small table plus a `SECURITY DEFINER`
function, called from the unauthenticated handlers with a hashed IP. The only
option that is reviewable in the repo, works identically in dev, in e2e and in
production, and survives a change of host. Costs: it is a schema change, so
`docs/database-changes.md`'s apply gate applies; it adds a write to every public
request; it needs a cleanup job (pg_cron is already in use here for the
notification digest); and it stores a hashed IP, though `waivers.signer_ip`
already stores real IPs as signing evidence, so the precedent exists.
Realistically a table + function + grants + a `rate-limit.server.ts` + wiring
into five handlers + tests. A day, not an hour. And it still runs *after* the
request has reached the Worker and opened a database connection, so it protects
the mail and the storage bucket, not the compute.

**4. In-process counters.** I recommend against this one. On Cloudflare there is
no single process: isolates are per-location and short-lived, so a flood spread
across locations or across time is unbounded. It would give the appearance of a
fix without being one, which is worse than nothing here.

**Recommendation: 1 now, 3 next, as separate work.** Turn on the Cloudflare rule
today if the zone is yours, because it is the fastest protection available and
costs nothing; then land option 3 so the protection is in the repo, visible to
review, and independent of the host. **The question I need answered: who owns
the `jitsu.au` Cloudflare zone, you or Lovable?**

Issue #52 also asks to cap manager email fan-out (item 3). That one is a product
decision (per-event mail vs a digest) and touches the notifications flow, so it
belongs with the rate-limiting work rather than in this PR.

Suggest tracking items 2 and 3 as their own issue and leaving #52 open until
they land, which is why this is `Refs #52` and not `Closes`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDhmgjwGva3uNvUf7yWVFx