### PR TITLE
Make a digest that is not sending say so (#69)

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -1178,7 +1178,7 @@ Two things that fail silently every morning rather than loudly once:
   that one 302s, and pg_net does not follow redirects.
 
 The migration deliberately **does not arm the job**. It fires nightly and returns
-immediately with a `RAISE WARNING` until both secrets exist:
+immediately until both secrets exist:
 
 ```sql
 SELECT vault.create_secret(
@@ -1186,6 +1186,15 @@ SELECT vault.create_secret(
 SELECT vault.create_secret('<same value as NOTIFICATION_DIGEST_KEY>',
   'notification_digest_key');
 ```
+
+`20260821000000_notification_digest_fails_loudly.sql` replaces the function body
+so that the unarmed branch **raises** instead of warning and returning, naming
+whichever secret is missing. A plpgsql function that returns is one pg_cron
+records as `succeeded`, so until that migration every unarmed night went into
+`cron.job_run_details` as a success. It now goes in as a failure, which is what
+it is. Arming the job is what clears it; a club that does not want the digest at
+all should `cron.unschedule('notification-digest')` rather than leave it red.
+The runbook for arming it is in `docs/notifications.md`.
 
 ---
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -186,15 +186,11 @@ for using Actions ("pg_cron is not available") was never checked: it was inferre
 from the extension being absent from this repo's migrations, which says nothing
 about what the project offers. `pg_available_extensions` lists pg_cron 1.6.4.
 
-**It is not armed by the migration.** The job fires nightly and returns
-immediately, with a warning in the Postgres log, until both Vault secrets exist:
-
-```sql
-SELECT vault.create_secret(
-  'https://jitsu.au/api/notifications/digest', 'notification_digest_url');
-SELECT vault.create_secret('<same value as NOTIFICATION_DIGEST_KEY>',
-  'notification_digest_key');
-```
+**It is not armed by the migration**, and as of this writing it never has been:
+the two Vault secrets do not exist, `NOTIFICATION_DIGEST_KEY` is unset, and no
+digest email has ever gone out. The job fires nightly and raises, so the
+scheduler records it as failed. "Arming the digest: the runbook" below is the
+whole procedure, including what to do with the backlog first.
 
 Two traps worth stating, because both fail silently every morning rather than
 loudly once:
@@ -250,9 +246,130 @@ SELECT count(*) FROM public.notifications WHERE emailed_at IS NULL;        -- ba
 ```
 
 That last query is the one worth watching: a number that climbs day over day
-means the digest has stopped, whatever the scheduler thinks. Closing this
-properly wants a second job that reads back the response and raises on a non-2xx
-so the failure lands in `cron.job_run_details`. Not built yet.
+means the digest has stopped, whatever the scheduler thinks.
+
+#### What now watches it
+
+Two changes, and the split between them is the point. One makes the scheduler
+stop lying; the other stops relying on the scheduler at all.
+
+- **An unarmed run is now recorded as failed**
+  (`20260821000000_notification_digest_fails_loudly.sql`). The fail-closed branch
+  raises instead of returning, naming whichever Vault secret is missing, so
+  `cron.job_run_details` says `failed` for a job that emailed nobody. This is
+  narrow on purpose: it only catches the half of the problem the database can
+  see. An armed job still records success no matter what the site answered.
+- **A stalled digest is an attention item on `/notifications`.** Any notification
+  row that has sat unemailed for more than `DIGEST_STALL_HOURS` (36) raises "The
+  daily email summary has stopped going out", with the backlog size and the date
+  of the oldest row. This asserts on the **outcome**, not the mechanism, which is
+  the only check that survives pg_net being fire and forget: Vault secret
+  missing, key drifted from the env var, endpoint answering 503 because
+  `NOTIFICATION_DIGEST_KEY` is unset, site down, DNS or TLS failing, request
+  timing out. All of them look identical from here, which is exactly what makes
+  the check cheap and total.
+
+36 hours rather than 24: the run is daily, so anything younger is waiting for
+tonight, and a run that is a few hours late is not news. Two missed mornings is.
+
+Three things about that item are deliberate and will look like bugs otherwise:
+
+- **It has no button.** Both halves of the fix live outside this repo, in
+  Supabase Vault and the Lovable Cloud project secrets, so every destination the
+  page could offer would be one that cannot help. `ManagerNotification` carries
+  `href` and `actionLabel` as an all-or-nothing pair for this reason.
+- **It cannot be dismissed**, like every attention item, and unlike the others it
+  can stay up for weeks. It clears when the digest actually sends, or when
+  somebody stamps the backlog as emailed. That is the correct behaviour while
+  members are silently getting no email.
+- **It fires while the digest has simply never been armed**, which is the state
+  the club is in today. That is not a false positive: the rows are owed and
+  nobody has had them.
+
+Still not built: a second job that reads `net._http_response` back and raises on
+a non-2xx, so an ARMED failure lands in `cron.job_run_details` the same night
+rather than a day and a half later on the notifications page. It needs somewhere
+durable to keep the verdict, since pg_net garbage-collects that table after
+`pg_net.ttl` (6 hours by default). The backlog check covers the same failures
+more slowly, which is why this is worth doing and not urgent.
+
+### Arming the digest: the runbook
+
+Nothing here can be done from this repo, and both halves have to be in place
+before a single email goes out. The key exists in two places and must match.
+
+**1. Set the server env var.** In the **Lovable Cloud project secrets**, add
+`NOTIFICATION_DIGEST_KEY`. Generate it fresh, treat it as a credential, and do
+not put it in `.env` (which is committed, see CLAUDE.md). Anything unguessable
+works; `openssl rand -hex 32` is fine. Redeploy so the server picks it up, then
+confirm the endpoint has stopped refusing everything:
+
+```sh
+curl -si -X POST https://jitsu.au/api/notifications/digest      # expect 401, NOT 503
+```
+
+503 means the env var still is not reaching the server. 401 means it is, and the
+endpoint is now asking for the right token. Do not send the real token here
+unless you mean to run a digest immediately.
+
+**2. Decide what happens to the backlog, BEFORE step 3.** The digest sweeps
+every row with a NULL `emailed_at` and no age limit, so arming it releases the
+whole backlog in one go, as one email per person. Old announcements arriving in
+a burst is the kind of send that gets a domain marked as spam, and the club
+depends on that domain for magic links and account activation. To start clean:
+
+```sql
+-- Stamp the backlog as emailed without sending it. Run this BEFORE arming.
+UPDATE public.notifications
+   SET emailed_at = now()
+ WHERE emailed_at IS NULL
+   AND created_at < now() - interval '36 hours';
+```
+
+Everything stays on each person's `/notifications` page: `emailed_at` governs the
+inbox only, never the page. The alternative is to let them send, which is a
+product decision and not a default.
+
+**3. Add the two Vault secrets** (Supabase → Integrations → Vault, or the SQL
+editor). The key must match step 1 **exactly**, and the URL must be the
+`jitsu.au` origin, not the `*.lovable.app` one:
+
+```sql
+SELECT vault.create_secret(
+  'https://jitsu.au/api/notifications/digest', 'notification_digest_url');
+SELECT vault.create_secret('<the same value as NOTIFICATION_DIGEST_KEY>',
+  'notification_digest_key');
+```
+
+**4. Prove it works, without waiting for 20:00 UTC.** Run the job by hand and
+read the response back inside pg_net's 6-hour TTL:
+
+```sql
+SELECT private.run_notification_digest();          -- raises if a secret is missing
+SELECT id, status_code, content, error_msg, created
+  FROM net._http_response ORDER BY created DESC LIMIT 1;
+```
+
+`status_code` 200 with a body like `{"ok":true,"considered":N,...}` is the
+answer you want. 401 means the two copies of the key differ. 503 means step 1 did
+not take. A row with `error_msg` and no status is a network or TLS failure. A
+302 means the URL is the `*.lovable.app` host, which pg_net will not follow.
+
+**5. Confirm the next scheduled run.** The morning after:
+
+```sql
+SELECT status, return_message, start_time FROM cron.job_run_details
+ WHERE jobname = 'notification-digest' ORDER BY start_time DESC LIMIT 3;
+SELECT count(*) FROM public.notifications WHERE emailed_at IS NULL;
+```
+
+`succeeded` with a backlog that is not climbing is a working digest. The
+notifications page is the standing version of that second query: the "daily email
+summary has stopped" item disappears once the backlog is cleared and stays away
+while it is being kept clear.
+
+Rotating the key later means changing it in **both** places in the same sitting
+(`vault.update_secret` for the Vault copy), or every run 401s until they agree.
 
 ### A post goes live
 
@@ -290,11 +407,11 @@ choice to a member would be a lie about what they can turn on.
 - **No per-thread mute.** The switches are per kind. If one thread turns noisy,
   the answer today is to turn thread activity off.
 - **No in-app bell or toast.** The sidebar badge is the only in-app signal.
-- **The attention list has four checks**: waivers waiting for approval, unanswered
-  contact messages, new interest registrations, and the club's training dates
-  running out. Unmatched bank transactions and unpaid invoices are the obvious
-  next entries and the shape supports them, but widening the manager queue
-  further is separate work.
+- **The attention list has five checks**: waivers waiting for approval, unanswered
+  contact messages, a stalled daily digest, new interest registrations, and the
+  club's training dates running out. Unmatched bank transactions and unpaid
+  invoices are the obvious next entries and the shape supports them, but widening
+  the manager queue further is separate work.
 - **Signing up notifies managers by email at the moment it happens** (a new-lead
   email on registration, a copy of the waiver on signing), and none of that is
   changed by the attention items. Neither item claims a copy was emailed: those
@@ -330,22 +447,24 @@ Two consequences worth knowing:
 
 ## Where the code lives
 
-| Concern                      | File                                                                   |
-| ---------------------------- | ---------------------------------------------------------------------- |
-| The rules (pure, tested)     | `src/lib/notifications.ts`                                             |
-| The attention list           | `src/lib/manager-notifications.functions.ts`                           |
-| Contact messages             | `src/lib/contact-messages.functions.ts`, `contact-email.server.ts`     |
-| Interest registrations       | `src/lib/leads.functions.ts`                                           |
-| Waivers waiting on a manager | `countWaiversAwaitingApproval` in `src/lib/waiver.functions.ts`        |
-| The club-wide watermarks     | `src/lib/seen-markers.ts`                                              |
-| Who hears about what         | `src/lib/notification-events.server.ts`                                |
-| Sending, and the digest run  | `src/lib/notification-email.server.ts`                                 |
-| Page and settings server fns | `src/lib/notifications.functions.ts`                                   |
-| The shared query             | `src/hooks/useNotifications.ts`                                        |
-| The page                     | `src/routes/_authenticated/notifications.tsx`                          |
-| The signed-out settings      | `src/routes/email-settings/$token.tsx`                                 |
-| The switches                 | `src/components/site/NotificationSwitches.tsx`                         |
-| The sidebar badge            | `src/components/site/MemberLayout.tsx`                                 |
-| The digest endpoint          | `src/routes/api/notifications/digest.ts`                               |
-| The schedule                 | `supabase/migrations/20260807000000_notification_digest_cron.sql`      |
-| Email templates              | `src/lib/email-templates/comment-reply.tsx`, `notification-digest.tsx` |
+| Concern                      | File                                                                      |
+| ---------------------------- | ------------------------------------------------------------------------- |
+| The rules (pure, tested)     | `src/lib/notifications.ts`                                                |
+| The attention list           | `src/lib/manager-notifications.functions.ts`                              |
+| Contact messages             | `src/lib/contact-messages.functions.ts`, `contact-email.server.ts`        |
+| Interest registrations       | `src/lib/leads.functions.ts`                                              |
+| Waivers waiting on a manager | `countWaiversAwaitingApproval` in `src/lib/waiver.functions.ts`           |
+| The club-wide watermarks     | `src/lib/seen-markers.ts`                                                 |
+| Who hears about what         | `src/lib/notification-events.server.ts`                                   |
+| Sending, and the digest run  | `src/lib/notification-email.server.ts`                                    |
+| Page and settings server fns | `src/lib/notifications.functions.ts`                                      |
+| The shared query             | `src/hooks/useNotifications.ts`                                           |
+| The page                     | `src/routes/_authenticated/notifications.tsx`                             |
+| The signed-out settings      | `src/routes/email-settings/$token.tsx`                                    |
+| The switches                 | `src/components/site/NotificationSwitches.tsx`                            |
+| The sidebar badge            | `src/components/site/MemberLayout.tsx`                                    |
+| The digest endpoint          | `src/routes/api/notifications/digest.ts`                                  |
+| The schedule                 | `supabase/migrations/20260807000000_notification_digest_cron.sql`         |
+| Failing loudly when unarmed  | `supabase/migrations/20260821000000_notification_digest_fails_loudly.sql` |
+| The stalled-digest item      | `digestStalledNotifications` in `src/lib/validation.ts`                   |
+| Email templates              | `src/lib/email-templates/comment-reply.tsx`, `notification-digest.tsx`    |

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -186,9 +186,9 @@ for using Actions ("pg_cron is not available") was never checked: it was inferre
 from the extension being absent from this repo's migrations, which says nothing
 about what the project offers. `pg_available_extensions` lists pg_cron 1.6.4.
 
-**It is not armed by the migration**, and as of this writing it never has been:
-the two Vault secrets do not exist, `NOTIFICATION_DIGEST_KEY` is unset, and no
-digest email has ever gone out. The job fires nightly and raises, so the
+**It is not armed by the migration**, and as of 2026-08-21 it never has been:
+both Vault secrets are absent, `NOTIFICATION_DIGEST_KEY` is unset, and no digest
+email has ever gone out (checked against the live project, see the runbook). The job fires nightly and raises, so the
 scheduler records it as failed. "Arming the digest: the runbook" below is the
 whole procedure, including what to do with the backlog first.
 
@@ -298,11 +298,27 @@ more slowly, which is why this is worth doing and not urgent.
 Nothing here can be done from this repo, and both halves have to be in place
 before a single email goes out. The key exists in two places and must match.
 
-**1. Set the server env var.** In the **Lovable Cloud project secrets**, add
-`NOTIFICATION_DIGEST_KEY`. Generate it fresh, treat it as a credential, and do
-not put it in `.env` (which is committed, see CLAUDE.md). Anything unguessable
-works; `openssl rand -hex 32` is fine. Redeploy so the server picks it up, then
-confirm the endpoint has stopped refusing everything:
+Checked against the live project through Lovable on **2026-08-21**, read-only:
+`NOTIFICATION_DIGEST_KEY` is not set (the project has three secrets and this is
+not one of them), neither Vault secret exists, and so no digest email has ever
+been sent. pg_cron is installed and job `notification-digest` is active on
+`0 20 * * *` with the expected command; pg_net is installed with its extension
+home in `extensions` and its functions in `net`, which is what the migration
+asserts. The five runs from 17 to 21 August all recorded **succeeded**, return
+message `1 row`, having done nothing. The backlog stood at **34 rows**, from
+2026-08-10 12:53 UTC to 2026-08-20 03:09 UTC.
+
+**1. Set the server env var.** In Lovable, **Project Settings → Secrets**, add
+`NOTIFICATION_DIGEST_KEY`. That screen is the only place it goes: there is no
+separate environment-variable screen, and it must not go in `.env` (which is
+committed, see CLAUDE.md). Generate it yourself and treat it as a credential;
+`openssl rand -hex 32` is fine. You need the identical string in Vault at step 3,
+so generate it somewhere you can copy it from.
+
+Preview and the published site read the same secret store, but the deployed
+`jitsu.au` build only picks up a new value on the next publish, so **publish
+(Publish → Update) before going further**. Then confirm the endpoint has stopped
+refusing everything:
 
 ```sh
 curl -si -X POST https://jitsu.au/api/notifications/digest      # expect 401, NOT 503
@@ -330,9 +346,9 @@ Everything stays on each person's `/notifications` page: `emailed_at` governs th
 inbox only, never the page. The alternative is to let them send, which is a
 product decision and not a default.
 
-**3. Add the two Vault secrets** (Supabase → Integrations → Vault, or the SQL
-editor). The key must match step 1 **exactly**, and the URL must be the
-`jitsu.au` origin, not the `*.lovable.app` one:
+**3. Add the two Vault secrets.** There is no Vault UI on Lovable Cloud, so this
+is SQL. The key must match step 1 **exactly**, and the URL must be the `jitsu.au`
+origin, not the `*.lovable.app` one:
 
 ```sql
 SELECT vault.create_secret(
@@ -367,6 +383,11 @@ SELECT count(*) FROM public.notifications WHERE emailed_at IS NULL;
 notifications page is the standing version of that second query: the "daily email
 summary has stopped" item disappears once the backlog is cleared and stays away
 while it is being kept clear.
+
+Do the two halves in this order, env var first. While Vault is empty the job
+returns without posting anything, so there is no window where something unwanted
+happens. The reverse order gives a night of the job POSTing into a 503, which is
+harmless but pointless.
 
 Rotating the key later means changing it in **both** places in the same sitting
 (`vault.update_secret` for the Vault copy), or every run 401s until they agree.

--- a/scripts/seed-local-club.mjs
+++ b/scripts/seed-local-club.mjs
@@ -676,6 +676,11 @@ await insert("notification_preferences", {
   thread_activity: false,
 });
 
+// Every row here is stamped `emailed_at`, which is what a club whose daily
+// digest is working looks like. Left NULL they would age past
+// DIGEST_STALL_HOURS and put a permanent "the daily email summary has stopped"
+// item on the manager's notifications page in every run and every screenshot,
+// which is a fault this fixture does not have. See docs/notifications.md.
 await insert("notifications", [
   {
     user_id: users.member,
@@ -686,6 +691,7 @@ await insert("notifications", [
     body: "New term, new mats, and a beginners' block starting in week one.",
     href: "/blog/welcome-to-semester-two",
     created_at: at(-9),
+    emailed_at: at(-8),
   },
   {
     user_id: users.member,
@@ -698,6 +704,7 @@ await insert("notifications", [
     href: "/blog/welcome-to-semester-two",
     created_at: at(-8),
     read_at: at(-7),
+    emailed_at: at(-8, 10),
   },
   {
     user_id: users.manager,
@@ -709,6 +716,7 @@ await insert("notifications", [
     body: "Does this mean I should take my wedding ring off, or is taping it enough?",
     href: "/kb/mat-etiquette",
     created_at: at(-5),
+    emailed_at: at(-4),
   },
 ]);
 

--- a/src/lib/manager-notifications.functions.test.ts
+++ b/src/lib/manager-notifications.functions.test.ts
@@ -1,0 +1,135 @@
+// The stalled-digest source of the "needs attention" list.
+//
+// What is worth pinning here is not the SQL but the discrimination: this item
+// cannot be dismissed and it accuses the club's email of being broken, so it has
+// to be right in both directions. It must fire while the digest has never been
+// armed (the state the club is in), and it must NOT fire for a digest that is
+// working but has one recipient whose address bounces every night, whose rows
+// stay unstamped for good. Both look like "rows with a NULL emailed_at" from a
+// distance, which is exactly the trap.
+import { describe, expect, it } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/integrations/supabase/types";
+
+import { digestBacklogNotifications } from "./manager-notifications.functions";
+
+type QueryResult = { data: unknown; error: { message: string } | null; count?: number | null };
+
+/**
+ * A PostgREST chain answering each `from()` with the next queued result and
+ * recording the filters it was given. The filters matter as much as the
+ * results: the whole check hangs on a cutoff, and a fake that swallowed `.lt()`
+ * would let the window silently become "all of time" with every test still
+ * green. Thenable because the counts are awaited directly rather than through
+ * `.maybeSingle()`.
+ */
+function fakeAdmin(results: QueryResult[]) {
+  const queue = [...results];
+  const filters: Array<[string, unknown]> = [];
+  let queries = 0;
+  const admin = {
+    from() {
+      queries += 1;
+      const result = queue.shift() ?? { data: null, error: null, count: 0 };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const chain: any = {
+        select: () => chain,
+        is: (col: string, value: unknown) => {
+          filters.push([`is:${col}`, value]);
+          return chain;
+        },
+        lt: (col: string, value: unknown) => {
+          filters.push([`lt:${col}`, value]);
+          return chain;
+        },
+        gte: (col: string, value: unknown) => {
+          filters.push([`gte:${col}`, value]);
+          return chain;
+        },
+        order: () => chain,
+        limit: () => chain,
+        maybeSingle: () => Promise.resolve(result),
+        then: (
+          onFulfilled?: (value: QueryResult) => unknown,
+          onRejected?: (reason: unknown) => unknown,
+        ) => Promise.resolve(result).then(onFulfilled, onRejected),
+      };
+      return chain;
+    },
+  };
+  return {
+    admin: admin as unknown as SupabaseClient<Database>,
+    filters,
+    queryCount: () => queries,
+  };
+}
+
+const NOW = new Date("2026-08-21T00:00:00.000Z");
+/** 36 hours before NOW, which is what every query below should be bounded by. */
+const CUTOFF = "2026-08-19T12:00:00.000Z";
+
+const backlog = (count: number): QueryResult => ({ data: null, error: null, count });
+const oldest = (created_at: string): QueryResult => ({ data: { created_at }, error: null });
+const failed: QueryResult = { data: null, error: { message: "nope" }, count: null };
+
+describe("digestBacklogNotifications", () => {
+  it("says nothing, in one query, while no row is overdue", async () => {
+    const { admin, filters, queryCount } = fakeAdmin([backlog(0)]);
+    expect(await digestBacklogNotifications(admin, NOW)).toEqual([]);
+    // The quiet case is the one that runs on every manager's page load, so it
+    // must not pay for the two follow-up reads.
+    expect(queryCount()).toBe(1);
+    expect(filters).toEqual([
+      ["is:emailed_at", null],
+      ["lt:created_at", CUTOFF],
+    ]);
+  });
+
+  it("raises the item when a backlog has aged and nothing has been emailed", async () => {
+    // The club's actual state: the digest has never been armed, so there is no
+    // evidence anywhere of a run that worked.
+    const { admin } = fakeAdmin([backlog(34), backlog(0), oldest("2026-08-05T23:00:00.000Z")]);
+    const [n] = await digestBacklogNotifications(admin, NOW);
+    expect(n.type).toBe("notification_digest_stalled");
+    expect(n.body).toContain("34 notifications");
+    expect(n.body).toContain("since 06/08/2026");
+  });
+
+  it("stays quiet when the digest is delivering to somebody", async () => {
+    // One person's address bounces every night. `sendDailyDigests` swallows that
+    // failure and deliberately leaves THEIR rows unstamped so tomorrow retries,
+    // which means their backlog ages forever. Without this check the club would
+    // carry a permanent, undismissable "the summary has stopped" item on a
+    // digest that is working for everybody else.
+    const { admin, queryCount } = fakeAdmin([backlog(4), backlog(19)]);
+    expect(await digestBacklogNotifications(admin, NOW)).toEqual([]);
+    // Stops before reading the oldest row: there is no item to date.
+    expect(queryCount()).toBe(2);
+  });
+
+  it("bounds the recent-send check by the same window as the backlog", async () => {
+    const { admin, filters } = fakeAdmin([backlog(4), backlog(19)]);
+    await digestBacklogNotifications(admin, NOW);
+    expect(filters).toContainEqual(["gte:emailed_at", CUTOFF]);
+  });
+
+  it("says nothing when a read fails, rather than crying wolf", async () => {
+    // Telling a manager the club's email is broken on the strength of a query
+    // that did not run is worse than saying nothing: the item cannot be
+    // dismissed, so a wrong one stays up.
+    expect(await digestBacklogNotifications(fakeAdmin([failed]).admin, NOW)).toEqual([]);
+    expect(await digestBacklogNotifications(fakeAdmin([backlog(9), failed]).admin, NOW)).toEqual(
+      [],
+    );
+  });
+
+  it("keeps the item when only the oldest row could not be read", async () => {
+    // The count is what the item cannot do without. A missing date makes the
+    // copy vaguer and must not cost the warning itself.
+    const { admin } = fakeAdmin([backlog(9), backlog(0), failed]);
+    const [n] = await digestBacklogNotifications(admin, NOW);
+    expect(n.type).toBe("notification_digest_stalled");
+    expect(n.body).toContain("9 notifications have been waiting to be emailed, and nobody");
+    expect(n.body).not.toContain("the oldest");
+  });
+});

--- a/src/lib/manager-notifications.functions.ts
+++ b/src/lib/manager-notifications.functions.ts
@@ -6,7 +6,9 @@
 // messages belong here rather than among the stored activity rows: they clear
 // when a manager opens the inbox, and there is no per-message read state. The
 // two sign-up steps arrive the same way: a waiver clears by being approved, and
-// a registration by a manager opening the users list.
+// a registration by a manager opening the users list. The stalled digest is the
+// same shape again: it clears by the email actually going out, and there is
+// deliberately no way to tick it off while it has not.
 //
 // This is a composition point, not a feature: each source contributes its own
 // items and this module decides what order a manager meets them in. The rules
@@ -25,6 +27,8 @@
 import {
   composeManagerNotifications,
   contactMessageNotifications,
+  digestStalledNotifications,
+  DIGEST_STALL_HOURS,
   interestRegistrationNotifications,
   sellableWindowNotifications,
   waiverApprovalNotifications,
@@ -53,26 +57,81 @@ async function membershipWindowNotifications(
   return sellableWindowNotifications(dated, new Date().toISOString());
 }
 
+/**
+ * "The daily email summary has stopped going out." The backlog of notification
+ * rows still carrying a NULL `emailed_at` well after the run that should have
+ * cleared them, which is the only honest signal the digest has that it worked:
+ * its scheduler reports success no matter what the site answered. See
+ * `digestStalledNotifications` and docs/notifications.md.
+ *
+ * Read here rather than in `notifications.functions.ts`, which owns every other
+ * query against this table, on purpose: that module imports this one, and a
+ * count reaching back the other way would put an import cycle between the page
+ * and the list it renders. `membershipWindowNotifications` above already sets
+ * the precedent that a source can do its own reading here.
+ */
+async function digestBacklogNotifications(
+  admin: MembershipClient,
+  now: Date,
+): Promise<ManagerNotification[]> {
+  const cutoff = new Date(now.getTime() - DIGEST_STALL_HOURS * 3_600_000).toISOString();
+  const overdue = admin
+    .from("notifications")
+    .select("id", { count: "exact", head: true })
+    .is("emailed_at", null)
+    .lt("created_at", cutoff);
+  const oldest = admin
+    .from("notifications")
+    .select("created_at")
+    .is("emailed_at", null)
+    .lt("created_at", cutoff)
+    .order("created_at", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  const [{ count, error }, { data: first, error: oldestError }] = await Promise.all([
+    overdue,
+    oldest,
+  ]);
+  // Degrade rather than throw, exactly as the three counts below do: a failed
+  // read here must not empty the queue around it. Reporting nothing is the safe
+  // direction for this one specifically, since the alternative is telling a
+  // manager the club's email is broken on the strength of a query that failed.
+  if (error) {
+    console.error("[notifications] could not count the unemailed backlog:", error);
+    return [];
+  }
+  const stalled = count ?? 0;
+  if (stalled === 0) return [];
+  if (oldestError) {
+    console.error("[notifications] could not read the oldest unemailed row:", oldestError);
+  }
+  return digestStalledNotifications({ stalled, oldestAt: first?.created_at ?? null });
+}
+
 export async function managerAttentionItems(
   admin: MembershipClient,
 ): Promise<ManagerNotification[]> {
   // Sources are independent, so fetch them together rather than in sequence.
   //
-  // The three counts degrade to "nothing to report" on their own failed reads,
-  // so one bad query cannot empty the queue around it. The membership windows
-  // are the exception and still throw, which `Promise.all` turns into a failed
-  // notifications payload: the page then says it could not load and offers a
-  // retry, which is honest, rather than reporting all quiet.
-  const [windows, unreadContact, waitingWaivers, newLeads] = await Promise.all([
+  // The three counts and the digest backlog degrade to "nothing to report" on
+  // their own failed reads, so one bad query cannot empty the queue around it.
+  // The membership windows are the exception and still throw, which
+  // `Promise.all` turns into a failed notifications payload: the page then says
+  // it could not load and offers a retry, which is honest, rather than
+  // reporting all quiet.
+  const [windows, unreadContact, waitingWaivers, newLeads, digestStalled] = await Promise.all([
     membershipWindowNotifications(admin),
     countUnreadContactMessages(admin),
     countWaiversAwaitingApproval(admin),
     countNewInterestRegistrations(admin),
+    digestBacklogNotifications(admin, new Date()),
   ]);
 
   return composeManagerNotifications({
     waiverApprovals: waiverApprovalNotifications(waitingWaivers),
     contactMessages: contactMessageNotifications(unreadContact),
+    digestStalled,
     interestRegistrations: interestRegistrationNotifications(newLeads),
     membershipWindows: windows,
   });

--- a/src/lib/manager-notifications.functions.ts
+++ b/src/lib/manager-notifications.functions.ts
@@ -64,35 +64,30 @@ async function membershipWindowNotifications(
  * its scheduler reports success no matter what the site answered. See
  * `digestStalledNotifications` and docs/notifications.md.
  *
+ * Three reads, in order, and each one only happens because the last said it had
+ * to: how big the backlog is, whether anything has been emailed at all lately,
+ * and how old the oldest waiting row is. A healthy club stops at the first.
+ *
+ * Exported for its own tests, the same as the three `countX` sources it sits
+ * alongside. `managerAttentionItems` is its only caller in the app.
+ *
  * Read here rather than in `notifications.functions.ts`, which owns every other
  * query against this table, on purpose: that module imports this one, and a
  * count reaching back the other way would put an import cycle between the page
  * and the list it renders. `membershipWindowNotifications` above already sets
  * the precedent that a source can do its own reading here.
  */
-async function digestBacklogNotifications(
+export async function digestBacklogNotifications(
   admin: MembershipClient,
   now: Date,
 ): Promise<ManagerNotification[]> {
   const cutoff = new Date(now.getTime() - DIGEST_STALL_HOURS * 3_600_000).toISOString();
-  const overdue = admin
+
+  const { count, error } = await admin
     .from("notifications")
     .select("id", { count: "exact", head: true })
     .is("emailed_at", null)
     .lt("created_at", cutoff);
-  const oldest = admin
-    .from("notifications")
-    .select("created_at")
-    .is("emailed_at", null)
-    .lt("created_at", cutoff)
-    .order("created_at", { ascending: true })
-    .limit(1)
-    .maybeSingle();
-
-  const [{ count, error }, { data: first, error: oldestError }] = await Promise.all([
-    overdue,
-    oldest,
-  ]);
   // Degrade rather than throw, exactly as the three counts below do: a failed
   // read here must not empty the queue around it. Reporting nothing is the safe
   // direction for this one specifically, since the alternative is telling a
@@ -102,7 +97,40 @@ async function digestBacklogNotifications(
     return [];
   }
   const stalled = count ?? 0;
+  // The quiet case is the common one, so it costs one query and stops here.
   if (stalled === 0) return [];
+
+  // A backlog alone does not mean the digest has stopped, and this is the
+  // difference between an alarm and a false alarm that can never be cleared.
+  // `sendDailyDigests` stamps per person and swallows one recipient's failure,
+  // so an address that bounces every night keeps ITS rows unstamped for good
+  // while everybody else is served. Those rows would otherwise pin an
+  // undismissable "the summary has stopped" item on a digest that is working.
+  //
+  // So: also require that NOTHING at all has been emailed inside the same
+  // window. Every row a run considers is stamped, including the ones a
+  // preference suppressed, so a single working run leaves evidence here even if
+  // it sent no mail. No evidence plus an ageing backlog is the real thing.
+  const { count: emailedRecently, error: recentError } = await admin
+    .from("notifications")
+    .select("id", { count: "exact", head: true })
+    .gte("emailed_at", cutoff);
+  if (recentError) {
+    console.error("[notifications] could not check for recent digest sends:", recentError);
+    return [];
+  }
+  if ((emailedRecently ?? 0) > 0) return [];
+
+  const { data: first, error: oldestError } = await admin
+    .from("notifications")
+    .select("created_at")
+    .is("emailed_at", null)
+    .lt("created_at", cutoff)
+    .order("created_at", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  // The count is the part the item cannot do without; a missing date only makes
+  // the copy vaguer, so this one degrades without giving up the item.
   if (oldestError) {
     console.error("[notifications] could not read the oldest unemailed row:", oldestError);
   }

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1220,12 +1220,17 @@ describe("digestStalledNotifications", () => {
   it("still renders when the oldest row could not be read", () => {
     // The count is what the item cannot do without. The oldest timestamp comes
     // from a second query that is allowed to fail on its own, so a missing date
-    // must make the copy vaguer rather than produce "the oldest since ."
+    // has to drop the clause that names it rather than leave the stump. The
+    // plural line used to read "..., the oldest. Nobody has had them." here,
+    // which a loose "does not contain a dangling since" check waved through.
     for (const oldestAt of [null, undefined]) {
-      const [n] = digestStalledNotifications({ stalled: 7, oldestAt });
-      expect(n.body).toContain("7 notifications");
-      expect(n.body).not.toMatch(/since\s*\./);
-      expect(n.body).not.toContain("undefined");
+      const [one] = digestStalledNotifications({ stalled: 1, oldestAt });
+      expect(one.body).toContain("One notification has been waiting to be emailed, and nobody");
+      const [many] = digestStalledNotifications({ stalled: 7, oldestAt });
+      expect(many.body).toContain(
+        "7 notifications have been waiting to be emailed, and nobody has had them.",
+      );
+      expect(many.body).not.toContain("the oldest");
     }
   });
 

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -18,6 +18,7 @@ import {
   composeManagerNotifications,
   markContactMessagesSeenSchema,
   contactMessageNotifications,
+  digestStalledNotifications,
   contactSchema,
   coverageSources,
   listContactMessagesSchema,
@@ -1184,32 +1185,97 @@ describe("waiverApprovalNotifications", () => {
   });
 });
 
+describe("digestStalledNotifications", () => {
+  it("says nothing while the backlog is empty", () => {
+    expect(digestStalledNotifications({ stalled: 0 })).toEqual([]);
+    expect(digestStalledNotifications({ stalled: -1 })).toEqual([]);
+  });
+
+  it("carries no button, because nothing on this site can fix it", () => {
+    // The whole point of the item. Both halves of the digest chain live outside
+    // the repo (a Supabase Vault secret and a project env var), so every
+    // destination the dashboard could offer would send a manager somewhere that
+    // cannot help. Before this kind existed, `href` and `actionLabel` were
+    // required and an item like this could not be expressed at all.
+    const [n] = digestStalledNotifications({ stalled: 4, oldestAt: "2026-08-05T23:00:00.000Z" });
+    expect(n.href).toBeUndefined();
+    expect(n.actionLabel).toBeUndefined();
+  });
+
+  it("names the count and the oldest waiting row", () => {
+    const [n] = digestStalledNotifications({ stalled: 34, oldestAt: "2026-08-05T23:00:00.000Z" });
+    expect(n.type).toBe("notification_digest_stalled");
+    expect(n.body).toContain("34 notifications");
+    // 9am Sydney on the 6th is still the 5th in UTC, and this string is built on
+    // the server. Same rule as the contact-message item above.
+    expect(n.body).toContain("since 06/08/2026");
+  });
+
+  it("reads as one thing for a backlog of one", () => {
+    const [n] = digestStalledNotifications({ stalled: 1, oldestAt: "2026-08-05T23:00:00.000Z" });
+    expect(n.body).toContain("One notification has been waiting");
+    expect(n.body).not.toContain("1 notifications");
+  });
+
+  it("still renders when the oldest row could not be read", () => {
+    // The count is what the item cannot do without. The oldest timestamp comes
+    // from a second query that is allowed to fail on its own, so a missing date
+    // must make the copy vaguer rather than produce "the oldest since ."
+    for (const oldestAt of [null, undefined]) {
+      const [n] = digestStalledNotifications({ stalled: 7, oldestAt });
+      expect(n.body).toContain("7 notifications");
+      expect(n.body).not.toMatch(/since\s*\./);
+      expect(n.body).not.toContain("undefined");
+    }
+  });
+
+  it("tells the reader nothing is lost, and where the fix is", () => {
+    // A manager reading this has just been told the club's email is broken. The
+    // two things they need are that the people affected can still see what they
+    // missed, and that hunting this site for a switch is wasted time.
+    const [n] = digestStalledNotifications({ stalled: 2, oldestAt: "2026-08-05T23:00:00.000Z" });
+    expect(n.body).toContain("Nothing is lost");
+    expect(n.body).toContain("outside the site");
+  });
+
+  it("writes copy without an em dash", () => {
+    // AGENTS.md: no em dashes in user-facing copy, and this item is on screen.
+    const [n] = digestStalledNotifications({ stalled: 2, oldestAt: "2026-08-05T23:00:00.000Z" });
+    expect(`${n.title} ${n.body}`).not.toContain("\u2014");
+  });
+});
+
 describe("composeManagerNotifications", () => {
   const waivers = waiverApprovalNotifications({ pending: 1, latestName: "Ada" });
   const contact = contactMessageNotifications({ unread: 1, latestName: "Sam" });
   const leads = interestRegistrationNotifications({ unread: 1, latestName: "Kim" });
   const windows = sellableWindowNotifications([], "2026-08-03T10:00:00.000Z");
+  const digest = digestStalledNotifications({ stalled: 3, oldestAt: "2026-08-01T22:00:00.000Z" });
   const quiet = {
     waiverApprovals: [],
     contactMessages: [],
+    digestStalled: [],
     interestRegistrations: [],
     membershipWindows: [],
   };
 
   it("orders the queue by who is held up, and for how long", () => {
     // A signed waiver blocks somebody from starting, an unanswered message has
-    // somebody waiting on a reply, a new registration has nobody waiting on
+    // somebody waiting on a reply, a stalled digest has every member quietly
+    // missing email but nobody blocked, a new registration has nobody waiting on
     // anything, and the training window is a chore that announces itself weeks
     // ahead. This is the whole reason the order is a function.
     const all = composeManagerNotifications({
       waiverApprovals: waivers,
       contactMessages: contact,
+      digestStalled: digest,
       interestRegistrations: leads,
       membershipWindows: windows,
     });
     expect(all.map((n) => n.type)).toEqual([
       "waivers_awaiting_approval",
       "unread_contact_messages",
+      "notification_digest_stalled",
       "new_interest_registrations",
       "define_membership_window",
     ]);
@@ -1228,6 +1294,9 @@ describe("composeManagerNotifications", () => {
     expect(
       composeManagerNotifications({ ...quiet, interestRegistrations: leads }).map((n) => n.type),
     ).toEqual(["new_interest_registrations"]);
+    expect(
+      composeManagerNotifications({ ...quiet, digestStalled: digest }).map((n) => n.type),
+    ).toEqual(["notification_digest_stalled"]);
     expect(composeManagerNotifications(quiet)).toEqual([]);
   });
 });

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1782,10 +1782,16 @@ export function digestStalledNotifications(input: {
   const { stalled, oldestAt } = input;
   if (stalled <= 0) return [];
   const since = clubDaySuffix(oldestAt, "since");
+  // The plural line names the oldest row's date, so it needs a second form for
+  // when there is no date to name: the timestamp comes from a query that is
+  // allowed to fail on its own, and "the oldest. Nobody has had them." is not a
+  // sentence. The singular reads correctly either way.
   const waiting =
     stalled === 1
       ? `One notification has been waiting to be emailed${since}, and nobody has had it.`
-      : `${stalled} notifications have been waiting to be emailed, the oldest${since}. Nobody has had them.`;
+      : since
+        ? `${stalled} notifications have been waiting to be emailed, the oldest${since}. Nobody has had them.`
+        : `${stalled} notifications have been waiting to be emailed, and nobody has had them.`;
   return [
     {
       type: "notification_digest_stalled",

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1506,19 +1506,35 @@ export type ManagerNotification = {
     | "define_membership_window"
     | "unread_contact_messages"
     | "waivers_awaiting_approval"
-    | "new_interest_registrations";
+    | "new_interest_registrations"
+    | "notification_digest_stalled";
   title: string;
   body: string;
-  href: string;
+} & (
+  | {
+      href: string;
+      /**
+       * What the item's button says. Carried here rather than fixed in the
+       * dashboard, because the right verb depends on the item: unset training
+       * dates really do need fixing, an unanswered message needs reading.
+       * Required alongside `href`, not optional-with-a-default, so adding a kind
+       * of notification cannot silently inherit a verb that does not fit it.
+       */
+      actionLabel: string;
+    }
   /**
-   * What the item's button says. Carried here rather than fixed in the
-   * dashboard, because the right verb depends on the item: unset training dates
-   * really do need fixing, an unanswered message needs reading. Required, not
-   * optional-with-a-default, so adding a kind of notification cannot silently
-   * inherit a verb that does not fit it.
+   * An item with nowhere to send anybody. The pair is all-or-nothing rather
+   * than two independent optionals, so an item can carry a destination with no
+   * verb or a verb with no destination only by failing the typecheck.
+   *
+   * Only one kind uses this today, and the reason is the whole point of it: a
+   * stalled digest is fixed outside the site entirely, so every button the
+   * dashboard could offer would be a lie. Confirming everything trains people
+   * to click through without reading, and a button that does nothing trains
+   * them to ignore buttons. `notifications.tsx` renders the card without one.
    */
-  actionLabel: string;
-};
+  | { href?: undefined; actionLabel?: undefined }
+);
 
 /**
  * The membership-window notifications: training is unsellable while no dated
@@ -1564,7 +1580,9 @@ export function sellableWindowNotifications<
 
 /**
  * " on 06/08/2026" for a notification body, resolved to the CLUB's day rather
- * than the server's, or "" when the timestamp could not be read.
+ * than the server's, or "" when the timestamp could not be read. `preposition`
+ * is there because the backlog item reads " since 06/08/2026"; the day itself
+ * is worked out identically and there is no reason for two of these.
  *
  * These strings are built inside `listMyNotifications`, so they render on the
  * server (UTC) while the screen each one links to formats the same timestamp in
@@ -1574,8 +1592,8 @@ export function sellableWindowNotifications<
  * on, which is exactly what `formatDateOnly` is for, and being pure it also
  * drops the dependency on the runtime having full ICU.
  */
-function clubDaySuffix(at: string | null | undefined): string {
-  return at ? ` on ${formatDateOnly(clubLocalDate(new Date(at), CLUB_TIME_ZONE))}` : "";
+function clubDaySuffix(at: string | null | undefined, preposition: string = "on"): string {
+  return at ? ` ${preposition} ${formatDateOnly(clubLocalDate(new Date(at), CLUB_TIME_ZONE))}` : "";
 }
 
 /**
@@ -1726,6 +1744,62 @@ export function contactMessageNotifications(input: {
 }
 
 /**
+ * How long a notification may sit unemailed before the daily summary counts as
+ * broken. The digest runs once a day, so anything under 24 hours is simply
+ * waiting for tonight's run and is not news. 36 gives a run a full extra half
+ * day to be late, delayed or retried before a manager is told about it, and
+ * still catches a digest that has missed two mornings.
+ */
+export const DIGEST_STALL_HOURS = 36;
+
+/**
+ * The daily summary has stopped going out.
+ *
+ * This asserts on the OUTCOME, not on the mechanism, which is the only kind of
+ * check that works here. The digest is a pg_cron job that POSTs to
+ * `/api/notifications/digest` with pg_net, and pg_net is fire and forget: the
+ * job records `succeeded` whether the site answered 200, 401, 503 or nothing at
+ * all, so the scheduler's own view of itself is worthless. Every failure mode
+ * (Vault secret missing, key drifted from the env var, endpoint unconfigured
+ * and answering 503, site down, DNS or TLS failing, request timing out) shows
+ * up the same way here: rows keep their NULL `emailed_at` and the backlog ages.
+ *
+ * Deliberately carries no button. Nothing on this site can fix it: both halves
+ * of the chain live outside the repo, in Supabase Vault and the Lovable Cloud
+ * project secrets. See docs/notifications.md for the runbook.
+ *
+ * It also cannot be dismissed, which is the point of an attention item and is
+ * worth saying out loud here because this one can stay up for a long time. It
+ * clears when the digest actually sends, or when somebody stamps the backlog as
+ * emailed to start clean. A club that decides not to email at all clears it the
+ * same way. Hiding it while members silently get no email is the one outcome
+ * this exists to prevent.
+ */
+export function digestStalledNotifications(input: {
+  stalled: number;
+  oldestAt?: string | null;
+}): ManagerNotification[] {
+  const { stalled, oldestAt } = input;
+  if (stalled <= 0) return [];
+  const since = clubDaySuffix(oldestAt, "since");
+  const waiting =
+    stalled === 1
+      ? `One notification has been waiting to be emailed${since}, and nobody has had it.`
+      : `${stalled} notifications have been waiting to be emailed, the oldest${since}. Nobody has had them.`;
+  return [
+    {
+      type: "notification_digest_stalled",
+      title: "The daily email summary has stopped going out",
+      // Says what is safe before what is broken: the people affected have lost
+      // an email, not the thing the email was about. Then where the fix is,
+      // because it is not here and a manager hunting the site for a switch
+      // would be hunting for something that does not exist.
+      body: `${waiting} Nothing is lost, everyone can still see them on their own notifications page. Starting the summary again is done outside the site, so pass this on to whoever set it up.`,
+    },
+  ];
+}
+
+/**
  * The order a manager meets the "needs attention" items in.
  *
  * Sorted by who is held up and for how long:
@@ -1734,9 +1808,15 @@ export function contactMessageNotifications(input: {
  *    presses the button. They are stuck, and only this list says so.
  * 2. **Unanswered messages.** Somebody is waiting on a reply, but nothing about
  *    them is blocked in the meantime.
- * 3. **New interest registrations.** Nobody is waiting on anything. It is news,
- *    and it sits below the two items that are work.
- * 4. **The membership window.** A chore that announces itself weeks ahead.
+ * 3. **The stalled digest.** Nobody is blocked from training, but every member
+ *    the club owes an email is quietly not getting one, and it has been that
+ *    way for at least a day and a half. It sits below the two items where a
+ *    named person is waiting on a specific manager action, and above the two
+ *    where nobody is affected yet. Its own body says the fix is not on this
+ *    site; that is a reason to rank it honestly, not to bury it.
+ * 4. **New interest registrations.** Nobody is waiting on anything. It is news,
+ *    and it sits below the items that are work.
+ * 5. **The membership window.** A chore that announces itself weeks ahead.
  *
  * Kept as a function rather than an inline spread in the handler so the priority
  * is a decision with a test on it, not an accident of argument order.
@@ -1744,12 +1824,14 @@ export function contactMessageNotifications(input: {
 export function composeManagerNotifications(sources: {
   waiverApprovals: ManagerNotification[];
   contactMessages: ManagerNotification[];
+  digestStalled: ManagerNotification[];
   interestRegistrations: ManagerNotification[];
   membershipWindows: ManagerNotification[];
 }): ManagerNotification[] {
   return [
     ...sources.waiverApprovals,
     ...sources.contactMessages,
+    ...sources.digestStalled,
     ...sources.interestRegistrations,
     ...sources.membershipWindows,
   ];

--- a/src/routes/_authenticated/notifications.test.tsx
+++ b/src/routes/_authenticated/notifications.test.tsx
@@ -165,6 +165,29 @@ describe("/notifications", () => {
     expect(screen.queryByRole("link", { name: /fix it/i })).not.toBeInTheDocument();
   });
 
+  it("renders an item with no action as a statement, not a dead button", async () => {
+    // A stalled digest is fixed in the project's own settings, outside this site
+    // entirely, so there is nowhere to send anybody. The item still has to be on
+    // screen: the whole failure it reports is that nothing said anything.
+    mockPayload({
+      attention: [
+        {
+          type: "notification_digest_stalled" as const,
+          title: "The daily email summary has stopped going out",
+          body: "34 notifications have been waiting to be emailed, the oldest since 05/08/2026.",
+        },
+      ],
+      isManager: true,
+    });
+    render(<NotificationsPage />);
+
+    expect(
+      await screen.findByText("The daily email summary has stopped going out"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /mark all as read/i })).not.toBeInTheDocument();
+  });
+
   it("shows both steps of signing up, one to read and one to approve", async () => {
     // Somebody signing up used to reach this page not at all. Registering is
     // news and offers only a reading verb; a signed waiver is work and blocks

--- a/src/routes/_authenticated/notifications.tsx
+++ b/src/routes/_authenticated/notifications.tsx
@@ -138,9 +138,15 @@ function NotificationsPage() {
                   <p className="font-medium">{n.title}</p>
                   <p className="mt-1 text-sm text-muted-foreground">{n.body}</p>
                 </div>
-                <Button asChild size="sm" variant="outline">
-                  <Link to={n.href}>{n.actionLabel}</Link>
-                </Button>
+                {/* Not every item has somewhere to send you. A stalled digest
+                    is fixed in the project's own settings, outside this site
+                    entirely, so it renders as a statement rather than a button
+                    that would go nowhere useful. See `ManagerNotification`. */}
+                {n.href && n.actionLabel && (
+                  <Button asChild size="sm" variant="outline">
+                    <Link to={n.href}>{n.actionLabel}</Link>
+                  </Button>
+                )}
               </div>
             ))}
           </CardContent>

--- a/supabase/migrations/20260821000000_notification_digest_fails_loudly.sql
+++ b/supabase/migrations/20260821000000_notification_digest_fails_loudly.sql
@@ -1,0 +1,110 @@
+-- The nightly digest job stops reporting success when it did nothing.
+--
+-- WHY. `private.run_notification_digest()` (20260807000000) reads two Vault
+-- secrets and returns early when either is missing, with a RAISE WARNING. That
+-- fail-closed posture is right and is not what this changes. What it changes is
+-- what the SCHEDULER is told: a plpgsql function that RETURNs is a function that
+-- succeeded, so `cron.job_run_details` records `succeeded` for every night the
+-- digest has never been armed. As of this migration that is every night since
+-- 20260807000000 was applied, and nothing anywhere has said so. The warning goes
+-- to the Postgres log, which nobody reads on a schedule.
+--
+-- A green tick that means "the code ran" rather than "the work happened" is the
+-- pattern this repo has been bitten by before (see the Migration drift note in
+-- CLAUDE.md, which reports green while checking nothing). RAISE EXCEPTION makes
+-- pg_cron record `failed` with the message, which is the truth: the job did not
+-- do its job.
+--
+-- WHAT THIS DOES NOT FIX. pg_net is fire and forget, so an ARMED job still
+-- reports success whatever the site answered (401, 503, timeout, DNS failure).
+-- Reading the response back wants a second scheduled job and somewhere durable
+-- to keep the verdict, since `net._http_response` is garbage-collected after
+-- `pg_net.ttl` (6 hours). That is still not built. What IS now built is a check
+-- on the OUTCOME rather than the mechanism: the manager notifications page
+-- raises a "needs attention" item when any notification row has sat unemailed
+-- for more than 36 hours, which catches every one of those failure modes plus
+-- this one. See `digestStalledNotifications` in src/lib/validation.ts.
+--
+-- IF THE CLUB DOES NOT WANT THE DIGEST, the answer is to unschedule the job
+-- (`SELECT cron.unschedule('notification-digest');`), not to leave it failing
+-- nightly. A permanent red is a signal nobody reads either.
+--
+-- SEQUENCING. Replaces one function body. Nothing is dropped, no policy is
+-- narrowed, no table or column changes, and the schedule itself is untouched.
+-- The only visible effect is that an unarmed run is recorded as failed instead
+-- of succeeded. Applying it cannot start emailing anybody: the fail-closed
+-- branch still returns without calling out, it just raises on the way.
+--
+-- No `NOTIFY pgrst, 'reload schema'` at the end: `private` is not in PostgREST's
+-- db-schemas, so there is nothing in this file for PostgREST to have cached.
+
+CREATE OR REPLACE FUNCTION private.run_notification_digest()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+-- Empty search_path with fully-qualified names throughout: a SECURITY DEFINER
+-- function without this is the `function_search_path_mutable` advisor finding,
+-- which fails supabase-lint at WARN. See supabase/lint/README.md.
+SET search_path = ''
+AS $$
+DECLARE
+  digest_url TEXT;
+  digest_key TEXT;
+  missing TEXT[] := ARRAY[]::TEXT[];
+BEGIN
+  -- `vault.decrypted_secrets`, NOT `vault.secrets`. The latter's `secret`
+  -- column is the ciphertext; only the view exposes `decrypted_secret`. Reading
+  -- the wrong one would send the site an Authorization header of base64 noise
+  -- and get a 401 every morning.
+  SELECT decrypted_secret INTO digest_url
+    FROM vault.decrypted_secrets WHERE name = 'notification_digest_url';
+  SELECT decrypted_secret INTO digest_key
+    FROM vault.decrypted_secrets WHERE name = 'notification_digest_key';
+
+  -- Fail closed AND fail loudly. Closed because a digest endpoint anybody can
+  -- POST to is a way to make the club email its own members on demand, and loud
+  -- because an unconfigured job that reports success is how a digest silently
+  -- stops going out for a month.
+  --
+  -- Naming the secrets that are actually missing, rather than both every time,
+  -- is the difference between a message somebody can act on and one they have
+  -- to go and investigate. Half-configured is the likelier state of the two:
+  -- the URL and the key are added by separate steps, and the key also has to
+  -- match a server env var that is set somewhere else again.
+  IF digest_url IS NULL THEN
+    missing := missing || 'notification_digest_url';
+  END IF;
+  IF digest_key IS NULL THEN
+    missing := missing || 'notification_digest_key';
+  END IF;
+  IF array_length(missing, 1) IS NOT NULL THEN
+    RAISE EXCEPTION
+      'notification digest not armed: missing vault secret(s) %. No email has been sent. See docs/notifications.md.',
+      array_to_string(missing, ', ');
+  END IF;
+
+  -- Fire and forget: pg_net queues the request and the response lands in
+  -- `net._http_response`. The endpoint is idempotent per person per day (the
+  -- digest-<user>-<date> key), so a retry after a timeout cannot double-send.
+  -- The timeout is generous because the run emails every recipient inline.
+  --
+  -- ⚠️ Reaching this line is NOT evidence that anybody was emailed. The request
+  -- id is discarded and the function returns successfully whatever the site
+  -- answers. The backlog check on the notifications page is what actually
+  -- watches this.
+  PERFORM net.http_post(
+    url := digest_url,
+    body := '{}'::jsonb,
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || digest_key
+    ),
+    timeout_milliseconds := 300000
+  );
+END;
+$$;
+
+-- CREATE OR REPLACE keeps the existing ACL, so this re-asserts rather than
+-- restores. It stays because the grant matters more than the duplication:
+-- nobody but the scheduler needs to be able to make the site email everybody.
+REVOKE ALL ON FUNCTION private.run_notification_digest() FROM PUBLIC;


### PR DESCRIPTION
Closes nothing on its own: #69 is a configuration problem and this PR cannot configure anything. What it does is make the failure visible, and write down the exact steps to fix it.

I asked Lovable to check the live project read-only, so the numbers below are confirmed rather than assumed.

## What a manager sees

A new card on `/notifications`, under "Needs attention":

> **The daily email summary has stopped going out**
> 34 notifications have been waiting to be emailed, the oldest since 10/08/2026. Nobody has had them. Nothing is lost, everyone can still see them on their own notifications page. Starting the summary again is done outside the site, so pass this on to whoever set it up.

Three deliberate things about it:

- **No button.** Both halves of the fix live outside this site (a Lovable project secret and a Supabase Vault secret), so every destination the page could offer would be one that cannot help. This is the first attention item with no action, so `href` and `actionLabel` are now an all-or-nothing pair rather than two required fields.
- **It cannot be dismissed**, like every attention item, and unlike the others it can stay up for weeks. It clears when the digest actually sends, or when the backlog is stamped as emailed.
- **It will be showing the moment this ships**, because the digest has genuinely never sent. That is not a false positive.

Nothing changes for members. No email goes out as a result of this PR.

## Live state, confirmed 2026-08-21

| | |
| --- | --- |
| `NOTIFICATION_DIGEST_KEY` | **Not set.** The project holds three secrets and this is not one of them, so `/api/notifications/digest` is answering 503 to everything. |
| `notification_digest_url` in Vault | **Absent.** |
| `notification_digest_key` in Vault | **Absent.** |
| pg_cron | Installed. Job `notification-digest` active, `0 20 * * *`, command `SELECT private.run_notification_digest()`. |
| pg_net | Installed, extension home `extensions`, functions in `net` — which is exactly what the cron migration asserts. |
| Last 5 runs (17–21 Aug) | All **succeeded**, return message `1 row`, having done nothing. |
| Backlog | **34 rows**, 2026-08-10 12:53 UTC to 2026-08-20 03:09 UTC. |

So the issue's figures were right, including the 34 and the eleven days.

## What is broken vs. what is merely unconfigured

I also checked the issue's claims against the repo. They hold up:

| Claim | Verdict |
| --- | --- |
| The migration schedules the job and does not arm it | Correct. `20260807000000_notification_digest_cron.sql` carries the `⚠️ THIS MIGRATION DOES NOT ARM THE DIGEST` header verbatim. |
| The cron function fail-closes on missing Vault secrets | Correct. `RAISE WARNING` then `RETURN`, before any `net.http_post`. |
| The endpoint answers 503 with `NOTIFICATION_DIGEST_KEY` unset | Correct, and deliberately 503 rather than 401. |
| pg_cron records the fail-closed return as `succeeded` | Correct, and confirmed live: five nights of green for a job that did nothing. |
| Arming it as-is would release the whole backlog at once | Correct. `sendDailyDigests` selects on `emailed_at IS NULL` with no age bound (cap 5000 rows), grouped per person. |

One small correction: the observability note is at `src/routes/api/notifications/digest.ts:52-55`, not `:50-53`.

**Nothing is broken in the code.** Both halves fail closed exactly as designed. What is missing is the configuration, and what was missing in the code is any way to notice that.

**Have members been silently missing emails?** Yes, but only the batched kinds. Instant reply emails do not go through the digest, so a reply to your comment still emailed you. Everything batched (new post announcements, thread activity, moderation alerts) has never been emailed to anybody. The backlog dates put that at **eleven days and counting**, but that is only how long rows have been accumulating, not how long it has been broken: it has never worked.

## The two changes

**1. The attention item** (`digestStalledNotifications`, `DIGEST_STALL_HOURS = 36`). Asserts on the outcome, not the mechanism. pg_net is fire and forget, so the scheduler's view of itself is worthless: Vault secret missing, key drifted from the env var, endpoint 503, site down, DNS/TLS failure and timeout all look identical from the database. They also all look identical here, as a backlog that ages, which is what makes this check cheap and total. 36 hours rather than 24 because a daily run that is a few hours late is not news; two missed mornings is.

It takes a second reading before it accuses anything: it also requires that **nothing at all** has been emailed inside the same window. `sendDailyDigests` swallows a per-recipient failure and deliberately leaves that person's rows unstamped so tomorrow retries, so one bouncing address would otherwise pin an undismissable "the summary has stopped" on a digest that is working for everybody else.

**2. A migration, not applied.** `supabase/migrations/20260821000000_notification_digest_fails_loudly.sql` replaces `private.run_notification_digest()` so the unarmed branch raises instead of returning, naming whichever Vault secret is missing. `cron.job_run_details` then says `failed` for a job that emailed nobody, instead of the five greens above.

> [!IMPORTANT]
> **A human applies this, per `docs/database-changes.md`.** I have not run it. It replaces one function body: nothing dropped, no policy narrowed, no table or column touched, and the schedule itself untouched. Applying it cannot start emailing anybody, since the fail-closed branch still returns without calling out, it just raises on the way. Its only visible effect is that an unarmed run is recorded as failed instead of succeeded.
>
> **If the club decides not to arm the digest at all**, the answer is `SELECT cron.unschedule('notification-digest');`, not leaving it red every night. A permanent red is a signal nobody reads either.

Also: the e2e seed now stamps `emailed_at` on its notification rows, so the fixture keeps looking like a club whose digest works instead of putting the new "stopped going out" card in every screenshot.

## The runbook

Also in `docs/notifications.md`, which is where it will still be findable in six months. Nothing here can be done from this repo, and the details below are Lovable's own answers about how this project is wired.

**Step 1. Set the server env var.** In Lovable, **Project Settings → Secrets**, add `NOTIFICATION_DIGEST_KEY`. That screen is the only place it goes: there is no separate environment-variable screen, and it must not go in `.env`, which is committed (`scripts/check-committed-env.mjs` already knows this key by name and would fail the commit and CI). Generate it yourself and treat it as a credential; `openssl rand -hex 32` is fine. You need the identical string in Vault at step 3, so keep it somewhere you can copy from.

Preview and the published site read the same secret store, but the deployed `jitsu.au` build only picks up a new value on the next publish, so **publish (Publish → Update) before going further**. Then:

```sh
curl -si -X POST https://jitsu.au/api/notifications/digest      # expect 401, NOT 503
```

503 means the value has not reached the deployed server. 401 means it has.

**Step 2. Decide what happens to the 34 backlogged rows, before step 3.** This is a product call, and it has to be made first. Arming with the backlog in place sends every waiting row at once, as one email per person, including announcements from 10 August. That is the send that gets `notify.jitsu.au` marked as spam, and the club depends on that domain for magic links and account activation (#52).

Recommended: start clean.

```sql
-- Stamp the backlog as emailed WITHOUT sending it. Run this BEFORE arming.
UPDATE public.notifications
   SET emailed_at = now()
 WHERE emailed_at IS NULL
   AND created_at < now() - interval '36 hours';
```

Nobody loses anything: the rows stay on each person's `/notifications` page either way, because `emailed_at` governs the inbox only. The alternative is to let them send, which is a decision, not a default.

**Step 3. Add the two Vault secrets.** There is no Vault UI on Lovable Cloud, so this is SQL. The key must match step 1 **exactly**, and the URL must be the `jitsu.au` origin, not the `*.lovable.app` one (that 302s, and pg_net does not follow redirects):

```sql
SELECT vault.create_secret(
  'https://jitsu.au/api/notifications/digest', 'notification_digest_url');
SELECT vault.create_secret('<the same value as NOTIFICATION_DIGEST_KEY>',
  'notification_digest_key');
```

Env var first, then Vault: while Vault is empty the job returns without posting anything, so that order has no bad window. The reverse gives a night of the job POSTing into a 503.

**Step 4. Prove the first send, without waiting for 20:00 UTC.** Run it by hand and read the response back inside pg_net's 6-hour TTL:

```sql
SELECT private.run_notification_digest();          -- raises if a secret is missing
SELECT id, status_code, content, error_msg, created
  FROM net._http_response ORDER BY created DESC LIMIT 1;
```

`status_code` 200 with a body like `{"ok":true,"considered":N,"recipients":M,"sent":M}` is the answer you want, and `sent` is the count of people who actually got an email. 401 means the two copies of the key differ. 503 means step 1 did not take. 302 means the URL is the `*.lovable.app` host. A row with `error_msg` and no status is a network or TLS failure.

**Step 5. Confirm the next scheduled run**, the morning after:

```sql
SELECT status, return_message, start_time FROM cron.job_run_details
 WHERE jobname = 'notification-digest' ORDER BY start_time DESC LIMIT 3;
SELECT count(*) FROM public.notifications WHERE emailed_at IS NULL;
```

`succeeded` on its own still is not proof, even after this PR: it only ever proves the job ran. The backlog not climbing is the proof. The new attention card is the standing version of that second query: it disappears once the backlog is clear and stays away while it is kept clear.

Rotating the key later means changing it in **both** places in the same sitting (`vault.update_secret` for the Vault copy), or every run 401s until they agree.

## Still not built

A second job that reads `net._http_response` back and raises on a non-2xx, so an **armed** failure lands in `cron.job_run_details` that same night rather than a day and a half later on the notifications page. It needs somewhere durable to keep the verdict, since pg_net garbage-collects that table after `pg_net.ttl`. The backlog check covers the same failures more slowly, which is why this is worth doing and not urgent. Written up in `docs/notifications.md`.

## Checks

`bun run deps`, `bun run lint`, `bun run typecheck`, `bun run test` (2040 passing, 109 files), `bun run build` all green locally. `bun.lock` untouched.

New tests: `manager-notifications.functions.test.ts` pins the discrimination that matters (it fires while the digest has never been armed, and stays quiet while the digest is delivering to somebody), plus the builder's copy and date handling, the no-button case, the queue ordering, and the page rendering an action-less item as a statement rather than a dead button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ET5aaZauFf6PjybLbVGu3Z