### PR TITLE
Remove the manager agent API's environment-key auth path

### DIFF
--- a/.claude/skills/uts-manager-agent/SKILL.md
+++ b/.claude/skills/uts-manager-agent/SKILL.md
@@ -33,9 +33,9 @@ of truth for the current action set.
 
 - `UTS_MANAGER_API_URL` — the site's base URL, e.g. `https://jitsu.au`
 - `UTS_MANAGER_API_KEY` — a manager agent token. A manager mints one at
-  **`/manager/api-tokens`** on the site (it's shown once — copy it then). A
-  server-side `MANAGER_AGENT_API_KEY` env var also works as a break-glass
-  fallback.
+  **`/manager/api-tokens`** on the site (it's shown once — copy it then). That is
+  the only kind of token the endpoint accepts: there is no server-side
+  environment-variable fallback, so a lost token means minting a new one.
 
 The endpoint is `POST $UTS_MANAGER_API_URL/api/manager/agent`. Every request
 sends `Authorization: Bearer $UTS_MANAGER_API_KEY`.

--- a/.claude/skills/uts-manager-agent/scripts/agent.sh
+++ b/.claude/skills/uts-manager-agent/scripts/agent.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 : "${UTS_MANAGER_API_URL:?set UTS_MANAGER_API_URL, e.g. https://jitsu.au}"
-: "${UTS_MANAGER_API_KEY:?set UTS_MANAGER_API_KEY (server MANAGER_AGENT_API_KEY)}"
+: "${UTS_MANAGER_API_KEY:?set UTS_MANAGER_API_KEY (mint one at /manager/api-tokens)}"
 
 endpoint="${UTS_MANAGER_API_URL%/}/api/manager/agent"
 action="${1:-manifest}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -704,10 +704,6 @@ The app reads:
   `VITE_SUPABASE_PROJECT_ID`.
 - Server: `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
   (admin client only), plus `LOVABLE_API_KEY` / `LOVABLE_SEND_URL` for auth email.
-- Server, optional: `MANAGER_AGENT_API_KEY` — break-glass bearer token for the
-  manager agent API (`/api/manager/agent`). Normally managers mint revocable
-  tokens at `/manager/api-tokens` (stored hashed in `manager_api_tokens`); this
-  env var is just an optional fallback (see `docs/manager-agent-api.md`).
 - Server, optional: `NOTIFICATION_DIGEST_KEY` — bearer token for the daily
   notification digest (`POST /api/notifications/digest`). **Unset means the
   endpoint refuses everything**, so no digest goes out until it is configured.

--- a/docs/manager-agent-api.md
+++ b/docs/manager-agent-api.md
@@ -18,11 +18,17 @@ driven directly by the bundled skill.
   `_authenticated/manager.api-tokens.tsx`). Only a SHA-256 hash is stored
   (`manager_api_tokens` table); the raw token is shown once at creation. On each
   request the endpoint looks the token up by hash, confirms it isn't revoked, and
-  re-checks the owner still holds the `manager` role. A `MANAGER_AGENT_API_KEY`
-  env var is accepted as an **optional break-glass fallback** (e.g. bootstrap /
-  CI); it is not required. The endpoint runs actions with the service-role
-  client, so a token grants manager-level access to the exposed actions — treat
-  it as a secret.
+  re-checks the owner still holds the `manager` role. The endpoint runs actions
+  with the service-role client, so a token grants manager-level access to the
+  exposed actions — treat it as a secret.
+  - **A minted token is the only credential this endpoint accepts.** There is no
+    environment-variable fallback and there should not be one: an env key cannot
+    be revoked without a redeploy, is stored in plaintext, never expires, is not
+    re-checked against the owner's role, and belongs to nobody — so anything it
+    wrote (a filed waiver, a published article) named no auth user. If every
+    token is lost, a manager signs in and mints another at `/manager/api-tokens`;
+    that needs only a manager login, which is why no separate break-glass
+    mechanism is warranted. Please do not add one back.
   - Token management server functions: `src/lib/manager-api-tokens.functions.ts`
     (`listApiTokens` / `createApiToken` / `revokeApiToken`); token crypto +
     the paste-able agent prompt: `src/lib/manager-api-tokens.ts`.
@@ -109,9 +115,9 @@ An "invoice" is a `memberships` row — its price/reference/status _are_ the inv
   **pending**: it never approves, emails anyone, or marks the email verified
   — approving is a separate, deliberate manager action because it promotes
   the record, unlocks the login, emails them that their account is active and
-  assigns the free trial (docs/waivers.md rule 6). `uploaded_by` on the filed row is the
-  token's owner, or the `AGENT_ENV_KEY_UPLOADER` sentinel for the break-glass
-  env key, which has no owner to resolve. Filing a waiver the person already
+  assigns the free trial (docs/waivers.md rule 6). `uploaded_by` on the filed row is always
+  the token's owner: a waiver is legal evidence, so every filing names the
+  manager who vouched for the scan. Filing a waiver the person already
   has for the same `signed_on` is refused with `409 duplicate_waiver` (the
   colliding rows come back in `error.existing`); `confirm_duplicate` files it
   anyway, for the corrected re-scan that is a genuine second document. The

--- a/src/lib/kb-admin.test.ts
+++ b/src/lib/kb-admin.test.ts
@@ -257,12 +257,13 @@ describe("saveKbArticle", () => {
     expect(promote).toHaveLength(1);
   });
 
-  // The break-glass agent key authenticates as a non-UUID sentinel with no auth
-  // user behind it; writing it into a `references auth.users` column fails the
-  // insert outright.
-  it("records no author when the actor is not a real user id", async () => {
+  // `created_by` is a real FK to auth.users, so a caller with nobody behind it
+  // records no author rather than a stand-in. Every caller in the app resolves
+  // to a real manager (the manager agent API has no environment-key fallback any
+  // more), which is exactly why a non-id must never be invented for this column.
+  it("records no author when there is no actor", async () => {
     const { db, calls } = saveHarness({ existing: null, maxVersion: 0 });
-    await saveKbArticle(db, baseInput, "manager-agent-env-key");
+    await saveKbArticle(db, baseInput, null);
     expect(inserts(calls, "kb_articles")[0].values).toMatchObject({ created_by: null });
     expect(inserts(calls, "kb_article_versions")[0].values).toMatchObject({ created_by: null });
   });
@@ -333,16 +334,6 @@ describe("saveKbArticle", () => {
     await expect(
       saveKbArticle(db, { ...baseInput, expect_new: true }, null),
     ).resolves.toMatchObject({ created: true, version: 1 });
-  });
-
-  // The break-glass agent key authenticates as a non-UUID sentinel with no auth
-  // user behind it; writing it into a `references auth.users` column fails the
-  // insert outright.
-  it("records no author when the actor is not a real user id", async () => {
-    const { db, calls } = saveHarness({ existing: null, maxVersion: 0 });
-    await saveKbArticle(db, baseInput, "manager-agent-env-key");
-    expect(inserts(calls, "kb_articles")[0].values).toMatchObject({ created_by: null });
-    expect(inserts(calls, "kb_article_versions")[0].values).toMatchObject({ created_by: null });
   });
 });
 

--- a/src/lib/kb-admin.ts
+++ b/src/lib/kb-admin.ts
@@ -16,7 +16,6 @@ import type {
   KbSectionRow,
 } from "@/lib/kb-types";
 import type { SaveKbArticleInput, SaveKbSectionInput } from "@/lib/validation";
-import { actorUserId } from "@/lib/manager-agent";
 
 /** An article together with the version being read. */
 export type LoadedArticle = {
@@ -234,7 +233,6 @@ export async function saveKbArticle(
   input: SaveKbArticleInput,
   actingAs: string | null,
 ): Promise<{ slug: string; version: number | null; article_id: string; created: boolean }> {
-  const createdBy = actorUserId(actingAs);
   const sectionId = await resolveSectionId(db, input.section);
 
   const { data: existing, error: findErr } = await db
@@ -323,7 +321,7 @@ export async function saveKbArticle(
         position: input.position ?? 0,
         nav_title: input.nav_title || null,
         link_path: input.link_path || null,
-        created_by: createdBy,
+        created_by: actingAs,
       })
       .select("*")
       .single();
@@ -420,7 +418,7 @@ export async function saveKbArticle(
         body_md: text.body_md,
         change_note: input.change_note || null,
         is_current: false,
-        created_by: createdBy,
+        created_by: actingAs,
       })
       .select("id, version")
       .single();

--- a/src/lib/manager-agent.test.ts
+++ b/src/lib/manager-agent.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  AGENT_ENV_KEY_UPLOADER,
   AGENT_MANIFEST,
-  actorUserId,
   AgentError,
   bearerToken,
   buildInvoicePatch,
@@ -540,14 +538,6 @@ describe("AGENT_MANIFEST", () => {
   });
 });
 
-describe("AGENT_ENV_KEY_UPLOADER", () => {
-  it("is not a UUID, so filePaperWaiver knows to skip resolving it to a real user", () => {
-    expect(AGENT_ENV_KEY_UPLOADER).not.toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
-    );
-  });
-});
-
 describe("AgentError", () => {
   it("carries an http status and a machine code", () => {
     const e = new AgentError(401, "unauthorized", "nope");
@@ -672,24 +662,5 @@ describe("projectAgentWaiverTemplate", () => {
       title: "Training Waiver",
       created_at: "2026-08-01T00:00:00Z",
     });
-  });
-});
-
-describe("actorUserId", () => {
-  // Every column this feeds `references auth.users`, so the sentinel the
-  // break-glass env key authenticates as must never reach one: the insert would
-  // fail outright, taking a waiver filing or a published article with it.
-  it("refuses the break-glass sentinel, which is no auth user", () => {
-    expect(actorUserId(AGENT_ENV_KEY_UPLOADER)).toBeNull();
-  });
-
-  it("records a real manager", () => {
-    const id = "63ab09b5-20e4-451a-ad8e-08caa0c299a2";
-    expect(actorUserId(id)).toBe(id);
-  });
-
-  it("treats no actor at all as no author", () => {
-    expect(actorUserId(null)).toBeNull();
-    expect(actorUserId("")).toBeNull();
   });
 });

--- a/src/lib/manager-agent.ts
+++ b/src/lib/manager-agent.ts
@@ -854,35 +854,6 @@ export const AGENT_MANIFEST: {
 };
 
 /**
- * The `uploaded_by` recorded on a waiver filed through the break-glass
- * `MANAGER_AGENT_API_KEY` fallback, which authenticates without resolving to
- * any real auth user. Not a UUID on purpose: `filePaperWaiver` only attempts
- * to look up an owner's email for values that look like one.
- */
-export const AGENT_ENV_KEY_UPLOADER = "manager-agent-env-key";
-
-/**
- * The actor to record as the author of a row, or null when there isn't one.
- *
- * Every write this API makes on somebody's behalf lands in a column that
- * `references auth.users`, and the break-glass env key authenticates as
- * `AGENT_ENV_KEY_UPLOADER` — deliberately not a UUID, with no auth user behind
- * it. Writing that sentinel into such a column fails the insert outright, so
- * each writer asks this instead: record the manager when the token resolved to
- * one, null when it did not.
- *
- * Lives here, with the sentinel it exists because of, rather than as a private
- * copy in each writer — this is the third caller, which is the point the repo's
- * own rule says to stop duplicating.
- */
-export function actorUserId(actingAs: string | null): string | null {
-  if (!actingAs) return null;
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(actingAs)
-    ? actingAs
-    : null;
-}
-
-/**
  * Classify a raw request body's `action` field before dispatch, distinguishing
  * an absent field from a present-but-invalid one — otherwise both report
  * "unknown_action" and a caller who built the body wrong (forgot the field

--- a/src/lib/waiver-template.functions.test.ts
+++ b/src/lib/waiver-template.functions.test.ts
@@ -351,8 +351,8 @@ describe("saveWaiverTemplateVersion", () => {
   });
 
   it("records no author when the caller resolves to no auth user", async () => {
-    // `created_by` is a real FK to auth.users, and the agent API's break-glass
-    // key has no user behind it.
+    // `created_by` is a real FK to auth.users, so a caller with nobody behind it
+    // records no author rather than a stand-in for one.
     const store = fakeStore([row({ version: 1, is_current: true })]);
     await saveWaiverTemplateVersion(store.admin, draft, null);
     expect(store.inserts[0]).toMatchObject({ created_by: null });

--- a/src/lib/waiver.functions.test.ts
+++ b/src/lib/waiver.functions.test.ts
@@ -1236,16 +1236,20 @@ describe("filePaperWaiver", () => {
     expect(meta.uploaded_by_email).toBe("manager@example.com");
   });
 
-  it("skips the uploader lookup for a non-UUID caller (the agent API's break-glass key)", async () => {
-    const { admin, calls } = fakeAdmin({ existingId: EXISTING_USER });
+  // There is no longer a caller that files a waiver without a real auth user
+  // behind it: the manager agent API dropped its environment-key fallback, so
+  // every filing names the manager who vouched for the scan. The lookup is
+  // therefore attempted every time, and an address it cannot find is a missing
+  // decoration, not a filing that skipped the question.
+  it("still names the uploader when their address cannot be resolved", async () => {
+    const { admin, calls } = fakeAdmin({ existingId: EXISTING_USER, getUserByIdEmail: null });
     const { filePaperWaiver } = await import("./waiver.functions");
-    const { AGENT_ENV_KEY_UPLOADER } = await import("./manager-agent");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await filePaperWaiver(admin as any, validInput, AGENT_ENV_KEY_UPLOADER);
-    expect(calls.getUserById).toEqual([]);
+    await filePaperWaiver(admin as any, validInput, MANAGER_ID);
+    expect(calls.getUserById).toEqual([MANAGER_ID]);
     const row = calls.insert[0] as Record<string, unknown>;
     const meta = row.signer_meta as Record<string, unknown>;
-    expect(meta.uploaded_by).toBe(AGENT_ENV_KEY_UPLOADER);
+    expect(meta.uploaded_by).toBe(MANAGER_ID);
     expect(meta).not.toHaveProperty("uploaded_by_email");
   });
 

--- a/src/lib/waiver.functions.ts
+++ b/src/lib/waiver.functions.ts
@@ -48,7 +48,6 @@ import { hasMediaAcknowledgement, WaiverTemplateError } from "@/lib/waiver-templ
 import type { DuplicateWaiverRef } from "@/lib/waiver-duplicates";
 import { userIdByEmail } from "@/lib/supabase-rpc";
 import { resolveWaiverContacts } from "@/lib/waiver-contacts";
-import { actorUserId } from "@/lib/manager-agent";
 
 const BUCKET = "waivers";
 const CLUB_NAME = "UTS Jitsu";
@@ -1166,8 +1165,9 @@ export const setCurrentWaiverTemplate = createServerFn({ method: "POST" })
  * so the manager agent API saves through exactly this path instead of a second
  * one that could drift from it.
  *
- * `createdBy` is null for a caller that resolves to no auth user (the agent
- * API's break-glass env key), because the column is a real FK to `auth.users`.
+ * `createdBy` is the manager saving it, and the column is a real FK to
+ * `auth.users`, so only a real user id or null may go in — never a placeholder
+ * standing in for one.
  *
  * The media-consent check runs BEFORE the insert. `promoteWaiverTemplate` would
  * refuse the publish anyway, but only after the row existed, leaving a draft
@@ -1560,16 +1560,15 @@ export async function filePaperWaiver(
     uploaded_by: uploadedByUserId,
     scan_files: data.scan.map((f) => f.name),
   };
-  // Not every caller resolves to a real auth user: the manager agent API's
-  // break-glass env-key fallback (docs/manager-agent-api.md) has no owner to look up, so
-  // skip the lookup rather than log a spurious not-found error every call.
-  if (actorUserId(uploadedByUserId)) {
-    try {
-      const { data: manager } = await admin.auth.admin.getUserById(uploadedByUserId);
-      if (manager.user?.email) signer_meta.uploaded_by_email = manager.user.email;
-    } catch (e) {
-      console.error("[filePaperWaiver] could not resolve the uploading manager:", e);
-    }
+  // Every caller resolves to a real auth user — the manager's own upload form
+  // passes the signed-in manager, and the agent API passes the token's owner —
+  // so the uploader is always worth looking up. Failing to resolve one is
+  // logged, never fatal: the provenance the row already carries is enough.
+  try {
+    const { data: manager } = await admin.auth.admin.getUserById(uploadedByUserId);
+    if (manager.user?.email) signer_meta.uploaded_by_email = manager.user.email;
+  } catch (e) {
+    console.error("[filePaperWaiver] could not resolve the uploading manager:", e);
   }
 
   // Every field just submitted, written onto the row whether this is a fresh

--- a/src/routes/api/manager/agent.test.ts
+++ b/src/routes/api/manager/agent.test.ts
@@ -5,6 +5,7 @@
 // reachable directly — see membership.functions.test.ts for why that isn't
 // true of createServerFn handlers.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { hashToken } from "@/lib/manager-api-tokens";
 
 type Result<T> = { data: T | null; error: { message: string } | null };
 const ok = <T>(data: T): Result<T> => ({ data, error: null });
@@ -124,7 +125,7 @@ function fakeAdminForEditInvoice(
 let currentAdmin: unknown;
 vi.mock("@/integrations/supabase/client.server", () => ({
   get supabaseAdmin() {
-    return currentAdmin;
+    return withMintedToken(currentAdmin);
   },
 }));
 
@@ -151,7 +152,69 @@ vi.mock("@/lib/waiver.functions", () => ({
   promoteWaiverTemplate: (...args: unknown[]) => promoteWaiverTemplateMock(...args),
 }));
 
-const BREAK_GLASS_KEY = "test-break-glass-key";
+const MINTED_TOKEN = "utsj_0123456789abcdef0123456789abcdef0123456789abcdef";
+const TOKEN_OWNER = "44444444-4444-4444-4444-444444444444";
+/**
+ * Shaped like something somebody would have put in MANAGER_AGENT_API_KEY. It is
+ * never minted, so the endpoint must refuse it — that env fallback is gone.
+ */
+const ENV_STYLE_KEY = "test-break-glass-key";
+
+/**
+ * The manager_api_tokens chains `authenticate` walks: look the token up by
+ * hash, then stamp last_used_at.
+ *
+ * It really compares the hash rather than waving any bearer token through. A
+ * fake that returned the row unconditionally would pass just as happily with
+ * the whole minted-token lookup deleted, which is exactly the assertion the
+ * env-key tests below depend on.
+ */
+function fakeTokensTable() {
+  let hash: string | null = null;
+  const select = {
+    eq: (col: string, val: string) => {
+      if (col === "token_hash") hash = val;
+      return select;
+    },
+    is: () => select,
+    maybeSingle: async () =>
+      ok(
+        hash === (await hashToken(MINTED_TOKEN)) ? { id: "tok-1", created_by: TOKEN_OWNER } : null,
+      ),
+  };
+  const stamp = {
+    eq: () => stamp,
+    then: (resolve: (r: Result<unknown>) => void) => resolve(ok(null)),
+  };
+  return { select: () => select, update: () => stamp };
+}
+
+/**
+ * Wrap a fake service-role client so it can also answer the two calls
+ * `authenticate` makes before any action runs: the hashed-token lookup and the
+ * has_role re-check of the token's owner. Every fake below models only the
+ * tables its own action walks, so without this each of them would throw
+ * "unexpected table manager_api_tokens" at the door instead of running.
+ */
+function withMintedToken(db: unknown) {
+  const base = (db ?? {}) as {
+    from?: (table: string) => unknown;
+    rpc?: (name: string, args?: unknown) => unknown;
+  };
+  return {
+    ...base,
+    from: (table: string) => {
+      if (table === "manager_api_tokens") return fakeTokensTable();
+      if (!base.from) throw new Error(`unexpected table ${table}`);
+      return base.from(table);
+    },
+    rpc: (name: string, args?: unknown) => {
+      if (name === "has_role") return Promise.resolve(ok(true));
+      if (!base.rpc) throw new Error(`unexpected rpc ${name}`);
+      return base.rpc(name, args);
+    },
+  };
+}
 
 type RouteHandler = (ctx: { request: Request }) => Promise<Response>;
 type RouteHandlers = Record<"GET" | "POST" | "PUT" | "PATCH" | "DELETE", RouteHandler>;
@@ -162,11 +225,11 @@ async function handlers(): Promise<RouteHandlers> {
     .handlers;
 }
 
-async function post(body: unknown) {
+async function post(body: unknown, token: string = MINTED_TOKEN) {
   return (await handlers()).POST({
     request: new Request("http://localhost/api/manager/agent", {
       method: "POST",
-      headers: { authorization: `Bearer ${BREAK_GLASS_KEY}`, "content-type": "application/json" },
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
       body: JSON.stringify(body),
     }),
   });
@@ -181,11 +244,50 @@ async function method(verb: "PUT" | "PATCH" | "DELETE") {
 describe("manager agent route", () => {
   beforeEach(() => {
     vi.resetModules();
-    process.env.MANAGER_AGENT_API_KEY = BREAK_GLASS_KEY;
   });
   afterEach(() => {
     delete process.env.MANAGER_AGENT_API_KEY;
     vi.restoreAllMocks();
+  });
+
+  // A minted, hashed manager_api_tokens row is now the ONLY credential this
+  // endpoint accepts. It used to take a MANAGER_AGENT_API_KEY env var as well,
+  // which was checked FIRST, stored in plaintext, revocable only by redeploy,
+  // and attributed to nobody — so a waiver filed through it named no auth user.
+  // Setting that variable must do nothing at all now, or the removal is
+  // reversible by anyone who can edit an environment.
+  describe("authentication", () => {
+    it("refuses an env-style key even when MANAGER_AGENT_API_KEY is set to it", async () => {
+      process.env.MANAGER_AGENT_API_KEY = ENV_STYLE_KEY;
+      // A fake with no tables but the token lookup: reaching any action at all
+      // would throw "unexpected table", so a 401 proves it stopped at the door.
+      currentAdmin = {};
+      const res = await post({ action: "list_invoices", params: {} }, ENV_STYLE_KEY);
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body).toMatchObject({ ok: false, error: { code: "unauthorized" } });
+    });
+
+    it("refuses any token that hashes to no unrevoked row", async () => {
+      currentAdmin = {};
+      const res = await post({ action: "list_invoices", params: {} }, "utsj_not-a-minted-token");
+      expect(res.status).toBe(401);
+      expect((await res.json()).error.code).toBe("unauthorized");
+    });
+
+    it("still refuses a request with no bearer token at all", async () => {
+      currentAdmin = {};
+      const res = await (
+        await handlers()
+      ).POST({
+        request: new Request("http://localhost/api/manager/agent", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ action: "list_invoices", params: {} }),
+        }),
+      });
+      expect(res.status).toBe(401);
+    });
   });
 
   it.each(["PUT", "PATCH", "DELETE"] as const)(
@@ -478,15 +580,11 @@ describe("manager agent route: the waiver template", () => {
 
   beforeEach(() => {
     vi.resetModules();
-    process.env.MANAGER_AGENT_API_KEY = BREAK_GLASS_KEY;
     currentAdmin = {};
     listWaiverTemplateRowsMock.mockReset();
     loadWaiverTemplateVersionMock.mockReset();
     saveWaiverTemplateVersionMock.mockReset();
     promoteWaiverTemplateMock.mockReset();
-  });
-  afterEach(() => {
-    delete process.env.MANAGER_AGENT_API_KEY;
   });
 
   /**

--- a/src/routes/api/manager/agent.ts
+++ b/src/routes/api/manager/agent.ts
@@ -6,11 +6,13 @@
 //
 // Auth is an opaque bearer token rather than a manager's Supabase JWT: agents
 // can't run the email/password login flow, and this endpoint only ever exposes
-// the whitelisted manager actions below. Tokens are manager-issued and revocable
-// (the manager_api_tokens table, minted from /manager/api-tokens); an optional
-// MANAGER_AGENT_API_KEY env var is accepted as a break-glass fallback. All DB
-// access uses the service-role admin client, so it is lazy-imported inside the
-// handler (route files are bundled to the client — never top-level import it).
+// the whitelisted manager actions below. A minted, hashed manager_api_tokens row
+// is the ONLY thing that authenticates here — there is no environment-variable
+// fallback, so every request resolves to a named manager who still holds the
+// role today, and losing a token means minting another at /manager/api-tokens.
+// All DB access uses the service-role admin client, so it is lazy-imported
+// inside the handler (route files are bundled to the client — never top-level
+// import it).
 import { createFileRoute } from "@tanstack/react-router";
 import { ZodError } from "zod";
 import {
@@ -36,9 +38,7 @@ import {
 } from "@/lib/validation";
 import type { ManagerAgentAction } from "@/lib/validation";
 import {
-  AGENT_ENV_KEY_UPLOADER,
   AGENT_MANIFEST,
-  actorUserId,
   AgentError,
   bearerToken,
   buildInvoicePatch,
@@ -50,7 +50,6 @@ import {
   projectInvoice,
   reconciledEditBlockers,
   reconciledEditMessage,
-  safeEqual,
 } from "@/lib/manager-agent";
 import {
   DuplicateCheckFailedError,
@@ -159,22 +158,19 @@ async function adminClient(): Promise<MembershipClient> {
 }
 
 /**
- * Authenticate the request. Accepts either a manager-issued token (looked up by
- * SHA-256 hash in manager_api_tokens, whose owner must still be a manager) or,
- * as a break-glass fallback, the MANAGER_AGENT_API_KEY env var. Throws
- * AgentError on any failure. On success, best-effort stamps last_used_at.
+ * Authenticate the request. A manager-issued token is the only credential this
+ * endpoint accepts: looked up by SHA-256 hash in manager_api_tokens, unrevoked,
+ * and owned by somebody who still holds the manager role. Throws AgentError on
+ * any failure. On success, best-effort stamps last_used_at.
  *
- * Returns who is acting: the token owner's user id for a manager-issued token,
- * or AGENT_ENV_KEY_UPLOADER for the break-glass key, which has no owner to
- * resolve. `file_waiver` records this as the waiver's `uploaded_by`.
+ * Returns who is acting — always the token owner's user id, so every row this
+ * API writes on somebody's behalf names a real auth user. `file_waiver` records
+ * it as the waiver's `uploaded_by`, which is why that matters: a waiver is legal
+ * evidence, and one filed by nobody is weaker evidence.
  */
 async function authenticate(request: Request): Promise<string> {
   const token = bearerToken(request.headers.get("authorization"));
   if (!token) throw new AgentError(401, "unauthorized", "Missing bearer token.");
-
-  // Break-glass env key (optional; constant-time compared).
-  const envKey = process.env.MANAGER_AGENT_API_KEY;
-  if (envKey && safeEqual(token, envKey)) return AGENT_ENV_KEY_UPLOADER;
 
   const db = await adminClient();
   const tokenHash = await hashToken(token);
@@ -902,7 +898,7 @@ async function handleSaveWaiverTemplate(params: unknown, actingAs: string) {
         body_md: input.body_md ?? base!.body_md,
         acknowledgements: input.acknowledgements ?? base!.acknowledgements,
       },
-      actorUserId(actingAs),
+      actingAs,
     );
     // `based_on` is what makes a carry-over auditable: it names the version the
     // fields this call did not send actually came from.


### PR DESCRIPTION
## Breaking change, read first

**Anyone calling `/api/manager/agent` with the value of the server's `MANAGER_AGENT_API_KEY` will start getting `401 unauthorized` the moment this deploys.** There is no grace period and no warning response: the branch that accepted that key is deleted, so setting the variable does nothing at all afterwards.

The replacement is a token minted at **`/manager/api-tokens`**. A manager signs in, mints one, copies it once, and puts it in `UTS_MANAGER_API_KEY` (or wherever their agent reads it from). Nothing else about the API changes.

**I could not check whether that variable is actually set in the Lovable Cloud project.** The tooling available to this session lists projects and reads code, but does not expose Cloud project secrets, so I have no way to confirm it either way. Please check the Lovable Cloud secrets before merging. Issue #66 states two minted tokens are already live and nothing depends on the env key; I am relying on that rather than on anything I verified. If the variable is set, whoever is using it needs a minted token first, and the variable should be deleted from the project afterwards so it is not left lying around as a dead plaintext credential.

Closes #66

## What the user will feel

**Managers:** nothing, unless they are one of the people driving the API with the environment key today. Every manager screen, the paper waiver upload form, and the knowledge base editor behave exactly as they did. A manager whose agent stops working fixes it in about a minute: `/manager/api-tokens`, "Create token", paste it into their agent's config. That screen already exists and already prints the copy-paste agent prompt.

**Members and prospective members:** nothing at all. No page, form, email or copy changes.

**One thing that quietly gets better:** a paper waiver filed through the old environment key recorded `uploaded_by` with no auth user behind it, so the record could not say who vouched for the scan. Every filing now names a real manager. Waivers already on file are untouched.

## Why delete it rather than leave it unset

Leaving it unset works only for as long as nobody sets it, and setting an environment variable is not a code review. The env key was the weaker path on every axis compared to a minted token, and it was checked **first**, so the safer path could never shadow it:

| | Minted token | `MANAGER_AGENT_API_KEY` |
|---|---|---|
| Storage | SHA-256 hash | Plaintext env var |
| Revocation | Instant, from a screen | Redeploy only |
| Attribution | Named manager | Non-UUID sentinel |
| Expiry | Revocable any time | Never |
| Role re-check | Every request | None |

There is deliberately no replacement break-glass mechanism. Losing every token is recoverable by signing in as a manager and minting another, which needs only a manager login, so a second credential path buys nothing and costs everything in the table above. `docs/manager-agent-api.md` now says that outright so the next person does not re-add one.

## What else fell out

With the sentinel gone, every actor the API hands to a writer is a real manager's user id, which makes the UUID-shaped guard around it dead:

- `AGENT_ENV_KEY_UPLOADER` and `actorUserId()` are deleted (`src/lib/manager-agent.ts`).
- `saveKbArticle` and `save_waiver_template` pass the actor straight through.
- `filePaperWaiver` always looks its uploader's address up instead of guarding against a value that can no longer arrive.
- `created_by` / `uploaded_by` stay nullable, because the columns are. Nothing is tightened; the point is only that a placeholder is never invented for them.

Not touched: `MANAGER_AGENT_API_KEY` stays in `KNOWN_SECRET_KEYS` in `scripts/check-committed-env.mjs`. That list is a deny-list of names that are secrets, not a mirror of what the server reads, and keeping it there means a committed `.env` holding one still fails with the specific message rather than the generic "not in the allowlist" one. The migration comment in `20260722130000_manager_api_tokens.sql` also still names it, as applied migrations are historical record.

Docs updated in the same change: `docs/manager-agent-api.md` (auth section + the `file_waiver` `uploaded_by` note), `CLAUDE.md`'s environment variables list, `.claude/skills/uts-manager-agent/SKILL.md` and its `agent.sh` usage line.

## Tests

The route suite used to authenticate every request through the env key. It now authenticates through a fake `manager_api_tokens` table that **really compares the SHA-256 hash** rather than waving any bearer token through, so the new refusals are real assertions and not a fake rubber-stamping them.

Added under `describe("authentication")` in `src/routes/api/manager/agent.test.ts`:

- **refuses an env-style key even when `MANAGER_AGENT_API_KEY` is set to it** — the case the issue asked for. Restoring the old branch makes it fail: the request authenticates and reaches dispatch instead of stopping at 401.
- refuses any token that hashes to no unrevoked row.
- still refuses a request with no bearer token at all.

The sentinel-specific cases elsewhere are replaced rather than deleted (`waiver.functions.test.ts` now pins that a filing names its uploader even when the address cannot be resolved; `kb-admin.test.ts` and `waiver-template.functions.test.ts` pin the real remaining case, no actor means no author).

## Review + merge with `main`

A second pass reviewed this diff independently, confirmed the removal is genuine (no branch still accepts the env key, even with it set), confirmed the minted-token path, hashing and revocation are untouched, and confirmed all four action-contract sync points plus `CLAUDE.md`'s env var list were updated. No defect found.

`main` had moved 63 commits ahead; it's now merged in (one conflict in `src/lib/kb-admin.ts`, an import-list collision with an unrelated `main` change, resolved by keeping both sides' real imports and dropping the deleted `actorUserId` one).

`bun run lint`, `bun run typecheck`, `bun run test` (122 files, 2257 tests) and `bun run build` all pass locally after the merge. `bun.lock` is untouched. Both CI jobs (Lint/typecheck/test/build, and the e2e user-flow walk) are green on the merged branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFxDwmhMTAt6vFwCf61zU6)_