### PR TITLE
Send a Referrer-Policy, and no referrer at all from the token URLs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ src/
   start.ts                createStart(): global function + request middleware
   styles.css              Tailwind v4 entry + design tokens
 public/                   Served at the site root
+  _headers                Static-asset response headers (see Security headers)
   manifest.webmanifest    PWA manifest (start_url /app, icons, shortcuts)
   sw.js                   Service worker (pages network-only, assets cached)
   offline.html            Shown when a page is opened with no connection
@@ -656,6 +657,36 @@ Two non-obvious rules:
 
 Non-production hosts (Lovable previews, branch deploys) are served a blanket
 `Disallow: /`, so a preview never competes with `jitsu.au` in search results.
+
+## Security headers
+
+`src/lib/security-headers.ts` holds every response header the app sets for
+safety reasons, and `start.ts` applies it as the outermost request middleware,
+so it covers SSR pages, API route handlers, server-function RPCs and the error
+page alike. `public/_headers` states the same rules again for the static assets
+the platform serves without going through the server; Nitro merges that file
+into `.output/public/_headers` at build time, alongside its own `/assets/*`
+rule.
+
+Today that is `Referrer-Policy`, and the reason is three routes that carry a
+token in the URL **path**: `/api/calendar/<token>`, `/api/verify-email/<token>`
+and `/email-settings/<token>`. A calendar app and a mail client cannot send an
+Authorization header or a POST body, so on those three the token has to be in
+the URL, which makes it the browser's job not to pass that URL on. The site
+sends `strict-origin-when-cross-origin` everywhere and `no-referrer` on those
+three prefixes (the only value that also keeps the path out of a **same-origin**
+`Referer`), plus `Cache-Control: no-store` on them unless the route set its own.
+
+- **Adding a route that takes a token in its path?** Add its prefix to
+  `TOKEN_PATH_PREFIXES` and to `public/_headers`. `security-headers.test.ts`
+  fails if the two disagree.
+- **A route's own headers win.** The middleware only fills in `cache-control`
+  when the route did not set one, so the calendar feed keeps the
+  `private, max-age=300` its subscribers poll against.
+- CSP, HSTS and `X-Frame-Options` are **not** set here. Lovable owns the
+  Cloudflare deploy and the platform already sends `strict-transport-security`
+  and `x-content-type-options`; check what is already on the response with
+  `curl -I https://jitsu.au/` before adding anything that could overlap.
 
 ## Environment variables
 

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -156,7 +156,11 @@ top-up, so a repeat offers "Stop repeating" instead. Cancel keeps the record.
 4. **No public calendar feed.** Only per-person links, so a subscriber can never
    silently miss a members-only entry. A link is a secret, but a durable one:
    like any calendar app's private ICS address it is stored and shown to its
-   owner whenever they ask, not shown once and then unrecoverable.
+   owner whenever they ask, not shown once and then unrecoverable. Because the
+   secret is in the URL, the feed is served with `Referrer-Policy: no-referrer`
+   (see "Security headers" in `CLAUDE.md`). It keeps its own
+   `Cache-Control: private, max-age=300`, which is what a polling calendar client
+   wants.
 5. **"Member" means paid.** Members-only visibility keys off an active, non-trial
    membership with a price above zero (mirroring `deriveLifecycleStatus`), via the
    `has_active_paid_membership` helper used in RLS.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -280,6 +280,12 @@ existed, one that has been rotated, and a malformed one all render the same
 page. Anything else would make the endpoint a way to probe which links the club
 has issued.
 
+Because the token is in the URL, the page is served with
+`Referrer-Policy: no-referrer` and `Cache-Control: no-store`, so the link never
+travels in a `Referer` header (the footer has outbound links) and never lands in
+a shared or on-disk cache. That is set for every token path at once; see
+"Security headers" in `CLAUDE.md`.
+
 The signed-out page deliberately omits the manager switch. With no session it
 cannot tell whether the person holds the role, and offering a manager-only
 choice to a member would be a lie about what they can turn on.

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,22 @@
+# Response headers for anything the platform serves without going through the
+# app's request middleware, which is where src/lib/security-headers.ts sets the
+# same values on every response the server itself builds.
+#
+# Cloudflare reads this file when it serves this project's assets. If it turns
+# out to be ignored here, nothing is lost: the middleware is the real fix and
+# covers every route. Confirm with `curl -I https://jitsu.au/` once deployed.
+#
+# Keep these in step with TOKEN_PATH_PREFIXES in src/lib/security-headers.ts.
+# security-headers.test.ts fails if the two disagree.
+
+/*
+  Referrer-Policy: strict-origin-when-cross-origin
+
+/api/calendar/*
+  Referrer-Policy: no-referrer
+
+/api/verify-email/*
+  Referrer-Policy: no-referrer
+
+/email-settings/*
+  Referrer-Policy: no-referrer

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,19 @@
 # covers every route. Confirm with `curl -I https://jitsu.au/` once deployed.
 #
 # Keep these in step with TOKEN_PATH_PREFIXES in src/lib/security-headers.ts.
-# security-headers.test.ts fails if the two disagree.
+# security-headers.test.ts fails if the two disagree, on the referrer policy and
+# on the no-store below.
+#
+# The token paths carry Cache-Control: no-store for the same reason the
+# middleware sets it, and it matters MORE here: this file is what covers the
+# case where a response never reached the middleware, so the middleware's own
+# no-store never ran. A URL with a credential in its path landing in a shared
+# or on-disk cache is the thing being prevented.
+#
+# /api/calendar/* is the deliberate exception. A calendar client polls that feed
+# every few minutes, so the route sets `private, max-age=300` itself and the
+# middleware leaves a route's own choice alone. `private` already keeps it out
+# of shared caches, and no-store here would turn every poll into a miss.
 
 /*
   Referrer-Policy: strict-origin-when-cross-origin
@@ -17,6 +29,8 @@
 
 /api/verify-email/*
   Referrer-Policy: no-referrer
+  Cache-Control: no-store
 
 /email-settings/*
   Referrer-Policy: no-referrer
+  Cache-Control: no-store

--- a/src/lib/security-headers.test.ts
+++ b/src/lib/security-headers.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  DEFAULT_REFERRER_POLICY,
+  TOKEN_PATH_PREFIXES,
+  TOKEN_PATH_REFERRER_POLICY,
+  applySecurityHeaders,
+  carriesTokenInPath,
+  referrerPolicyFor,
+} from "./security-headers";
+
+describe("carriesTokenInPath", () => {
+  it("recognises the three routes that take a token in the path", () => {
+    expect(carriesTokenInPath("/api/calendar/abc123.ics")).toBe(true);
+    expect(carriesTokenInPath("/api/verify-email/abc123")).toBe(true);
+    expect(carriesTokenInPath("/email-settings/abc123")).toBe(true);
+  });
+
+  it("leaves every other path alone", () => {
+    for (const path of [
+      "/",
+      "/about",
+      "/waiver",
+      "/notifications",
+      "/api/manager/agent",
+      "/api/notifications/digest",
+      // Near misses: a shared prefix is not a token path.
+      "/email-settings",
+      "/api/calendars/nope",
+    ]) {
+      expect(carriesTokenInPath(path)).toBe(false);
+    }
+  });
+});
+
+describe("referrerPolicyFor", () => {
+  it("sends nothing at all from a URL that contains a credential", () => {
+    // Same-origin requests are the point: strict-origin-when-cross-origin
+    // still hands the full path to same-site requests, token included.
+    expect(referrerPolicyFor("/email-settings/abc123")).toBe("no-referrer");
+    expect(TOKEN_PATH_REFERRER_POLICY).toBe("no-referrer");
+  });
+
+  it("sends the origin, and only the origin, off-site from every other page", () => {
+    expect(referrerPolicyFor("/about")).toBe("strict-origin-when-cross-origin");
+    expect(DEFAULT_REFERRER_POLICY).toBe("strict-origin-when-cross-origin");
+  });
+});
+
+describe("applySecurityHeaders", () => {
+  it("puts the policy on an ordinary page response", () => {
+    const response = applySecurityHeaders(new Response("<html></html>"), "/about");
+    expect(response.headers.get("referrer-policy")).toBe("strict-origin-when-cross-origin");
+    expect(response.headers.get("cache-control")).toBeNull();
+  });
+
+  it("keeps a token URL out of caches as well as out of referrers", async () => {
+    const response = applySecurityHeaders(new Response("<html></html>"), "/email-settings/abc123");
+    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.text()).toBe("<html></html>");
+  });
+
+  it("leaves a route's own cache-control alone", () => {
+    // The calendar feed asks for a five minute private cache on purpose: a
+    // calendar client polls it. Overriding that would make every poll a miss.
+    const feed = new Response("BEGIN:VCALENDAR", {
+      headers: { "cache-control": "private, max-age=300" },
+    });
+    const response = applySecurityHeaders(feed, "/api/calendar/abc123");
+    expect(response.headers.get("cache-control")).toBe("private, max-age=300");
+    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+  });
+
+  it("returns the very same response object when it can", () => {
+    // The SSR response wraps a live stream bound to the request for cleanup.
+    // Re-wrapping it would cut that binding, so mutation in place is required.
+    const original = new Response("hello");
+    expect(applySecurityHeaders(original, "/about")).toBe(original);
+  });
+
+  it("rebuilds a redirect, whose headers cannot be written to", () => {
+    // Response.redirect() hands back an immutable headers guard.
+    const redirect = Response.redirect("https://jitsu.au/account", 302);
+    const response = applySecurityHeaders(redirect, "/api/verify-email/abc123");
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://jitsu.au/account");
+    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+});
+
+describe("public/_headers", () => {
+  // The static file the platform reads and the middleware the app runs have to
+  // agree, or a response gets one policy in one deploy path and another in the
+  // other. Parse the file and hold it to the module.
+  const source = readFileSync(join(process.cwd(), "public/_headers"), "utf8");
+
+  function parseRules(text: string): Array<{ pattern: string; headers: Record<string, string> }> {
+    const rules: Array<{ pattern: string; headers: Record<string, string> }> = [];
+    for (const line of text.split("\n")) {
+      if (!line.trim() || line.trim().startsWith("#")) continue;
+      if (!/^\s/.test(line)) {
+        rules.push({ pattern: line.trim(), headers: {} });
+        continue;
+      }
+      const [name, ...rest] = line.trim().split(":");
+      expect(rules.length, `header line before any path: ${line}`).toBeGreaterThan(0);
+      rules[rules.length - 1].headers[name.trim().toLowerCase()] = rest.join(":").trim();
+    }
+    return rules;
+  }
+
+  const rules = parseRules(source);
+
+  it("sets the site-wide policy first", () => {
+    expect(rules[0]?.pattern).toBe("/*");
+    expect(rules[0]?.headers["referrer-policy"]).toBe(DEFAULT_REFERRER_POLICY);
+  });
+
+  it("lists every token path, and nothing else", () => {
+    expect(rules.slice(1).map((r) => r.pattern)).toEqual(
+      TOKEN_PATH_PREFIXES.map((prefix) => `${prefix}*`),
+    );
+  });
+
+  it("gives each rule the policy the middleware would", () => {
+    for (const rule of rules) {
+      const pathname = `${rule.pattern.replace(/\*$/, "")}sample-token`;
+      expect(rule.headers["referrer-policy"], rule.pattern).toBe(referrerPolicyFor(pathname));
+    }
+  });
+});

--- a/src/lib/security-headers.test.ts
+++ b/src/lib/security-headers.test.ts
@@ -91,6 +91,42 @@ describe("applySecurityHeaders", () => {
   });
 });
 
+describe("applySecurityHeaders, when setting a header throws", () => {
+  /** A response whose `headers.set` throws whatever it is given. */
+  function throwingResponse(error: unknown): Response {
+    const headers = {
+      set() {
+        throw error;
+      },
+      has: () => false,
+      get: () => null,
+      forEach: () => {},
+      [Symbol.iterator]: function* () {},
+    };
+    return {
+      headers,
+      body: null,
+      status: 200,
+      statusText: "OK",
+    } as unknown as Response;
+  }
+
+  it("rebuilds the response for the immutable-headers guard", () => {
+    // What `Response.redirect()` does. The rebuild is correct here.
+    const out = applySecurityHeaders(throwingResponse(new TypeError("immutable")), "/about");
+    expect(out.headers.get("referrer-policy")).toBe(DEFAULT_REFERRER_POLICY);
+  });
+
+  it("rethrows anything that is not a TypeError instead of rebuilding", () => {
+    // The rebuild path re-wraps the body, and the SSR response's body is a live
+    // stream bound to the request for cleanup: re-wrapping it cuts that binding
+    // and the symptom is a truncated or leaked response, not a visible error.
+    // A bare `catch` sent every failure down that path. This one has to escape.
+    const boom = new RangeError("something else went wrong");
+    expect(() => applySecurityHeaders(throwingResponse(boom), "/about")).toThrow(boom);
+  });
+});
+
 describe("public/_headers", () => {
   // The static file the platform reads and the middleware the app runs have to
   // agree, or a response gets one policy in one deploy path and another in the
@@ -130,5 +166,32 @@ describe("public/_headers", () => {
       const pathname = `${rule.pattern.replace(/\*$/, "")}sample-token`;
       expect(rule.headers["referrer-policy"], rule.pattern).toBe(referrerPolicyFor(pathname));
     }
+  });
+
+  // The referrer policy was the only thing held to the module here, while
+  // `setHeaders` sets a second header the file did not carry at all. This file
+  // exists for responses the middleware never saw, so its no-store is the only
+  // no-store those responses get: leaving it out meant a URL with a credential
+  // in its path could be cached by whatever default the platform applies, which
+  // is the exact risk the module's no-store is there to close.
+  it("keeps a token URL out of a cache, except the feed that sets its own", () => {
+    for (const rule of rules.slice(1)) {
+      const prefix = rule.pattern.replace(/\*$/, "");
+      if (prefix === "/api/calendar/") {
+        // A calendar client polls this every few minutes and the route answers
+        // with `private, max-age=300`. `private` already keeps it out of shared
+        // caches, and no-store would make every poll a miss.
+        expect(rule.headers["cache-control"], rule.pattern).toBeUndefined();
+        continue;
+      }
+      expect(rule.headers["cache-control"], rule.pattern).toBe("no-store");
+    }
+  });
+
+  it("leaves the site-wide rule to whatever each response chose", () => {
+    // Only the token paths get a caching rule from this file. A blanket
+    // no-store over `/*` would strip the asset caching Nitro generates into
+    // this same file at build time.
+    expect(rules[0]?.headers["cache-control"]).toBeUndefined();
   });
 });

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -1,0 +1,93 @@
+/**
+ * The response headers the site sets on everything it serves.
+ *
+ * This module exists because of one header: `Referer`. Three routes carry a
+ * credential in the URL **path**, because the software that opens them has
+ * nowhere else to put it:
+ *
+ *   /api/calendar/<token>      an ICS feed a calendar app polls for months
+ *   /api/verify-email/<token>  an email link, single use and time bound
+ *   /email-settings/<token>    the settings panel at the foot of every email
+ *
+ * A calendar client and a mail client cannot send an Authorization header or a
+ * POST body, so for those three the token stays in the path. What is avoidable
+ * is the browser then handing that URL to somebody else. With no
+ * `Referrer-Policy` the browser falls back to its own default, which still
+ * sends the full URL - token and all - on every same-origin request the page
+ * makes, and older or differently configured browsers send it cross-origin
+ * too. `/email-settings/<token>` is a full page with a footer full of outbound
+ * links, so this is not theoretical.
+ *
+ * So the site sends `strict-origin-when-cross-origin` everywhere, and the three
+ * token paths send `no-referrer`, which is the only value that keeps the path
+ * out of a same-origin `Referer` as well.
+ *
+ * The token paths also get `Cache-Control: no-store` unless the route set its
+ * own, which keeps a URL containing a credential out of shared and on-disk
+ * caches. The calendar feed sets `private, max-age=300` on purpose (a calendar
+ * client polls it), so it keeps that.
+ *
+ * `public/_headers` states the same referrer rules for anything the platform
+ * serves without going through this middleware. `security-headers.test.ts`
+ * fails if the two drift apart.
+ */
+
+/** What everything gets: the origin cross-site, the full URL same-site. */
+export const DEFAULT_REFERRER_POLICY = "strict-origin-when-cross-origin";
+
+/** What a URL with a credential in it gets: nothing, to anyone. */
+export const TOKEN_PATH_REFERRER_POLICY = "no-referrer";
+
+/**
+ * Route prefixes whose path segment after them is a credential.
+ *
+ * Adding a route that takes a token in its path? Add its prefix here and to
+ * `public/_headers`.
+ */
+export const TOKEN_PATH_PREFIXES = [
+  "/api/calendar/",
+  "/api/verify-email/",
+  "/email-settings/",
+] as const;
+
+/** True when this path carries a token a `Referer` header must never leak. */
+export function carriesTokenInPath(pathname: string): boolean {
+  return TOKEN_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
+/** The `Referrer-Policy` value for a path. */
+export function referrerPolicyFor(pathname: string): string {
+  return carriesTokenInPath(pathname) ? TOKEN_PATH_REFERRER_POLICY : DEFAULT_REFERRER_POLICY;
+}
+
+function setHeaders(headers: Headers, pathname: string): void {
+  headers.set("referrer-policy", referrerPolicyFor(pathname));
+  // A route that chose its own caching keeps it. See the calendar feed.
+  if (carriesTokenInPath(pathname) && !headers.has("cache-control")) {
+    headers.set("cache-control", "no-store");
+  }
+}
+
+/**
+ * The same response, with the security headers on it.
+ *
+ * Mutates in place where it can. That matters for the SSR response, whose body
+ * is a live stream bound to the request for cleanup: re-wrapping it would cut
+ * that binding. Only the responses that cannot be mutated get rebuilt.
+ */
+export function applySecurityHeaders(response: Response, pathname: string): Response {
+  try {
+    setHeaders(response.headers, pathname);
+    return response;
+  } catch {
+    // `Response.redirect()` and `Response.error()` hand back headers with an
+    // immutable guard, so the only way to add to one is to build a new one.
+    const headers = new Headers(response.headers);
+    setHeaders(headers, pathname);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+}

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -27,9 +27,11 @@
  * caches. The calendar feed sets `private, max-age=300` on purpose (a calendar
  * client polls it), so it keeps that.
  *
- * `public/_headers` states the same referrer rules for anything the platform
- * serves without going through this middleware. `security-headers.test.ts`
- * fails if the two drift apart.
+ * `public/_headers` states the same rules, referrer policy and no-store both,
+ * for anything the platform serves without going through this middleware.
+ * `security-headers.test.ts` fails if the two drift apart. The no-store matters
+ * more there than here: that file covers the case where this middleware never
+ * ran, so nothing else would keep a URL with a credential in it out of a cache.
  */
 
 /** What everything gets: the origin cross-site, the full URL same-site. */
@@ -79,9 +81,18 @@ export function applySecurityHeaders(response: Response, pathname: string): Resp
   try {
     setHeaders(response.headers, pathname);
     return response;
-  } catch {
+  } catch (error) {
     // `Response.redirect()` and `Response.error()` hand back headers with an
     // immutable guard, so the only way to add to one is to build a new one.
+    //
+    // Only for that. A bare `catch` here sent EVERY failure down the rebuild
+    // path, the SSR response included, and that response's body is a live
+    // stream bound to the request for cleanup: re-wrapping it cuts the binding,
+    // and the symptom is a truncated or leaked response rather than an error
+    // anybody sees. The comment above already says this response must be
+    // mutated in place, so the control flow should enforce it rather than rely
+    // on nothing else ever throwing.
+    if (!(error instanceof TypeError)) throw error;
     const headers = new Headers(response.headers);
     setHeaders(headers, pathname);
     return new Response(response.body, {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// The SSR entry builds its two error pages by hand, outside the request
+// middleware in start.ts, so they are the one place the security headers could
+// quietly go missing. That matters most on the routes with a token in the path:
+// the error page carries a link home, and a click on it from
+// /email-settings/<token> would hand the token to the next page.
+
+const serverEntryFetch = vi.fn();
+vi.mock("@tanstack/react-start/server-entry", () => ({
+  default: { fetch: (...args: unknown[]) => serverEntryFetch(...args) },
+}));
+
+async function fetchThrough(url: string): Promise<Response> {
+  const { default: entry } = await import("./server");
+  return entry.fetch(new Request(url), {}, {});
+}
+
+describe("SSR entry error pages", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    serverEntryFetch.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("carries the security headers when the handler throws", async () => {
+    serverEntryFetch.mockRejectedValue(new Error("boom"));
+    const response = await fetchThrough("https://jitsu.au/email-settings/abc123");
+    expect(response.status).toBe(500);
+    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("carries them on an h3-swallowed error too", async () => {
+    serverEntryFetch.mockResolvedValue(
+      new Response(JSON.stringify({ unhandled: true, message: "HTTPError" }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const response = await fetchThrough("https://jitsu.au/api/calendar/abc123");
+    expect(response.status).toBe(500);
+    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.text()).toContain("<!doctype html>");
+  });
+
+  it("uses the site-wide policy for an ordinary page", async () => {
+    serverEntryFetch.mockRejectedValue(new Error("boom"));
+    const response = await fetchThrough("https://jitsu.au/about");
+    expect(response.headers.get("referrer-policy")).toBe("strict-origin-when-cross-origin");
+    expect(response.headers.get("cache-control")).toBeNull();
+  });
+
+  it("passes a healthy response straight through", async () => {
+    // Already been through the middleware, so it keeps whatever it was given.
+    const ok = new Response("hi", { status: 200 });
+    serverEntryFetch.mockResolvedValue(ok);
+    expect(await fetchThrough("https://jitsu.au/about")).toBe(ok);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import "./lib/error-capture";
 
 import { consumeLastCapturedError } from "./lib/error-capture";
 import { renderErrorPage } from "./lib/error-page";
+import { applySecurityHeaders } from "./lib/security-headers";
 
 type ServerEntry = {
   fetch: (request: Request, env: unknown, ctx: unknown) => Promise<Response> | Response;
@@ -20,7 +21,10 @@ async function getServerEntry(): Promise<ServerEntry> {
 
 // h3 swallows in-handler throws into a normal 500 Response with body
 // {"unhandled":true,"message":"HTTPError"} — try/catch alone never fires for those.
-async function normalizeCatastrophicSsrResponse(response: Response): Promise<Response> {
+async function normalizeCatastrophicSsrResponse(
+  response: Response,
+  pathname: string,
+): Promise<Response> {
   if (response.status < 500) return response;
   const contentType = response.headers.get("content-type") ?? "";
   if (!contentType.includes("application/json")) return response;
@@ -29,10 +33,21 @@ async function normalizeCatastrophicSsrResponse(response: Response): Promise<Res
   if (!isH3SwallowedErrorBody(body)) return response;
 
   console.error(consumeLastCapturedError() ?? new Error(`h3 swallowed SSR error: ${body}`));
-  return new Response(renderErrorPage(), {
-    status: 500,
-    headers: { "content-type": "text/html; charset=utf-8" },
-  });
+  return errorResponse(pathname);
+}
+
+// The error page is built out here, past the request middleware in start.ts, so
+// it has to set its own headers. It carries a link home, and on
+// /email-settings/<token> a click on that link would otherwise hand the token
+// to the next page in a same-origin `Referer`.
+function errorResponse(pathname: string): Response {
+  return applySecurityHeaders(
+    new Response(renderErrorPage(), {
+      status: 500,
+      headers: { "content-type": "text/html; charset=utf-8" },
+    }),
+    pathname,
+  );
 }
 
 function isH3SwallowedErrorBody(body: string): boolean {
@@ -46,16 +61,14 @@ function isH3SwallowedErrorBody(body: string): boolean {
 
 export default {
   async fetch(request: Request, env: unknown, ctx: unknown) {
+    const { pathname } = new URL(request.url);
     try {
       const handler = await getServerEntry();
       const response = await handler.fetch(request, env, ctx);
-      return await normalizeCatastrophicSsrResponse(response);
+      return await normalizeCatastrophicSsrResponse(response, pathname);
     } catch (error) {
       console.error(error);
-      return new Response(renderErrorPage(), {
-        status: 500,
-        headers: { "content-type": "text/html; charset=utf-8" },
-      });
+      return errorResponse(pathname);
     }
   },
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -61,8 +61,16 @@ function isH3SwallowedErrorBody(body: string): boolean {
 
 export default {
   async fetch(request: Request, env: unknown, ctx: unknown) {
-    const { pathname } = new URL(request.url);
+    // Parsed inside the guard, not above it. Before the security headers this
+    // function never touched the URL, so the try covered everything it did; a
+    // `new URL()` hoisted out would be the one fallible call that could throw
+    // past it, and the reply to that is whatever bare error the runtime makes,
+    // with none of the headers this file exists to guarantee. `new URL()` is
+    // hard to make throw on a real request, which is the argument for keeping
+    // it cheap to be right rather than for assuming it cannot.
+    let pathname = "/";
     try {
+      pathname = new URL(request.url).pathname;
       const handler = await getServerEntry();
       const response = await handler.fetch(request, env, ctx);
       return await normalizeCatastrophicSsrResponse(response, pathname);

--- a/src/start.test.ts
+++ b/src/start.test.ts
@@ -1,0 +1,56 @@
+// The registration that makes the security headers real.
+//
+// `security-headers.test.ts` proves the module decides the right header for a
+// path, and `server.test.ts` proves the SSR entry's two hand-built error pages
+// carry it. Neither covers the thing that puts the header on an ordinary 200,
+// which is `securityHeadersMiddleware` sitting in `requestMiddleware` here: it
+// is the only place a normal page or server-function response gets one.
+//
+// Delete that entry and both of those suites stay green, e2e stays green (no
+// spec reads a response header), and every page on the live site quietly stops
+// sending Referrer-Policy. So this reads the source and holds the wiring in
+// place, the same way seo.test.ts holds the route files to the sitemap.
+//
+// Asserted against the source rather than by driving the instance because
+// `createStart` hands back a configured object whose middleware array is not
+// reachable to read, and a test that cannot see the list cannot notice one
+// going missing from it.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(join(process.cwd(), "src/start.ts"), "utf8");
+
+function requestMiddlewareNames(): string[] {
+  const match = source.match(/requestMiddleware:\s*\[([^\]]*)\]/);
+  expect(match, "requestMiddleware array not found in src/start.ts").toBeTruthy();
+  return match![1]
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean);
+}
+
+describe("startInstance request middleware", () => {
+  it("registers the security headers middleware", () => {
+    expect(requestMiddlewareNames()).toContain("securityHeadersMiddleware");
+  });
+
+  it("puts it outermost, so the 500 page gets the headers too", () => {
+    // `errorMiddleware` builds its own Response for an unhandled throw. Ordered
+    // the other way, that page would leave without a Referrer-Policy, and an
+    // error page is reachable from a token URL like any other.
+    const names = requestMiddlewareNames();
+    expect(names[0]).toBe("securityHeadersMiddleware");
+    expect(names).toContain("errorMiddleware");
+    expect(names.indexOf("securityHeadersMiddleware")).toBeLessThan(
+      names.indexOf("errorMiddleware"),
+    );
+  });
+
+  it("builds that middleware out of the shared module, not its own copy", () => {
+    // A second spelling of the rule here would drift from the one the tests and
+    // public/_headers are held to.
+    expect(source).toContain('from "./lib/security-headers"');
+    expect(source).toContain("applySecurityHeaders(result.response, pathname)");
+  });
+});

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,7 +1,15 @@
 import { createStart, createMiddleware } from "@tanstack/react-start";
 
 import { renderErrorPage } from "./lib/error-page";
+import { applySecurityHeaders } from "./lib/security-headers";
 import { attachSupabaseAuth } from "@/integrations/supabase/auth-attacher";
+
+// Outermost, so the headers land on the error middleware's 500 page too. Why
+// these headers, and why three routes need a stricter one: src/lib/security-headers.ts.
+const securityHeadersMiddleware = createMiddleware().server(async ({ next, pathname }) => {
+  const result = await next();
+  return { ...result, response: applySecurityHeaders(result.response, pathname) };
+});
 
 const errorMiddleware = createMiddleware().server(async ({ next }) => {
   try {
@@ -20,5 +28,5 @@ const errorMiddleware = createMiddleware().server(async ({ next }) => {
 
 export const startInstance = createStart(() => ({
   functionMiddleware: [attachSupabaseAuth],
-  requestMiddleware: [errorMiddleware],
+  requestMiddleware: [securityHeadersMiddleware, errorMiddleware],
 }));


### PR DESCRIPTION
Refs #67. Does the first half of that issue in full, and deliberately does not do the second half. What is left, and why, is spelled out below so it can be tracked.

## What the user will feel

Nothing, on any screen. No copy changes, no new step, no email goes out.

**Existing calendar subscriptions and unsubscribe links keep working exactly as they are.** No token is rotated, no URL shape changes, no route moves. Somebody who pasted their calendar link into their phone six months ago does not have to do anything, and a link at the bottom of an email sent last week still opens the same settings panel.

The one measurable difference: the calendar feed and the email settings page are no longer allowed to tell a third party what URL the reader came from. That was never a feature anybody used.

## The change

Three routes carry a credential in the URL **path**, because the software that opens them has nowhere else to put it:

| Route | What the token is worth |
| --- | --- |
| `/api/calendar/<token>` | somebody's schedule and RSVPs; the longest-lived of the three |
| `/api/verify-email/<token>` | single use, time bound, least valuable |
| `/email-settings/<token>` | changing somebody's notification preferences |

With no `Referrer-Policy`, the browser falls back to its own default, which still hands the **full URL** to every same-origin request the page makes, and sends the origin (or, on older or differently configured browsers, the full URL) cross-origin. `/email-settings/<token>` is a full page carrying `SiteFooter`, which has outbound links, so this is not theoretical.

- `src/lib/security-headers.ts` decides the headers for a path. `start.ts` applies them as the **outermost** request middleware, so SSR pages, API route handlers, server-function RPCs and the 500 error page all get them.
- `strict-origin-when-cross-origin` everywhere; `no-referrer` on the three token prefixes. `no-referrer` is the only value that also keeps the path out of a **same-origin** `Referer`, which is the case the site-wide policy does not cover.
- Those three paths also get `Cache-Control: no-store` **unless the route set its own**, keeping a URL with a credential in it out of shared and on-disk caches. The calendar feed keeps its deliberate `private, max-age=300`, because a calendar client polls it and overriding that would make every poll a miss.
- `public/_headers` states the same rules, referrer policy and `no-store` both, for anything the platform serves without going through the middleware.
- `src/server.ts` builds two 500 responses by hand, outside the middleware, so they set the headers themselves. That error page carries a link home, and a click on it from `/email-settings/<token>` is exactly the leak this change is about.

Two review rounds are folded in (commits 2 and 4). The second round closed three gaps worth naming, since each was a way for this change to look done and not be:

1. `applySecurityHeaders` caught **every** throw, not just the immutable-headers one, so any other failure took the rebuild path. The SSR response has to be mutated in place, because its body is a live stream bound to the request for cleanup and re-wrapping cuts that binding. Anything that is not a `TypeError` now escapes instead.
2. `public/_headers` carried the referrer policy but not the `no-store`, and the drift test only compared the referrer policy. That file is what covers responses the middleware never saw, so its `no-store` is the only one those get.
3. Nothing held `securityHeadersMiddleware` in `requestMiddleware`. Delete that one line and all three suites plus e2e stay green while every ordinary page quietly stops sending the header. `src/start.test.ts` now pins the registration and its ordering, the way `seo.test.ts` pins the sitemap.

### On whether the platform reads `_headers`

It does. Nitro already generates `.output/public/_headers` for its own `/assets/*` cache rule and merges this file into it at build time, so the deploy path was already using the mechanism. The middleware is still the real fix and covers every route regardless. Worth one `curl -I https://jitsu.au/` after this deploys to confirm on the live host, and to see what else the platform is already sending before anyone adds CSP or `X-Frame-Options` on top.

### Verified against a real build

`NITRO_PRESET=node-server bun run build`, then the built server:

| Path | Result |
| --- | --- |
| `/about` | 200, `referrer-policy: strict-origin-when-cross-origin` |
| `/email-settings/<token>` | 200, `no-referrer` + `no-store` |
| `/api/calendar/<token>` | 404 (bogus token), `no-referrer` + `no-store` |
| `/api/verify-email/<token>` | 302 with `Location` intact, `no-referrer` + `no-store` |
| `/robots.txt` | 200, keeps its own `cache-control: public, max-age=3600` |

## What this does NOT do, and why

**The token stays in the URL path on all three routes.** I judged the restructuring too big for this PR, and for two of the three routes I do not think it should be done at all:

- **The ICS feed has no alternative.** Apple Calendar, Google Calendar and Outlook subscribe to a URL. They cannot send an `Authorization` header or a POST body, and there is no second channel. Any redesign that moved the token out of the path would break every existing subscription and have nowhere to put the replacement. The token has to stay; mitigation is the right answer here, not restructuring.
- **Verify-email is not worth a redesign.** It is single use, time bound, and redirects immediately. The only shape that removes the token from the URL is a landing page with a "yes, confirm" button, which adds a click to every verification in exchange for closing a hole in a token that is already dead on arrival.
- **`/email-settings/<token>` is the one where a redesign is possible**, and it is a separate change. The shape that works: the token URL becomes an exchange endpoint that sets a short-lived cookie and redirects to a plain `/email-settings` with the token gone from the address bar, history and any `Referer`. That means introducing a signed-out session cookie the site does not currently have, deciding its lifetime, and reworking the two server functions that today take the token in their POST body. That is a design decision with a real diff behind it, not something to smuggle into a header change.

Also worth recording, since it came up while checking:

- The token is already **only** in the URL for the page load. `getNotificationPreferencesByToken` and `saveNotificationPreferencesByToken` are server-function POSTs, so the token is in a request body, not a query string, for every read and write the page does.
- `/email-settings/<token>` is genuinely `noindex, nofollow` to a crawler. Despite `ssr: false`, the meta tag is server-rendered into the shell (confirmed against the built server), so a crawler that somehow reached one of these URLs would see it. No change needed there.
- The calendar feed token has no rotate button by design (`docs/calendar.md` rule 4). That is a product decision, not an oversight, so I have left it alone. If the residual risk on that token matters, "let a member replace their calendar link" is the follow-up worth filing.

## Tests and docs

- `src/lib/security-headers.test.ts` (16 cases): the path classification including near misses, both policies, `no-store` only where it belongs, a route's own `cache-control` surviving, the same-object return for the stream case, the rebuild for the immutable redirect, a non-`TypeError` escaping instead of rebuilding, and a test that parses `public/_headers` and fails if either header drifts from the module.
- `src/server.test.ts` (4 cases): both hand-built error paths carry the headers, an ordinary path gets the site-wide policy, and a healthy response passes through untouched.
- `src/start.test.ts` (3 cases): the middleware is registered, it is outermost, and it is built from the shared module rather than a second copy of the rule.
- `CLAUDE.md` gains a "Security headers" section (what is set, where, and the rule for adding another token route). `docs/notifications.md` and `docs/calendar.md` each gain a line at the point where they explain why the token is in the path.

`bun run lint`, `bun run typecheck`, `bun run test` (2201 passing) and `bun run build` all pass locally, and both CI checks are green on the head commit. `bun.lock` untouched.