### PR TITLE
Let a manager delete an enquiry (issue #55, first slice)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,7 +303,10 @@ RLS, relationships, storage); it is the source of truth for the data model and
 Core tables:
 
 - `interest_registrations`, `contact_messages` — public insert-only (anon), with
-  column-length/format CHECK constraints in the RLS `WITH CHECK`.
+  column-length/format CHECK constraints in the RLS `WITH CHECK`. A manager can
+  **delete** an enquiry from either (service role, behind the manager gate);
+  that is the product's only erasure path, and what it deliberately does not
+  touch is `docs/erasing-personal-data.md`.
 - `profiles` — the person fields for an auth user, keyed by `user_id` (PK →
   `auth.users`). **The only email lives on `auth.users`** — no email column in
   `public`; the server resolves emails via the service-role-only

--- a/docs/database.md
+++ b/docs/database.md
@@ -1363,6 +1363,13 @@ length + email format). Each row is a **lead**: kept exactly as submitted,
 creating no person record. The manager directory merges leads in by normalized
 email until the email belongs to a person (they signed the waiver).
 
+A manager can **delete a lead** from `/manager/users` (`deleteLead`), which
+removes every registration under that address, since the directory merges them
+into one row. Refused, on the server, when the address belongs to a person: they
+have signed something, and their enquiry is part of that record. This is the
+only erasure the product has, and why it stops here is
+`docs/erasing-personal-data.md`.
+
 ### `contact_messages`
 
 `id` PK, `name`, `email`, `subject`, `message`, `client_submission_id`,
@@ -1371,7 +1378,10 @@ email until the email belongs to a person (they signed the waiver).
 Insert-only for both client roles, and it stays that way: managers read it
 through `listContactMessages` (`src/lib/contact-messages.functions.ts`) on the
 **service-role** client behind the manager gate, so `/manager/contact-messages`
-needed no read grant, no new policy and no migration.
+needed no read grant, no new policy and no migration. The same is true of
+`deleteContactMessage`, which removes one message for good: there is no copy
+elsewhere in the product, so a manager confirms what goes before it goes (see
+`docs/erasing-personal-data.md`).
 
 Submitting also emails the sender an acknowledgement and every manager the
 message itself (`src/lib/contact-email.server.ts`, best-effort: a send failure

--- a/docs/erasing-personal-data.md
+++ b/docs/erasing-personal-data.md
@@ -1,0 +1,121 @@
+# Erasing a person's data
+
+What the club can destroy today, what it deliberately cannot, and where every
+piece of a person actually lives. Opened by issue #55 (live readiness), where
+the product decisions behind it are still being made.
+
+**Nothing in here is legal advice.** The retention points below are a reading of
+the pre-launch review, not an independent view, and a practitioner should
+confirm them alongside the privacy policy. There is no privacy policy page on
+the site yet, so no promise has been made that the code has to live up to.
+
+## What exists today
+
+One thing: **a manager can delete an enquiry.**
+
+- `/manager/contact-messages` deletes a single message, with the name, address
+  and words on it. `deleteContactMessage`
+  (`src/lib/contact-messages.functions.ts`).
+- `/manager/users` deletes a **lead**, meaning every interest-form registration
+  filed under one address. `deleteLead` / `deleteLeadRegistrations`
+  (`src/lib/leads.functions.ts`).
+
+Both go through the service-role client behind the manager gate, so neither
+needed a grant, a policy or a migration: `interest_registrations` and
+`contact_messages` grant the client roles a bare `INSERT` and nothing else (see
+`docs/database.md`).
+
+Two rules hold that path together, and both are load-bearing:
+
+- **A lead delete re-checks that the address has no person behind it**, on the
+  server, every time. The directory a manager clicked from can be minutes old,
+  and a waiver signed in between turns a lead into an applicant with a profile
+  and frozen evidence under the same address. Deleting their enquiry then is not
+  clearing an untouched form, it is taking a piece out of somebody's record.
+- **The search is not the decision.** Registrations store the address as typed,
+  so one person can hold two rows differing only in capitalisation, and both
+  have to go or the lead reappears. The query prefilters with `ilike`, which
+  **over**-matches (`_` and `%` are LIKE wildcards and both are legal in an
+  email local part), and the exact comparison in JS chooses what is deleted.
+  Backwards, that pattern destroys a stranger's enquiry.
+
+Everything else about a person is untouched, on purpose. There is no way to
+delete a member, a waiver, a PDF or a login, by design rather than by omission.
+
+## Why the rest is not built
+
+Erasure for anyone who has signed something needs two answers the club has not
+given yet:
+
+1. **Does "delete me" mean erase or de-identify?** Stripping the person out and
+   keeping the skeleton (a waiver was signed on this date against this template;
+   a membership ran for these dates at this price) keeps the club's own history
+   without holding the person. Full erasure is simpler and leaves the club with
+   no evidence anybody consented to train.
+2. **What must be retained anyway, and for how long?** A signed waiver is
+   evidence of informed consent, and there is likely a period in which a claim
+   can still be brought. Minors are the sharp edge: that period commonly starts
+   when the person turns 18, so "N years from signing" and "until 18 plus N"
+   give very different answers for the same document. An insurer may also ask
+   for longer than the law does.
+
+Building either on a guess destroys evidence the club needs or keeps documents
+it should not have, which is why the slice above stops where it does.
+
+## Where a person's data actually lives
+
+The map, for whoever builds the rest. Deleting the `auth.users` row by hand
+today is worse than doing nothing, because it destroys the record and keeps the
+documents.
+
+**Cascades from the login** (`ON DELETE CASCADE`, directly or through
+`profiles.user_id`): `profiles`, `waivers` (the frozen submission, including the
+email as submitted), `session_checkins`, `code_of_conduct_acceptances`,
+`kb_annotations`, `kb_article_reads`, `notifications`,
+`notification_preferences`, `notification_tokens`, `event_rsvps`,
+`calendar_feed_tokens`, `email_verification_tokens`, `blog_comments`,
+`blog_comment_upvotes`, `blog_blocked_commenters`, `user_roles`,
+`app_user_connections`, `waiver_drive_uploads` (via `waivers`).
+
+**Survives, holding personal data:**
+
+| What                                         | Why                                                                                                                                                                                                                                                                                                                                                 |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Signed waiver PDFs in the `waivers` bucket   | Storage objects have no FK. The row cascades, the file does not. Each is `<waiver_id>.pdf`, and the id is gone with the row, so an orphaned file cannot even be traced back.                                                                                                                                                                        |
+| `memberships`                                | `user_id` is `ON DELETE SET NULL`. The row stays, orphaned, still carrying `uts_student_number` and `payment_reference`.                                                                                                                                                                                                                            |
+| `interest_registrations`, `contact_messages` | No user FK at all. Name, email, phone, free text. This is the only part the slice above closes.                                                                                                                                                                                                                                                     |
+| `bank_transactions`                          | The club's financial record. A member's name appears incidentally, in text the bank wrote.                                                                                                                                                                                                                                                          |
+| Google Drive exports                         | The file lives in a manager's personal Drive, named `<date> - <the name on the waiver>.pdf`. `waiver_drive_uploads` records the Drive file id, so a deletion path COULD remove it, but only while that manager still has Drive connected, and never a copy they moved by hand. `disconnectGoogleDrive` deliberately leaves exported files in place. |
+| The signed download link emailed at signing  | Expires, but the PDF may already be saved elsewhere. Not recallable.                                                                                                                                                                                                                                                                                |
+
+**Audit columns blank out silently** (`ON DELETE SET NULL`): `waivers.approved_by`,
+`blog_posts.author_id`, `kb_articles.created_by`, `kb_article_versions.created_by`,
+`kb_annotations.resolved_by`, `session_checkins.checked_in_by`,
+`calendar_series.created_by`, `calendar_events.created_by`,
+`waiver_templates.created_by`,
+`club_settings.updated_by`, `bank_transactions.matched_by`,
+`profiles.media_consent_updated_by`, `blog_comments.hidden_by`,
+`blog_blocked_commenters.blocked_by`, `manager_api_tokens.created_by`,
+`notifications.actor_id`. So deleting a **manager** quietly erases who approved
+what. Whatever gets built should refuse a manager outright, or make the club
+say so first.
+
+One thing that does fail safe: a manager API token whose owner is gone is
+rejected, because `/api/manager/agent` refuses a token with no `created_by`
+(see `docs/manager-agent-api.md`).
+
+## What the product would still need
+
+In the order I would build it, once the questions above are answered:
+
+1. Delete an enquiry. **Done.**
+2. Delete a person who never signed anything, as one operation. Refused when a
+   waiver, a membership or attendance is behind them.
+3. Delete or de-identify a person who did sign: their record, login, comments,
+   notifications, attendance and PDFs, with the waiver either going with them or
+   retained for the agreed period and kept out of the day-to-day screens.
+4. A member-facing **request**, if the club wants one, landing in the manager
+   queue rather than destroying anything on the spot.
+
+Steps 2 and 3 need a migration (a retention stamp at minimum), so
+`docs/database-changes.md` applies to both.

--- a/docs/erasing-personal-data.md
+++ b/docs/erasing-personal-data.md
@@ -25,19 +25,29 @@ needed a grant, a policy or a migration: `interest_registrations` and
 `contact_messages` grant the client roles a bare `INSERT` and nothing else (see
 `docs/database.md`).
 
-Two rules hold that path together, and both are load-bearing:
+Three rules hold that path together, and all of them are load-bearing:
 
 - **A lead delete re-checks that the address has no person behind it**, on the
   server, every time. The directory a manager clicked from can be minutes old,
   and a waiver signed in between turns a lead into an applicant with a profile
   and frozen evidence under the same address. Deleting their enquiry then is not
   clearing an untouched form, it is taking a piece out of somebody's record.
+  What that closes is the staleness, not a race: the check and the delete are
+  separate round trips, so a waiver signed in the sub-second gap between them
+  still loses its lead row. The address survives on the waiver as submitted,
+  which is the copy that matters.
 - **The search is not the decision.** Registrations store the address as typed,
   so one person can hold two rows differing only in capitalisation, and both
   have to go or the lead reappears. The query prefilters with `ilike`, which
-  **over**-matches (`_` and `%` are LIKE wildcards and both are legal in an
-  email local part), and the exact comparison in JS chooses what is deleted.
-  Backwards, that pattern destroys a stranger's enquiry.
+  **over**-matches (`_` is a LIKE wildcard and is legal in an email local part,
+  so `a_b@example.com` also matches `axb@example.com`), and the exact comparison
+  in JS chooses what is deleted. Backwards, that pattern destroys a stranger's
+  enquiry. `%` is a wildcard too, and the interest form's validator happens to
+  reject it today, which is not something the delete should lean on.
+- **The read is capped**, like every other read in that file. One address
+  holding more registrations than the cap logs a warning and leaves the
+  remainder, so the lead reappears and a second press takes another bite. On a
+  delete, doing less than asked is the safe direction to fail.
 
 Everything else about a person is untouched, on purpose. There is no way to
 delete a member, a waiver, a PDF or a login, by design rather than by omission.

--- a/src/lib/contact-messages.functions.ts
+++ b/src/lib/contact-messages.functions.ts
@@ -15,6 +15,7 @@ import { requireSupabaseAuth } from "@/integrations/supabase/auth-middleware";
 import { requireManager } from "@/lib/require-manager";
 import { CONTACT_SEEN_KEY, readSeenMarker, stampSeenMarker } from "@/lib/seen-markers";
 import {
+  deleteContactMessageSchema,
   listContactMessagesSchema,
   markContactMessagesSeenSchema,
   unreadSince,
@@ -102,6 +103,44 @@ export const markContactMessagesSeen = createServerFn({ method: "POST" })
       context.userId,
     );
     return { ok: true as const, marker, skipped };
+  });
+
+// ---- Manager: delete a message ----
+//
+// The contact inbox is the one place the club holds something a person wrote
+// with nothing else attached to it: no account, no waiver, no membership. Once
+// a message has been dealt with there is no reason to keep their name, address
+// and words on file, and until now there was no way not to. See
+// docs/erasing-personal-data.md.
+
+/**
+ * Delete one message, for good. There is no copy anywhere else in the product,
+ * so this is the whole record of it going.
+ *
+ * The club-wide seen marker is deliberately left where it is. It is a
+ * watermark over timestamps, not a set of message ids, so deleting a row
+ * neither breaks it nor needs it moved. If the message was still unread the
+ * dashboard count simply drops by one, which is the honest reading: nobody is
+ * waiting on it any more.
+ */
+export const deleteContactMessage = createServerFn({ method: "POST" })
+  .middleware([requireSupabaseAuth])
+  .inputValidator((d: unknown) => deleteContactMessageSchema.parse(d))
+  .handler(async ({ data, context }) => {
+    await requireManager(context);
+    const admin = await adminClient();
+    // `select()` so the delete reports what it actually matched. PostgREST
+    // returns no error for a filter that hit nothing, and telling a manager a
+    // message is deleted when it was never there is the wrong way round on a
+    // screen whose whole job is not giving false reassurance.
+    const { data: gone, error } = await admin
+      .from("contact_messages")
+      .delete()
+      .eq("id", data.id)
+      .select("id");
+    if (error) throw new Error(error.message);
+    if (!gone || gone.length === 0) throw new Error("That message has already been deleted.");
+    return { ok: true as const, id: data.id };
   });
 
 /**

--- a/src/lib/leads.functions.test.ts
+++ b/src/lib/leads.functions.test.ts
@@ -272,3 +272,131 @@ describe("acknowledgeInterestRegistrations", () => {
     expect(upserts).toEqual([]);
   });
 });
+
+/**
+ * A second fake, on purpose. The one above answers `from()` from a queue and
+ * knows nothing about `rpc`, `ilike` or `delete`, and widening it would make
+ * every existing test read as if it cared about deletion. This one records the
+ * two things the delete has to get right: the pattern it searched with, and the
+ * exact ids it asked to remove.
+ */
+function fakeDeleteAdmin(opts: {
+  personId?: string | null;
+  rows?: Array<{ id: string; email: string }>;
+  rpcError?: { message: string } | null;
+  readError?: { message: string } | null;
+  deleteError?: { message: string } | null;
+}) {
+  const patterns: string[] = [];
+  const deleted: string[][] = [];
+  const rpcCalls: Array<[string, unknown]> = [];
+  const admin = {
+    rpc(fn: string, args: unknown) {
+      rpcCalls.push([fn, args]);
+      return Promise.resolve({ data: opts.personId ?? null, error: opts.rpcError ?? null });
+    },
+    from() {
+      const read = { data: opts.rows ?? [], error: opts.readError ?? null };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const chain: any = {
+        select: () => chain,
+        ilike: (_col: string, pattern: string) => {
+          patterns.push(pattern);
+          return chain;
+        },
+        delete: () => chain,
+        in: (_col: string, values: string[]) => {
+          deleted.push(values);
+          return Promise.resolve({ data: null, error: opts.deleteError ?? null });
+        },
+        then: (
+          onFulfilled?: (value: typeof read) => unknown,
+          onRejected?: (reason: unknown) => unknown,
+        ) => Promise.resolve(read).then(onFulfilled, onRejected),
+      };
+      return chain;
+    },
+  };
+  return { admin: admin as unknown as SupabaseClient<Database>, patterns, deleted, rpcCalls };
+}
+
+describe("deleteLeadRegistrations", () => {
+  it("refuses an address that belongs to a person, and deletes nothing", async () => {
+    const { deleteLeadRegistrations } = await import("./leads.functions");
+    const { LEAD_HAS_PERSON_MESSAGE } = await import("./validation");
+    const { admin, deleted } = fakeDeleteAdmin({
+      personId: "user-1",
+      rows: [{ id: "reg-1", email: "sam@example.com" }],
+    });
+    // The list the Delete was drawn from can be minutes old. Somebody who
+    // signed a waiver in the meantime has a profile and frozen evidence behind
+    // this address, and their enquiry is part of that record now.
+    await expect(deleteLeadRegistrations(admin, "sam@example.com")).rejects.toThrow(
+      LEAD_HAS_PERSON_MESSAGE,
+    );
+    expect(deleted).toEqual([]);
+  });
+
+  it("deletes every registration under the address, whatever the capitalisation", async () => {
+    const { deleteLeadRegistrations } = await import("./leads.functions");
+    const { admin, deleted, patterns } = fakeDeleteAdmin({
+      personId: null,
+      rows: [
+        { id: "reg-1", email: "Sam@Example.com" },
+        { id: "reg-2", email: "sam@example.com" },
+      ],
+    });
+    // The directory merges both rows into one lead, so deleting "this lead" has
+    // to take both. Leaving the older one behind puts the person straight back
+    // on the list a manager just cleared them from.
+    expect(await deleteLeadRegistrations(admin, "  SAM@example.com ")).toEqual({ deleted: 2 });
+    expect(deleted).toEqual([["reg-1", "reg-2"]]);
+    // Searched with the normalized address, not the one that was typed.
+    expect(patterns).toEqual(["sam@example.com"]);
+  });
+
+  it("ignores rows the search over-matched on a LIKE wildcard", async () => {
+    const { deleteLeadRegistrations } = await import("./leads.functions");
+    const { admin, deleted } = fakeDeleteAdmin({
+      personId: null,
+      rows: [
+        { id: "reg-1", email: "a_b@example.com" },
+        // `_` is a single-character wildcard in a LIKE pattern and is legal in
+        // an email, so the prefilter hands back a stranger's enquiry too. If the
+        // query were ever allowed to decide, this row would be destroyed.
+        { id: "reg-2", email: "axb@example.com" },
+      ],
+    });
+    expect(await deleteLeadRegistrations(admin, "a_b@example.com")).toEqual({ deleted: 1 });
+    expect(deleted).toEqual([["reg-1"]]);
+  });
+
+  it("reports nothing deleted rather than issuing an empty delete", async () => {
+    const { deleteLeadRegistrations } = await import("./leads.functions");
+    const { admin, deleted } = fakeDeleteAdmin({ personId: null, rows: [] });
+    expect(await deleteLeadRegistrations(admin, "nobody@example.com")).toEqual({ deleted: 0 });
+    expect(deleted).toEqual([]);
+  });
+
+  it("throws on a failed person lookup instead of deleting anyway", async () => {
+    const { deleteLeadRegistrations } = await import("./leads.functions");
+    const { admin, deleted } = fakeDeleteAdmin({
+      rpcError: { message: "boom" },
+      rows: [{ id: "reg-1", email: "sam@example.com" }],
+    });
+    // Fail closed. The check that just failed is the only thing standing
+    // between this and deleting part of a member's record.
+    await expect(deleteLeadRegistrations(admin, "sam@example.com")).rejects.toThrow("boom");
+    expect(deleted).toEqual([]);
+  });
+
+  it("throws when the delete itself fails, rather than reporting a count", async () => {
+    const { deleteLeadRegistrations } = await import("./leads.functions");
+    const { admin } = fakeDeleteAdmin({
+      personId: null,
+      rows: [{ id: "reg-1", email: "sam@example.com" }],
+      deleteError: { message: "nope" },
+    });
+    await expect(deleteLeadRegistrations(admin, "sam@example.com")).rejects.toThrow("nope");
+  });
+});

--- a/src/lib/leads.functions.test.ts
+++ b/src/lib/leads.functions.test.ts
@@ -304,6 +304,7 @@ function fakeDeleteAdmin(opts: {
           patterns.push(pattern);
           return chain;
         },
+        limit: () => chain,
         delete: () => chain,
         in: (_col: string, values: string[]) => {
           deleted.push(values);
@@ -369,6 +370,24 @@ describe("deleteLeadRegistrations", () => {
     });
     expect(await deleteLeadRegistrations(admin, "a_b@example.com")).toEqual({ deleted: 1 });
     expect(deleted).toEqual([["reg-1"]]);
+  });
+
+  it("deletes what it read when the read hits its cap, rather than throwing", async () => {
+    const { deleteLeadRegistrations } = await import("./leads.functions");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // 500 is the cap. Nobody fills in the interest form this many times, so
+    // reaching it means something odd is happening; the safe direction on a
+    // delete is to take what was read and leave the rest, which puts the lead
+    // back on the list for a second press.
+    const rows = Array.from({ length: 500 }, (_, i) => ({
+      id: `reg-${i}`,
+      email: "sam@example.com",
+    }));
+    const { admin, deleted } = fakeDeleteAdmin({ personId: null, rows });
+    expect(await deleteLeadRegistrations(admin, "sam@example.com")).toEqual({ deleted: 500 });
+    expect(deleted[0]).toHaveLength(500);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   it("reports nothing deleted rather than issuing an empty delete", async () => {

--- a/src/lib/leads.functions.ts
+++ b/src/lib/leads.functions.ts
@@ -28,6 +28,14 @@ type AdminClient = SupabaseClient<Database>;
  */
 const NEW_EMAILS_LIMIT = 200;
 
+/**
+ * Registrations read in one pass when deleting a lead. Far above anything real
+ * (this is one person filling in the interest form over and over), and there so
+ * a delete cannot issue an unbounded read. PostgREST caps the response anyway,
+ * so the choice is between a bound we can see and one we cannot.
+ */
+const REGISTRATIONS_PER_LEAD_LIMIT = 500;
+
 async function adminClient(): Promise<AdminClient> {
   const { supabaseAdmin } = await import("@/integrations/supabase/client.server");
   return supabaseAdmin;
@@ -202,6 +210,13 @@ export async function deleteLeadRegistrations(
   // into an applicant with a person record, a profile and frozen evidence
   // behind the same address. Deleting their enquiry then is not tidying up an
   // untouched form, it is taking a piece out of somebody's record.
+  //
+  // What this closes is that staleness, not a race. The check and the delete
+  // are separate round trips with no transaction around them, so a waiver
+  // signed in the sub-second gap between them still loses its lead row. Worth
+  // knowing rather than worth fixing: the address survives on the waiver as
+  // submitted, which is the copy that matters, and this is a manager pressing a
+  // button a handful of times a month.
   const { data: personId, error: personErr } = await userIdByEmail(admin, wanted);
   if (personErr) throw new Error(personErr.message);
   if (personId) throw new Error(LEAD_HAS_PERSON_MESSAGE);
@@ -211,16 +226,30 @@ export async function deleteLeadRegistrations(
   // merges them into a single lead. Both have to go, or the row a manager just
   // deleted comes straight back.
   //
-  // `ilike` is the prefilter, not the decision. `_` and `%` are wildcards in a
-  // LIKE pattern and both are legal in an email local part, so this can match
-  // MORE rows than it should — `a_b@example.com` also matches `axb@example.com`.
-  // It can never match fewer, so the exact comparison below is what chooses.
-  // Getting that backwards on a destructive path deletes a stranger's enquiry.
+  // `ilike` is the prefilter, not the decision. `_` is a single-character
+  // wildcard in a LIKE pattern and is legal in an email local part, so this can
+  // match MORE rows than it should: `a_b@example.com` also matches
+  // `axb@example.com`. It can never match fewer, so the exact comparison below
+  // is what chooses. Getting that backwards on a destructive path deletes a
+  // stranger's enquiry. (`%` is a wildcard too; the form's validator happens to
+  // reject it today, which is not something this should lean on.)
   const { data: rows, error: readErr } = await admin
     .from("interest_registrations")
     .select("id, email")
-    .ilike("email", wanted);
+    .ilike("email", wanted)
+    .limit(REGISTRATIONS_PER_LEAD_LIMIT);
   if (readErr) throw new Error(readErr.message);
+
+  // One person filing this many interest forms is not a thing that happens, so
+  // reaching the cap means something else is going on. Say so and delete what
+  // was read: the rest survive, the lead reappears on the next load, and a
+  // second press takes another bite. Bounded like every other read in this
+  // file, and the safe direction to fail on a delete.
+  if ((rows ?? []).length >= REGISTRATIONS_PER_LEAD_LIMIT) {
+    console.warn(
+      `[deleteLeadRegistrations] capped at ${REGISTRATIONS_PER_LEAD_LIMIT}; older registrations under this address are not deleted yet`,
+    );
+  }
 
   const ids = (rows ?? []).filter((r) => normalizeEmail(r.email) === wanted).map((r) => r.id);
   if (ids.length === 0) return { deleted: 0 };

--- a/src/lib/leads.functions.ts
+++ b/src/lib/leads.functions.ts
@@ -16,7 +16,8 @@ import type { Database } from "@/integrations/supabase/types";
 import { requireSupabaseAuth } from "@/integrations/supabase/auth-middleware";
 import { requireManager } from "@/lib/require-manager";
 import { INTEREST_SEEN_KEY, readSeenMarker, stampSeenMarker } from "@/lib/seen-markers";
-import { normalizeEmail } from "@/lib/validation";
+import { LEAD_HAS_PERSON_MESSAGE, deleteLeadSchema, normalizeEmail } from "@/lib/validation";
+import { userIdByEmail } from "@/lib/supabase-rpc";
 
 type AdminClient = SupabaseClient<Database>;
 
@@ -170,4 +171,82 @@ export const markInterestRegistrationsSeen = createServerFn({ method: "POST" })
     const admin = await adminClient();
     const result = await acknowledgeInterestRegistrations(admin, context.userId);
     return { ok: true as const, ...result };
+  });
+
+// ---- Manager: delete a lead ----
+//
+// The one erasure the club can make without deciding anything first. A lead
+// signed nothing, owes nothing and has no record hanging off them, so there is
+// no evidence to weigh against destroying it. Everything else a person leaves
+// behind is either a signed waiver or the club's own history, and what happens
+// to those is an open question (docs/erasing-personal-data.md).
+
+/**
+ * Delete every interest-form registration filed under one email address.
+ *
+ * Exported for its own test: the `createServerFn` wrapper below cannot be
+ * called from the unit runner (no Start request context), and the two guards
+ * here are the whole feature.
+ *
+ * Returns how many rows went, so the caller can tell "deleted" from "somebody
+ * else got there first" rather than reporting a no-op as a success.
+ */
+export async function deleteLeadRegistrations(
+  admin: AdminClient,
+  email: string,
+): Promise<{ deleted: number }> {
+  const wanted = normalizeEmail(email);
+
+  // Re-checked here, never trusted from the browser. The list the Delete was
+  // drawn from can be minutes old, and a waiver signed in between turns a lead
+  // into an applicant with a person record, a profile and frozen evidence
+  // behind the same address. Deleting their enquiry then is not tidying up an
+  // untouched form, it is taking a piece out of somebody's record.
+  const { data: personId, error: personErr } = await userIdByEmail(admin, wanted);
+  if (personErr) throw new Error(personErr.message);
+  if (personId) throw new Error(LEAD_HAS_PERSON_MESSAGE);
+
+  // The column stores the address exactly as it was typed, so one person can
+  // hold two rows that differ only in capitalisation, and the directory already
+  // merges them into a single lead. Both have to go, or the row a manager just
+  // deleted comes straight back.
+  //
+  // `ilike` is the prefilter, not the decision. `_` and `%` are wildcards in a
+  // LIKE pattern and both are legal in an email local part, so this can match
+  // MORE rows than it should — `a_b@example.com` also matches `axb@example.com`.
+  // It can never match fewer, so the exact comparison below is what chooses.
+  // Getting that backwards on a destructive path deletes a stranger's enquiry.
+  const { data: rows, error: readErr } = await admin
+    .from("interest_registrations")
+    .select("id, email")
+    .ilike("email", wanted);
+  if (readErr) throw new Error(readErr.message);
+
+  const ids = (rows ?? []).filter((r) => normalizeEmail(r.email) === wanted).map((r) => r.id);
+  if (ids.length === 0) return { deleted: 0 };
+
+  const { error: delErr } = await admin.from("interest_registrations").delete().in("id", ids);
+  if (delErr) throw new Error(delErr.message);
+  return { deleted: ids.length };
+}
+
+/**
+ * Manager: delete a lead, meaning every interest-form registration under their
+ * address, with the name, phone number and message they typed.
+ *
+ * Contact-form messages are NOT touched, even from the same address: they are a
+ * separate inbox with its own screen, and a manager clearing a lead off the
+ * directory has not necessarily read what that person wrote in.
+ */
+export const deleteLead = createServerFn({ method: "POST" })
+  .middleware([requireSupabaseAuth])
+  .inputValidator((d: unknown) => deleteLeadSchema.parse(d))
+  .handler(async ({ data, context }) => {
+    await requireManager(context);
+    const { deleted } = await deleteLeadRegistrations(await adminClient(), data.email);
+    // Nothing matched. Almost always a second manager (or a second tab) that
+    // deleted it first, and saying so beats a success message over a row that
+    // was already gone.
+    if (deleted === 0) throw new Error("That enquiry has already been deleted.");
+    return { ok: true as const, deleted };
   });

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -21,6 +21,8 @@ import {
   contactSchema,
   coverageSources,
   listContactMessagesSchema,
+  deleteContactMessageSchema,
+  deleteLeadSchema,
   interestRegistrationNotifications,
   sellableWindowNotifications,
   unreadSince,
@@ -973,6 +975,44 @@ describe("markContactMessagesSeenSchema", () => {
     expect(markContactMessagesSeenSchema.safeParse({ seen_at: "2026-08-05" }).success).toBe(false);
     expect(markContactMessagesSeenSchema.safeParse({ seen_at: "" }).success).toBe(false);
     expect(markContactMessagesSeenSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("deleteContactMessageSchema", () => {
+  it("takes a message id and nothing else", () => {
+    const id = "11111111-2222-3333-4444-555555555555";
+    expect(deleteContactMessageSchema.safeParse({ id }).success).toBe(true);
+    expect(deleteContactMessageSchema.safeParse({ id: "not-a-uuid" }).success).toBe(false);
+    expect(deleteContactMessageSchema.safeParse({}).success).toBe(false);
+    // Strict, like the other manager delete inputs: an extra field on a
+    // destructive call means the caller and the handler disagree about what is
+    // being deleted, which is not a thing to shrug off on this path.
+    expect(deleteContactMessageSchema.safeParse({ id, email: "sam@example.com" }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe("deleteLeadSchema", () => {
+  it("takes one email address, trimmed, and nothing else", () => {
+    expect(deleteLeadSchema.parse({ email: "  sam@example.com  " })).toEqual({
+      email: "sam@example.com",
+    });
+    expect(deleteLeadSchema.safeParse({ email: "not-an-email" }).success).toBe(false);
+    expect(deleteLeadSchema.safeParse({ email: "" }).success).toBe(false);
+    expect(deleteLeadSchema.safeParse({}).success).toBe(false);
+    expect(
+      deleteLeadSchema.safeParse({ email: "sam@example.com", also: "everything" }).success,
+    ).toBe(false);
+  });
+
+  it("does not lowercase: the address is matched case-insensitively later", () => {
+    // Pinned so nobody "tidies" this into a `.toLowerCase()` transform and
+    // quietly changes what `deleteLeadRegistrations` is handed. Normalizing is
+    // that function's job, next to the exact comparison that depends on it.
+    expect(deleteLeadSchema.parse({ email: "Sam@Example.com" })).toEqual({
+      email: "Sam@Example.com",
+    });
   });
 });
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -434,6 +434,40 @@ export const markContactMessagesSeenSchema = z.object({
 });
 export type MarkContactMessagesSeenInput = z.infer<typeof markContactMessagesSeenSchema>;
 
+// ---- Deleting an enquiry ----
+//
+// An enquiry is the one thing a person leaves behind that the club has no
+// reason to keep once it has been dealt with: nothing was signed, nothing is
+// owed, and no record hangs off it. Everything else a person creates is either
+// evidence (a signed waiver) or the club's own history (memberships,
+// attendance), and destroying those is a decision the club has not made yet.
+// See docs/erasing-personal-data.md.
+
+/** Manager: delete one message from the contact inbox. */
+export const deleteContactMessageSchema = z.object({ id: z.string().uuid() }).strict();
+export type DeleteContactMessageInput = z.infer<typeof deleteContactMessageSchema>;
+
+/**
+ * Manager: delete every interest-form registration filed under one address.
+ *
+ * Keyed by email rather than by row id because that is what a lead IS: the
+ * directory merges every registration sharing an address into one person, so
+ * deleting "this lead" has to mean all of them. Deleting one row of two would
+ * leave the same person on the list with the older enquiry showing.
+ */
+export const deleteLeadSchema = z.object({ email: z.string().trim().email().max(255) }).strict();
+export type DeleteLeadInput = z.infer<typeof deleteLeadSchema>;
+
+/**
+ * Why a lead the screen offered a Delete for turns out not to be one.
+ *
+ * Read by a manager, so it says what the refusal means rather than naming the
+ * check: an address with a person behind it is somebody who signed something,
+ * and their enquiry is part of that record now.
+ */
+export const LEAD_HAS_PERSON_MESSAGE =
+  "That address belongs to someone the club has a record for, so this is more than an enquiry now. It can't be deleted here.";
+
 /**
  * Where the club-wide "messages seen up to here" marker should land.
  *

--- a/src/routes/_authenticated/manager.contact-messages.test.tsx
+++ b/src/routes/_authenticated/manager.contact-messages.test.tsx
@@ -1,0 +1,123 @@
+// Deleting a message is the club destroying the only copy it holds of something
+// a person wrote to it, so what is pinned here is the shape of that: nothing
+// goes until a manager has read what will go and confirmed it, and a delete
+// that fails leaves the message exactly where it was.
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const listContactMessages = vi.fn();
+const markContactMessagesSeen = vi.fn();
+const deleteContactMessage = vi.fn();
+
+const sam = {
+  id: "msg-1",
+  name: "Sam Lee",
+  email: "sam@example.com",
+  subject: "Class times",
+  message: "Are Tuesday classes still on?",
+  created_at: "2026-08-05T10:00:00.000Z",
+};
+const kim = {
+  ...sam,
+  id: "msg-2",
+  name: "Kim Tran",
+  email: "kim@example.com",
+  subject: null,
+  message: "Do you have a beginners course?",
+};
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => opts,
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@tanstack/react-start", () => ({
+  useServerFn: (fn: unknown) => fn,
+}));
+
+vi.mock("@/lib/contact-messages.functions", () => ({
+  listContactMessages: (...args: unknown[]) => listContactMessages(...args),
+  markContactMessagesSeen: (...args: unknown[]) => markContactMessagesSeen(...args),
+  deleteContactMessage: (...args: unknown[]) => deleteContactMessage(...args),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "manager-1" }, session: null, loading: false }),
+  useRoles: () => ({ roles: ["manager"], loading: false, isManager: true }),
+}));
+
+vi.mock("@/hooks/useNotifications", () => ({
+  useNotifications: () => ({ refresh: vi.fn() }),
+}));
+
+const { Route } = await import("./manager.contact-messages");
+const ContactMessagesPage = (Route as unknown as { component: () => ReactNode }).component;
+
+async function renderLoaded() {
+  render(<ContactMessagesPage />);
+  await screen.findByRole("table");
+}
+
+beforeEach(() => {
+  listContactMessages.mockReset().mockResolvedValue({
+    messages: [sam, kim],
+    total: 2,
+    truncated: false,
+    seenAt: null,
+    newestAt: sam.created_at,
+    unreadIds: [sam.id],
+  });
+  markContactMessagesSeen.mockReset().mockResolvedValue({ ok: true, marker: null, skipped: false });
+  deleteContactMessage.mockReset().mockResolvedValue({ ok: true, id: sam.id });
+});
+
+describe("/manager/contact-messages", () => {
+  it("deletes nothing until the manager confirms", async () => {
+    await renderLoaded();
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete the message from Sam Lee" }));
+
+    expect(deleteContactMessage).not.toHaveBeenCalled();
+    expect(screen.getByText("Are Tuesday classes still on?")).toBeInTheDocument();
+  });
+
+  it("says what is destroyed, and names whose message it is", async () => {
+    await renderLoaded();
+    await userEvent.click(screen.getByRole("button", { name: "Delete the message from Sam Lee" }));
+
+    const dialog = within(await screen.findByRole("alertdialog"));
+    expect(dialog.getByText(/Delete the message from Sam Lee\?/)).toBeInTheDocument();
+    // The three things a manager cannot get back, in the words that matter:
+    // their name, their address, and what they wrote.
+    expect(dialog.getByText(/name, their email address and everything they wrote/)).toBeVisible();
+    expect(dialog.getByText(/keeps no copy anywhere else/)).toBeVisible();
+  });
+
+  it("removes only the confirmed message from the list", async () => {
+    await renderLoaded();
+    await userEvent.click(screen.getByRole("button", { name: "Delete the message from Sam Lee" }));
+    await userEvent.click(
+      within(await screen.findByRole("alertdialog")).getByRole("button", { name: "Delete" }),
+    );
+
+    expect(deleteContactMessage).toHaveBeenCalledWith({ data: { id: "msg-1" } });
+    expect(screen.queryByText("Sam Lee")).toBeNull();
+    expect(screen.getByText("Kim Tran")).toBeInTheDocument();
+  });
+
+  it("keeps the message on screen when the delete fails", async () => {
+    deleteContactMessage.mockRejectedValue(new Error("That message has already been deleted."));
+    await renderLoaded();
+    await userEvent.click(screen.getByRole("button", { name: "Delete the message from Sam Lee" }));
+    await userEvent.click(
+      within(await screen.findByRole("alertdialog")).getByRole("button", { name: "Delete" }),
+    );
+
+    // Nothing was destroyed, so the row must not vanish: a list that quietly
+    // dropped it would tell a manager the message is gone when it is still on
+    // file, which is the one direction this screen must never get wrong.
+    expect(await screen.findByText("Sam Lee")).toBeInTheDocument();
+  });
+});

--- a/src/routes/_authenticated/manager.contact-messages.tsx
+++ b/src/routes/_authenticated/manager.contact-messages.tsx
@@ -7,6 +7,7 @@ import { UNREAD_CLASS } from "@/lib/status-colours";
 import { formatDateTime } from "@/lib/dates";
 import { cn } from "@/lib/utils";
 import {
+  deleteContactMessage,
   listContactMessages,
   markContactMessagesSeen,
   type ContactMessage,
@@ -14,6 +15,16 @@ import {
 import { useAuth, useRoles } from "@/hooks/useAuth";
 import { useNotifications } from "@/hooks/useNotifications";
 import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 export const Route = createFileRoute("/_authenticated/manager/contact-messages")({
   head: () => ({
@@ -28,6 +39,7 @@ function ContactMessagesPage() {
   const { isManager, loading: rolesLoading } = useRoles(user?.id);
   const fetchMessages = useServerFn(listContactMessages);
   const markSeen = useServerFn(markContactMessagesSeen);
+  const removeMessage = useServerFn(deleteContactMessage);
   const { refresh: refreshNotifications } = useNotifications();
 
   const [messages, setMessages] = useState<ContactMessage[]>([]);
@@ -45,6 +57,11 @@ function ContactMessagesPage() {
   // behind them" — the server declines to move it, and this says why rather than
   // leaving a badge that will not clear look broken.
   const [hiddenOlder, setHiddenOlder] = useState(0);
+  // The message a manager has asked to delete, held until they confirm. The row
+  // itself stays on screen the whole time: nothing disappears before the server
+  // says it is gone, so a failed delete leaves the message exactly where it was.
+  const [pendingDelete, setPendingDelete] = useState<ContactMessage | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!rolesLoading && user && !isManager) navigate({ to: "/account" });
@@ -101,6 +118,28 @@ function ContactMessagesPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isManager]);
 
+  async function onDelete(message: ContactMessage) {
+    setDeletingId(message.id);
+    try {
+      await removeMessage({ data: { id: message.id } });
+      setMessages((prev) => prev.filter((m) => m.id !== message.id));
+      setUnreadIds((prev) => {
+        if (!prev.has(message.id)) return prev;
+        const next = new Set(prev);
+        next.delete(message.id);
+        return next;
+      });
+      toast.success("Message deleted");
+    } catch (e) {
+      // The row is still on screen and still in the list, so there is nothing
+      // for the manager to recover here: the delete simply did not happen.
+      toast.error(e instanceof Error ? e.message : "Could not delete that message");
+    } finally {
+      setDeletingId(null);
+      setPendingDelete(null);
+    }
+  }
+
   if (loading) return <div className="p-8">Loading...</div>;
 
   return (
@@ -156,6 +195,9 @@ function ContactMessagesPage() {
                 <th scope="col" className="p-3">
                   Message
                 </th>
+                <th scope="col" className="p-3">
+                  <span className="sr-only">Actions</span>
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -177,12 +219,52 @@ function ContactMessagesPage() {
                   <td className="max-w-md p-3">
                     <p className="whitespace-pre-wrap break-words">{m.message}</p>
                   </td>
+                  <td className="p-3 text-right">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                      // Named after the message it deletes. A table of buttons
+                      // all called "Delete" tells a screen-reader user nothing
+                      // about which one they are on, and this one is final.
+                      aria-label={`Delete the message from ${m.name}`}
+                      disabled={deletingId === m.id}
+                      onClick={() => setPendingDelete(m)}
+                    >
+                      {deletingId === m.id ? "Deleting..." : "Delete"}
+                    </Button>
+                  </td>
                 </tr>
               ))}
             </tbody>
           </table>
         </div>
       )}
+
+      <AlertDialog
+        open={Boolean(pendingDelete)}
+        onOpenChange={(open) => !open && setPendingDelete(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete the message from {pendingDelete?.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This deletes their name, their email address and everything they wrote. The club keeps
+              no copy anywhere else, and it can't be undone. If you still owe them a reply, send it
+              first.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => pendingDelete && onDelete(pendingDelete)}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </section>
   );
 }

--- a/src/routes/_authenticated/manager.users.test.tsx
+++ b/src/routes/_authenticated/manager.users.test.tsx
@@ -1,0 +1,141 @@
+// The directory is one row per person across the whole funnel, and only one of
+// those phases can be deleted from here: a lead, who signed nothing and owes
+// nothing. Everybody else has a waiver, a membership or attendance behind them,
+// and what the club may destroy of that is still an open product question.
+// So the test that matters is the negative one: the button is not drawn on a
+// person's row, whatever else changes about this screen.
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const listClubUsers = vi.fn();
+const markInterestRegistrationsSeen = vi.fn();
+const deleteLead = vi.fn();
+
+const lead = {
+  user_id: null,
+  name: "Sam Lee",
+  greeting_name: null,
+  email: "sam@example.com",
+  email_confirmed_at: null,
+  phone: "0400 000 111",
+  roles: [] as string[],
+  lifecycle_status: "lead" as const,
+  has_waiver: false,
+  waiver_signed_at: null,
+  is_uts_student: false,
+  uts_student_number: null,
+  gi_size: null,
+  belt_size: null,
+  latest_plan_name: null,
+  latest_plan_kind: null,
+  latest_membership_status: null,
+  latest_sessions_remaining: null,
+  membership_count: 0,
+  sessions_attended: 0,
+  first_seen_at: "2026-08-05T10:00:00.000Z",
+};
+const member = {
+  ...lead,
+  user_id: "user-1",
+  name: "Kim Tran",
+  email: "kim@example.com",
+  lifecycle_status: "member" as const,
+  has_waiver: true,
+  waiver_signed_at: "2026-07-01T00:00:00.000Z",
+};
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => opts,
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@tanstack/react-start", () => ({
+  useServerFn: (fn: unknown) => fn,
+}));
+
+vi.mock("@/lib/membership.functions", () => ({
+  listClubUsers: (...args: unknown[]) => listClubUsers(...args),
+}));
+
+vi.mock("@/lib/leads.functions", () => ({
+  markInterestRegistrationsSeen: (...args: unknown[]) => markInterestRegistrationsSeen(...args),
+  deleteLead: (...args: unknown[]) => deleteLead(...args),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "manager-1" }, session: null, loading: false }),
+  useRoles: () => ({ roles: ["manager"], loading: false, isManager: true }),
+}));
+
+vi.mock("@/hooks/useNotifications", () => ({
+  useNotifications: () => ({ refresh: vi.fn() }),
+}));
+
+const { Route } = await import("./manager.users");
+const ManagerUsersPage = (Route as unknown as { component: () => ReactNode }).component;
+
+async function renderLoaded() {
+  render(<ManagerUsersPage />);
+  await screen.findByRole("table");
+}
+
+beforeEach(() => {
+  listClubUsers.mockReset().mockResolvedValue([lead, member]);
+  markInterestRegistrationsSeen.mockReset().mockResolvedValue({ ok: true, newEmails: [] });
+  deleteLead.mockReset().mockResolvedValue({ ok: true, deleted: 1 });
+});
+
+describe("/manager/users", () => {
+  it("offers no delete for someone the club has a record for", async () => {
+    await renderLoaded();
+    expect(screen.queryByRole("button", { name: /Delete the enquiry from Kim Tran/ })).toBeNull();
+  });
+
+  it("deletes nothing until the manager confirms", async () => {
+    await renderLoaded();
+    await userEvent.click(screen.getByRole("button", { name: "Delete the enquiry from Sam Lee" }));
+
+    expect(deleteLead).not.toHaveBeenCalled();
+    expect(screen.getByText("Sam Lee")).toBeInTheDocument();
+  });
+
+  it("names the address, and says the contact inbox is separate", async () => {
+    await renderLoaded();
+    await userEvent.click(screen.getByRole("button", { name: "Delete the enquiry from Sam Lee" }));
+
+    const dialog = within(await screen.findByRole("alertdialog"));
+    expect(dialog.getByText(/Delete the enquiry from Sam Lee\?/)).toBeInTheDocument();
+    // A manager pressing this is entitled to think it removes everything about
+    // the person. It does not: their contact-form messages live in another
+    // inbox, and the confirm has to say so before the click, not after.
+    expect(dialog.getByText(/deleted from Contact messages/)).toBeVisible();
+  });
+
+  it("takes the lead off the list once the server confirms", async () => {
+    await renderLoaded();
+    await userEvent.click(screen.getByRole("button", { name: "Delete the enquiry from Sam Lee" }));
+    await userEvent.click(
+      within(await screen.findByRole("alertdialog")).getByRole("button", { name: "Delete" }),
+    );
+
+    expect(deleteLead).toHaveBeenCalledWith({ data: { email: "sam@example.com" } });
+    expect(screen.queryByText("Sam Lee")).toBeNull();
+    expect(screen.getByText("Kim Tran")).toBeInTheDocument();
+  });
+
+  it("keeps the lead listed when the server refuses", async () => {
+    deleteLead.mockRejectedValue(new Error("That address belongs to someone the club has..."));
+    await renderLoaded();
+    await userEvent.click(screen.getByRole("button", { name: "Delete the enquiry from Sam Lee" }));
+    await userEvent.click(
+      within(await screen.findByRole("alertdialog")).getByRole("button", { name: "Delete" }),
+    );
+
+    // The likeliest refusal is that they signed a waiver since the page loaded.
+    // Their enquiry is still on file, so the row stays.
+    expect(await screen.findByText("Sam Lee")).toBeInTheDocument();
+  });
+});

--- a/src/routes/_authenticated/manager.users.tsx
+++ b/src/routes/_authenticated/manager.users.tsx
@@ -4,6 +4,16 @@ import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Pill } from "@/components/site/StatusPill";
 import { formatDate } from "@/lib/dates";
 import {
@@ -17,7 +27,7 @@ import { lifecycleLabel, membershipStatusLabel } from "@/lib/status-labels";
 import { lifecycleStatuses, normalizeEmail } from "@/lib/validation";
 import { emailVerificationLabel } from "@/lib/email-verification";
 import { listClubUsers } from "@/lib/membership.functions";
-import { markInterestRegistrationsSeen } from "@/lib/leads.functions";
+import { deleteLead, markInterestRegistrationsSeen } from "@/lib/leads.functions";
 import { useAuth, useRoles } from "@/hooks/useAuth";
 import { useNotifications } from "@/hooks/useNotifications";
 
@@ -41,6 +51,7 @@ function ManagerUsersPage() {
   const { isManager, loading: rolesLoading } = useRoles(user?.id);
   const fetchList = useServerFn(listClubUsers);
   const markLeadsSeen = useServerFn(markInterestRegistrationsSeen);
+  const removeLead = useServerFn(deleteLead);
   const { refresh: refreshNotifications } = useNotifications();
 
   const [rows, setRows] = useState<Row[]>([]);
@@ -56,6 +67,12 @@ function ManagerUsersPage() {
   const [waiver, setWaiver] = useState<string>("all");
   const [student, setStudent] = useState<string>("all");
   const [sort, setSort] = useState<SortKey>("name");
+
+  // The lead a manager has asked to delete, held until they confirm. The row
+  // stays in the table until the server says the rows are gone, so a refusal
+  // leaves the directory exactly as it was.
+  const [pendingDelete, setPendingDelete] = useState<Row | null>(null);
+  const [deletingEmail, setDeletingEmail] = useState<string | null>(null);
 
   useEffect(() => {
     if (!rolesLoading && user && !isManager) navigate({ to: "/account" });
@@ -148,6 +165,28 @@ function ManagerUsersPage() {
     }
     return sorted;
   }, [rows, search, lifecycle, role, waiver, student, sort]);
+
+  async function onDeleteLead(row: Row) {
+    if (!row.email) return;
+    const email = row.email;
+    setDeletingEmail(email);
+    try {
+      await removeLead({ data: { email } });
+      const wanted = normalizeEmail(email);
+      setRows((prev) =>
+        prev.filter((r) => r.user_id || !r.email || normalizeEmail(r.email) !== wanted),
+      );
+      toast.success("Enquiry deleted");
+    } catch (e) {
+      // Nothing was lost: the row is still in the table and still in the
+      // database. The likeliest refusal is that this address now belongs to
+      // somebody who has signed a waiver, and the message says so.
+      toast.error(e instanceof Error ? e.message : "Could not delete that enquiry");
+    } finally {
+      setDeletingEmail(null);
+      setPendingDelete(null);
+    }
+  }
 
   return (
     <>
@@ -266,6 +305,9 @@ function ManagerUsersPage() {
                     <th className="px-3 py-2">Sessions</th>
                     <th className="px-3 py-2">Latest membership</th>
                     <th className="px-3 py-2">First seen</th>
+                    <th className="px-3 py-2">
+                      <span className="sr-only">Actions</span>
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
@@ -365,6 +407,28 @@ function ManagerUsersPage() {
                         )}
                       </td>
                       <td className="px-3 py-2">{formatDate(r.first_seen_at)}</td>
+                      {/* Only a lead can be deleted from here. Everyone else has
+                          a signed waiver, a membership or attendance behind
+                          them, and what the club is allowed to destroy of that
+                          is still an open question, so the button is not drawn
+                          rather than drawn and refused. */}
+                      <td className="px-3 py-2 text-right">
+                        {!r.user_id && r.email ? (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                            // Named after whose enquiry it deletes: one row of
+                            // a long directory, and nothing about a button
+                            // called "Delete" says which row it belongs to.
+                            aria-label={`Delete the enquiry from ${r.name ?? r.email}`}
+                            disabled={deletingEmail === r.email}
+                            onClick={() => setPendingDelete(r)}
+                          >
+                            {deletingEmail === r.email ? "Deleting..." : "Delete"}
+                          </Button>
+                        ) : null}
+                      </td>
                     </tr>
                   ))}
                 </tbody>
@@ -373,6 +437,34 @@ function ManagerUsersPage() {
           </>
         )}
       </section>
+
+      <AlertDialog
+        open={Boolean(pendingDelete)}
+        onOpenChange={(open) => !open && setPendingDelete(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete the enquiry from {pendingDelete?.name ?? pendingDelete?.email}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This deletes every interest form filed under {pendingDelete?.email}, with the name,
+              phone number and message on it, and takes them off this list. The club keeps no copy,
+              and it can't be undone. Anything they sent through the contact form is separate, and
+              is deleted from Contact messages.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => pendingDelete && onDeleteLead(pendingDelete)}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }


### PR DESCRIPTION
## Open questions, before anything else

This is the first slice of #55, and the rest of that issue is blocked on decisions only the club can make. The full research (every place a person's data lives, and what deleting each one breaks) is in [a comment on the issue](https://github.com/fryorcraken/jitsu-au/issues/55#issuecomment-5369001881). The questions, in short:

1. **Does "delete me" mean erase, or de-identify?** Keeping the skeleton (a waiver was signed on this date; a membership ran for these dates at this price) keeps the club's history without holding the person. Full erasure is simpler and leaves the club with no evidence anybody consented to train.
2. **What must be retained regardless, and for how long?** A signed waiver is evidence of informed consent. Minors are the sharp edge: that period commonly starts when the person turns 18, so "N years from signing" and "until 18 plus N" give very different answers for the same document. This wants the same advice as the privacy policy, which does not exist on the site yet.
3. **Manager only, or can a member start it?** My recommendation is manager only for now, with a member-facing *request* later if the club wants one.
4. **What about waiver PDFs already exported into a manager's personal Google Drive?** They are filed under the member's real name. The club knows which files they are and could delete them, but only while that manager still has Drive connected.

None of those block this PR. Nothing here touches a waiver, a membership, attendance or a login.

## What changes for the people using the site

**For a manager.**

- On **Contact messages**, each message now has a Delete button. Confirming it destroys the message, the sender's name and their email address. There is no copy anywhere else in the product, and the confirm says so before the click.
- On **Users**, a **lead** (someone who filled in the interest form and never signed anything) can be deleted. That removes every interest form filed under their address and takes them off the list. Anyone the club has a record for gets no button at all, and the server refuses it even if one were somehow pressed.

Both confirms name the person and spell out what goes. Neither removes the row from the screen until the server confirms it, so a refusal or a failure leaves everything exactly where it was.

**For a member or a prospective member.** Nothing. No screen they see changes.

**Anything they'd feel.** Deletion is final and there is no undo, which is why both actions sit behind a confirm that reads like one. Deleting a lead does *not* delete anything they sent through the contact form: those are a separate inbox with their own screen, and the confirm says that too rather than letting a manager assume otherwise.

## Why this slice and not more

Someone who only enquired signed nothing, owes nothing and has no record hanging off them, so there is no evidence to weigh against destroying it. Until now those rows could not be removed by anybody, which also meant spam in the contact inbox was permanent.

Everything else a person leaves behind is either evidence or the club's own history, and building erasure for that on a guess would either destroy what the club needs or keep what it should not have.

Worth knowing: deleting somebody's login by hand in the dashboard today is **worse than doing nothing**. It destroys every waiver they signed, their whole record and their attendance, while leaving the signed PDF files, their memberships (still carrying student number and payment reference) and every enquiry in place forever. `docs/erasing-personal-data.md`, new in this PR, records that map in full for whoever builds the next step.

## Database

**No migration.** Both tables already grant the client roles a bare `INSERT` and nothing else; these deletes run on the service-role client behind the manager gate, so no grant, policy or schema change is involved. Nothing here needs applying to the live database.

## Notes for review

Three guards carry the risk, and all of them are pinned by tests:

- The lead delete **re-checks on the server** that the address has no person behind it. The directory a manager clicked from can be minutes old, and a waiver signed in between turns a lead into an applicant whose enquiry is part of a real record. That closes the staleness, not a race: the check and the delete are separate round trips, so a waiver signed in the sub-second gap between them still loses its lead row. The address survives on the waiver as submitted, which is the copy that matters.
- The row search is a **prefilter, not the decision**. `ilike` over-matches, because `_` is a LIKE wildcard and is legal in an email local part, so `a_b@example.com` also matches `axb@example.com`. The exact comparison in JS is what chooses. Backwards, that pattern would destroy a stranger's enquiry. (`%` is a wildcard too; the interest form's validator rejects it today, which is not something the delete leans on.)
- The read is **bounded**, like every other read in that file. One address holding more registrations than the cap warns and leaves the remainder, so the lead reappears and a second press takes another bite. On a delete, doing less than asked is the safe direction to fail.

Tests added: `deleteLeadRegistrations` (refusal when the address has a person, case-insensitive match across duplicate rows, the wildcard over-match, the cap, fail-closed on a failed lookup and on a failed delete), both new schemas, and component tests for the two screens covering "no button on a person's row", "nothing deleted until confirmed", the confirm copy, and "the row stays when the delete fails".

A code review over the diff found nothing must-fix; the three follow-ups it did raise are in `712b80c` and summarised in a comment below.

Verified with `bun run lint`, `bun run typecheck`, `bun run test` (2048 passing) and `bun run build`. `bun.lock` untouched. `main` merged in at `a54fd98`.

Closes nothing: #55 stays open for the decisions above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbsEszePvcjLdHrbThGNHk)_