### PR TITLE
Ask before approving a waiver, and put the friction where it belongs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -853,10 +853,13 @@ Then hold the change to this:
   option if you want a safety net — a modal gate on it only slows down the 99%
   of clicks that were correct. Save the hard stop for actions that are both
   irreversible and consequential, like the waiver-approval example above, and
-  build that stop as the app's own `AlertDialog` (see `manager.blog.tsx`'s
-  delete confirmation), never the browser's `window.confirm()`. Confirming
-  everything trains people to click through without reading, which is exactly
-  what makes the one confirm that matters stop working.
+  ask it through **`useConfirm`** (`src/hooks/use-confirm.tsx`), the app's own
+  `AlertDialog` asked as `await confirm({ ... })`, never the browser's
+  `window.confirm()`. Confirming everything trains people to click through
+  without reading, which is exactly what makes the one confirm that matters
+  stop working. One thing that IS worth a hard stop despite looking reversible:
+  a click that throws away text somebody typed and has not saved
+  (`discardUnsavedChanges`, in the same file). No second click brings that back.
 - **Mobile first.** Most of this club's traffic is phones. Check at ~375px wide,
   keep tap targets thumb-sized, and never hide something behind hover alone.
 - **Accessibility is part of "done", not a follow-up.** Real `<button>` and `<a>`

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -144,9 +144,12 @@ come back from the save and become the form's new baseline.
 again** — not on a later edit, and not on an unpublish/republish round trip —
 so a post's publish date and its position in the public list (sorted by
 `published_at`) both stay stable regardless of how many times it's drafted
-and republished. The editor warns before an unpublish and guards against
-losing unsaved work (a confirm on leaving, and a browser close/refresh
-warning) the same way the waiver template editor does.
+and republished. Switching a live post back to Draft puts a notice under the
+status picker saying saving takes it off the public blog and that it can be
+published again any time. There is deliberately no dialog on top of that: the
+same form undoes it in one click. Leaving with unsaved edits DOES ask, since
+nothing brings typed text back, and a browser close/refresh warning covers the
+same ground, the way the waiver template editor does.
 
 ### A manager moderates
 

--- a/docs/waivers.md
+++ b/docs/waivers.md
@@ -97,8 +97,8 @@ system. (The contact form stores a message, not a person.)
    in an hour, so it is usually dead by the time it is read, while this one
    still works whenever they get to it. Approving a newer waiver later
    refreshes the profile again (no repeat activation email, no second trial).
-   Unapprove only reverts the waiver's status; profile, login and trial stay
-   as they are.
+   Revoking approval only reverts the waiver's status; profile, login and
+   trial stay as they are.
    The trial is dated from the day the waiver was **signed**, not the day it
    was approved, so the row records when the entitlement was really earned: a
    form filled in at the gym may not be approved until hours or days later.
@@ -395,15 +395,24 @@ step happens. See `docs/notifications.md` for the two items and how each clears.
 
 The manager waivers screen lists submissions newest first with the submitted
 name/email, date, template version, status badge (pending / active /
-superseded), the PDF, and Approve / Unapprove. Approve = promote + unlock +
-assign the trial (see rule 6). The applicant becomes a visitor.
+superseded), the PDF, and Approve / Revoke approval. Approve = promote + unlock
+
+- assign the trial (see rule 6). The applicant becomes a visitor.
+
+Approve asks first, in the app's own dialog (`useConfirm`), naming the three
+things a first approval does that nothing here can take back: the email, the
+login, the trial. The wording is `approvalConfirmation` in
+`src/lib/waiver-approval.ts`, so both approval screens ask in the same words.
+Revoking is not gated: it flips the row back to pending and re-approving
+restores it, which is why the button no longer says "Unapprove". It never
+undid the email, the login or the trial, and the old label promised it did.
 
 For one person there is a user page (`/manager/users/:userId`, reached from the
 directory), which is where a review normally happens: the profile (the club's
 current record), their memberships, and every submission they ever made, newest
 first. Each submission is a collapsible panel holding the frozen submission in
 full, the signing record (IP + browser context), when it was approved and by
-whom, Approve / Unapprove, and the signed PDF embedded inline. The approver is
+whom, Approve / Revoke approval, and the signed PDF embedded inline. The approver is
 shown by name, or by their login address if they have no profile of their own;
 an approval recorded before the club started keeping that (or one whose
 approver's account is gone) reads as unknown rather than as nobody. The submissions themselves load with the page; the

--- a/docs/waivers.md
+++ b/docs/waivers.md
@@ -395,9 +395,8 @@ step happens. See `docs/notifications.md` for the two items and how each clears.
 
 The manager waivers screen lists submissions newest first with the submitted
 name/email, date, template version, status badge (pending / active /
-superseded), the PDF, and Approve / Revoke approval. Approve = promote + unlock
-
-- assign the trial (see rule 6). The applicant becomes a visitor.
+superseded), the PDF, and Approve / Revoke approval. Approve = promote + unlock +
+assign the trial (see rule 6). The applicant becomes a visitor.
 
 Approve asks first, in the app's own dialog (`useConfirm`), naming the three
 things a first approval does that nothing here can take back: the email, the

--- a/e2e/manager/new-member-journey.spec.ts
+++ b/e2e/manager/new-member-journey.spec.ts
@@ -133,9 +133,13 @@ test("a new member's journey: register, sign, trial, buy, pay, and switch plans"
   await step(page, "a manager approves the waiver, which assigns the free trial", async () => {
     await page.goto(`/manager/users/${newUserId}`);
     await expectPageRendered(page);
-    await page.getByRole("button", { name: "Approve" }).click();
+    await page.getByRole("button", { name: "Approve", exact: true }).click();
+    // Approving emails the member and opens their login, so it asks first and
+    // says so. The photograph of this step is that dialog.
+    await expect(page.getByRole("alertdialog")).toContainText("starts their free trial");
+    await page.getByRole("button", { name: "Approve waiver" }).click();
     // The button relabels once its own click lands — no toast text to guess.
-    await expect(page.getByRole("button", { name: "Unapprove" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Revoke approval" })).toBeVisible();
   });
 
   // The four earliest seeded classes (scripts/seed-local-club.mjs puts five

--- a/src/components/site/BlogPostEditor.tsx
+++ b/src/components/site/BlogPostEditor.tsx
@@ -214,14 +214,10 @@ export function BlogPostEditor({
       toast.error(check.error.issues[0]?.message ?? "Check the form for errors.");
       return;
     }
-    if (
-      willUnpublish &&
-      !window.confirm(
-        "This post is currently published. Saving as Draft will remove it from the public blog. Continue?",
-      )
-    ) {
-      return;
-    }
+    // Deliberately no confirm here. Taking a post off the blog is undone by
+    // publishing it again from this same form, and the notice under the status
+    // picker already says what saving will do, before the click rather than
+    // after it. A modal on top of that is friction on a reversible action.
     onSave(value);
   }
 
@@ -387,8 +383,8 @@ export function BlogPostEditor({
           </SelectContent>
         </Select>
         {willUnpublish && (
-          <p className="mt-1.5 text-xs text-amber-600 dark:text-amber-500">
-            Saving will remove this post from the public blog.
+          <p role="status" className="mt-1.5 text-xs text-amber-600 dark:text-amber-500">
+            Saving takes this post off the public blog. You can publish it again any time.
           </p>
         )}
       </div>

--- a/src/components/site/KbArticleReader.test.tsx
+++ b/src/components/site/KbArticleReader.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { KbArticleReader } from "./KbArticleReader";
 import type { ReaderAnnotation, ReaderArticle, ReaderViewer } from "./KbArticleReader";
@@ -52,6 +52,7 @@ function renderReader(over: {
   // The write callbacks report success; the component clears its inputs only
   // when they do. Default to success so the ordinary path is what is exercised.
   const onCreate = over.onCreate ?? vi.fn().mockResolvedValue(true);
+  const onDelete = vi.fn().mockResolvedValue(undefined);
   render(
     <KbArticleReader
       article={over.article ?? article}
@@ -59,11 +60,11 @@ function renderReader(over: {
       viewer={over.viewer ?? canAnnotate}
       onCreate={onCreate as never}
       onUpdate={vi.fn().mockResolvedValue(true)}
-      onDelete={vi.fn().mockResolvedValue(undefined)}
+      onDelete={onDelete}
       onResolve={vi.fn().mockResolvedValue(undefined)}
     />,
   );
-  return { onCreate };
+  return { onCreate, onDelete };
 }
 
 describe("KbArticleReader", () => {
@@ -238,5 +239,60 @@ describe("KbArticleReader", () => {
       ],
     });
     expect(screen.queryByRole("button", { name: /Reply/i })).not.toBeInTheDocument();
+  });
+
+  // Deleting a comment takes its replies with it and nothing brings either
+  // back, so it asks first, in the app's own dialog rather than the browser's.
+  it("says the replies go too before deleting a comment, and deletes only when told to", async () => {
+    const user = userEvent.setup();
+    const { onDelete } = renderReader({
+      annotations: [annotation({ is_mine: true, can_edit: true, block_id: null, quote: null })],
+    });
+
+    await user.click(screen.getByRole("button", { name: /Delete/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    expect(dialog).toHaveTextContent("Delete this comment?");
+    expect(dialog).toHaveTextContent("Any replies to it go too");
+    expect(onDelete).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Delete comment" }));
+    await waitFor(() => expect(onDelete).toHaveBeenCalledWith("a-1"));
+  });
+
+  it("keeps a comment when the question is answered no", async () => {
+    const user = userEvent.setup();
+    const { onDelete } = renderReader({
+      annotations: [annotation({ is_mine: true, can_edit: true, block_id: null, quote: null })],
+    });
+
+    await user.click(screen.getByRole("button", { name: /Delete/i }));
+    await screen.findByRole("alertdialog");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(screen.getByText("Does this include rash guards?")).toBeInTheDocument();
+  });
+
+  // A reply has nothing hanging off it, so it gets its own, shorter question.
+  it("asks about a reply on its own terms", async () => {
+    const user = userEvent.setup();
+    renderReader({
+      annotations: [
+        annotation({ block_id: null, quote: null }),
+        annotation({
+          id: "a-2",
+          parent_id: "a-1",
+          is_mine: true,
+          can_edit: true,
+          block_id: null,
+          quote: null,
+        }),
+      ],
+    });
+
+    await user.click(screen.getByRole("button", { name: /Delete/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    expect(dialog).toHaveTextContent("Delete this reply?");
+    expect(screen.getByRole("button", { name: "Delete reply" })).toBeInTheDocument();
   });
 });

--- a/src/components/site/KbArticleReader.tsx
+++ b/src/components/site/KbArticleReader.tsx
@@ -20,6 +20,7 @@ import { formatDate } from "@/lib/dates";
 import { groupThreads, resolveAnchors, splitBlocks } from "@/lib/kb";
 import type { AnnotationVisibility } from "@/lib/kb";
 import { extractHeadings } from "@/lib/kb-nav";
+import { useConfirm } from "@/hooks/use-confirm";
 import { kbMarkdownComponents, kbRemarkPlugins } from "@/lib/kb-markdown";
 
 /** One annotation, exactly as `listAnnotations` returns it. */
@@ -478,6 +479,7 @@ function AnnotationCard({
   // the card, so reopening the editor later showed stale text.
   const [draft, setDraft] = useState(annotation.body);
   const [draftFor, setDraftFor] = useState(annotation.body);
+  const { confirm, confirmDialog } = useConfirm();
   if (draftFor !== annotation.body && !editing) {
     setDraftFor(annotation.body);
     setDraft(annotation.body);
@@ -560,13 +562,26 @@ function AnnotationCard({
             <button
               type="button"
               disabled={busy}
-              onClick={() => {
+              onClick={async () => {
                 // Replies cascade with their root, so a thread's author deleting
-                // it takes the conversation. Ask first.
-                const warning = annotation.parent_id
-                  ? "Delete this reply?"
-                  : "Delete this comment and any replies to it?";
-                if (window.confirm(warning)) void onDelete(annotation.id);
+                // it takes the conversation with it. Nothing brings either back.
+                const ok = await confirm(
+                  annotation.parent_id
+                    ? {
+                        title: "Delete this reply?",
+                        description: "It comes off the thread for everyone who can see it.",
+                        confirmLabel: "Delete reply",
+                        destructive: true,
+                      }
+                    : {
+                        title: "Delete this comment?",
+                        description:
+                          "Any replies to it go too, for everyone who can see them. There is no way to get the thread back.",
+                        confirmLabel: "Delete comment",
+                        destructive: true,
+                      },
+                );
+                if (ok) void onDelete(annotation.id);
               }}
               className="flex items-center gap-1 hover:text-foreground"
             >
@@ -587,6 +602,7 @@ function AnnotationCard({
           )}
         </div>
       )}
+      {confirmDialog}
     </div>
   );
 }

--- a/src/hooks/use-confirm.test.tsx
+++ b/src/hooks/use-confirm.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi } from "vitest";
+import { useState } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useConfirm, type ConfirmRequest } from "./use-confirm";
+
+const REQUEST: ConfirmRequest = {
+  title: "Approve this waiver?",
+  description: "This copies what they signed onto their member record.",
+  details: ["emails them to say their account is active", "starts their free trial"],
+  footnote: "The email cannot be unsent.",
+  confirmLabel: "Approve waiver",
+};
+
+/**
+ * A page with one guarded action, so the tests can drive the hook the way a
+ * real screen does: click, answer, and see whether the work ran.
+ */
+function Harness({
+  request = REQUEST,
+  onAnswer,
+}: {
+  request?: ConfirmRequest;
+  onAnswer?: (answer: boolean) => void;
+}) {
+  const { confirm, confirmDialog } = useConfirm();
+  const [ran, setRan] = useState<boolean | null>(null);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={async () => {
+          const answer = await confirm(request);
+          onAnswer?.(answer);
+          setRan(answer);
+        }}
+      >
+        Do the thing
+      </button>
+      <p>{ran === null ? "not asked" : ran ? "went ahead" : "stopped"}</p>
+      {confirmDialog}
+    </>
+  );
+}
+
+describe("useConfirm", () => {
+  it("asks nothing until the action is taken", () => {
+    render(<Harness />);
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("shows the question, what it does, and what it cannot take back", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole("button", { name: "Do the thing" }));
+
+    const dialog = await screen.findByRole("alertdialog");
+    expect(dialog).toHaveTextContent("Approve this waiver?");
+    expect(dialog).toHaveTextContent("copies what they signed onto their member record");
+    expect(dialog).toHaveTextContent("emails them to say their account is active");
+    expect(dialog).toHaveTextContent("starts their free trial");
+    expect(dialog).toHaveTextContent("The email cannot be unsent.");
+  });
+
+  it("names the action on its button rather than saying OK", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole("button", { name: "Do the thing" }));
+    expect(await screen.findByRole("button", { name: "Approve waiver" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "OK" })).not.toBeInTheDocument();
+  });
+
+  it("answers true when the confirm button is pressed", async () => {
+    const user = userEvent.setup();
+    const onAnswer = vi.fn();
+    render(<Harness onAnswer={onAnswer} />);
+    await user.click(screen.getByRole("button", { name: "Do the thing" }));
+    await user.click(await screen.findByRole("button", { name: "Approve waiver" }));
+
+    await waitFor(() => expect(onAnswer).toHaveBeenCalledWith(true));
+    expect(screen.getByText("went ahead")).toBeInTheDocument();
+  });
+
+  it("answers false when cancelled, so the caller stops", async () => {
+    const user = userEvent.setup();
+    const onAnswer = vi.fn();
+    render(<Harness onAnswer={onAnswer} />);
+    await user.click(screen.getByRole("button", { name: "Do the thing" }));
+    await user.click(await screen.findByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => expect(onAnswer).toHaveBeenCalledWith(false));
+    expect(screen.getByText("stopped")).toBeInTheDocument();
+  });
+
+  it("answers false when the dialog is dismissed with Escape", async () => {
+    const user = userEvent.setup();
+    const onAnswer = vi.fn();
+    render(<Harness onAnswer={onAnswer} />);
+    await user.click(screen.getByRole("button", { name: "Do the thing" }));
+    await screen.findByRole("alertdialog");
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => expect(onAnswer).toHaveBeenCalledWith(false));
+    expect(screen.getByText("stopped")).toBeInTheDocument();
+  });
+
+  it("uses a custom cancel label when one is given", async () => {
+    const user = userEvent.setup();
+    render(<Harness request={{ ...REQUEST, cancelLabel: "Keep editing" }} />);
+    await user.click(screen.getByRole("button", { name: "Do the thing" }));
+    expect(await screen.findByRole("button", { name: "Keep editing" })).toBeInTheDocument();
+  });
+
+  it("leaves out the list and the footnote when there are none", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        request={{
+          title: "Delete this?",
+          description: "It goes for good.",
+          confirmLabel: "Delete",
+        }}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Do the thing" }));
+    const dialog = await screen.findByRole("alertdialog");
+    expect(dialog.querySelector("ul")).toBeNull();
+    expect(dialog).toHaveTextContent("It goes for good.");
+  });
+
+  it("answers an unmounted caller rather than leaving its flow hanging", async () => {
+    const user = userEvent.setup();
+    const onAnswer = vi.fn();
+    // A guarded action can outlive its screen: a manager clicks, then the
+    // route changes under them. An `await confirm(...)` that never settles
+    // would stop that flow halfway with nothing on screen to say so.
+    const { unmount } = render(<Harness onAnswer={onAnswer} />);
+    await user.click(screen.getByRole("button", { name: "Do the thing" }));
+    await screen.findByRole("alertdialog");
+    unmount();
+
+    await waitFor(() => expect(onAnswer).toHaveBeenCalledWith(false));
+  });
+
+  it("answers the first question no when a second one takes the dialog", async () => {
+    const user = userEvent.setup();
+    const answers: Record<string, boolean> = {};
+    function TwoQuestions() {
+      const { confirm, confirmDialog } = useConfirm();
+      return (
+        <>
+          <button
+            type="button"
+            onClick={async () => {
+              const first = confirm({ ...REQUEST, title: "First?" });
+              const second = confirm({ ...REQUEST, title: "Second?" });
+              answers.first = await first;
+              answers.second = await second;
+            }}
+          >
+            Do the thing
+          </button>
+          {confirmDialog}
+        </>
+      );
+    }
+    render(<TwoQuestions />);
+    await user.click(screen.getByRole("button", { name: "Do the thing" }));
+
+    const dialog = await screen.findByRole("alertdialog");
+    expect(dialog).toHaveTextContent("Second?");
+    await user.click(screen.getByRole("button", { name: "Approve waiver" }));
+
+    await waitFor(() => expect(answers).toEqual({ first: false, second: true }));
+  });
+});

--- a/src/hooks/use-confirm.tsx
+++ b/src/hooks/use-confirm.tsx
@@ -1,0 +1,156 @@
+// The app's hard stop: one question, asked in the app's own dialog, before an
+// action that cannot be taken back.
+//
+// This exists because the alternative in this codebase was `window.confirm()`,
+// which CLAUDE.md's UX bar bans outright. That ban is not about looks. A
+// browser confirm blocks the whole tab, ignores the theme, is cramped and
+// unreadable on the phones most of this club's traffic comes from, and Chrome
+// will offer to suppress every later one after a couple in a row. Losing the
+// one dialog that matters to a checkbox somebody ticked to get rid of the ones
+// that did not is exactly the failure this repo is trying to avoid.
+//
+// The API is a promise rather than a `pendingX` state plus a block of JSX
+// because most of these questions are asked in the MIDDLE of a flow ("you have
+// unsaved changes", "this widens who can read it"), where the old code read
+// `if (!window.confirm(...)) return;`. Keeping that shape means each call site
+// stays a two-line edit instead of being turned inside out, and the wording
+// stays next to the action it is about.
+//
+// Two dialogs deliberately do NOT use this: `MembershipRowActions` and
+// `manager.blog.tsx` already ask with the same `AlertDialog` primitive, and the
+// first has to stay open to show a failure and offer a retry, which a
+// yes/no promise cannot express. This is a replacement for `window.confirm`,
+// not a second way to open a dialog.
+//
+// What NOT to put behind it: anything a second click undoes. Cancel, hide,
+// reorder, unpublish-then-publish. Confirming everything teaches people to
+// click through without reading, which is what makes the one confirm that
+// matters stop working.
+
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+export type ConfirmRequest = {
+  /** The question, as a question. */
+  title: string;
+  /** What going ahead does, in the person's words, not the system's. */
+  description: ReactNode;
+  /** One line per thing the action does. Rendered as a list under the description. */
+  details?: string[];
+  /** The part that should stop someone: what this cannot take back. */
+  footnote?: ReactNode;
+  /** The button that goes ahead. Name the action, never "OK". */
+  confirmLabel: string;
+  /** Defaults to "Cancel". */
+  cancelLabel?: string;
+  /** Paints the confirm button red. For deletes, not for merely serious things. */
+  destructive?: boolean;
+};
+
+/**
+ * Ask before an irreversible or outward-facing action.
+ *
+ * ```tsx
+ * const { confirm, confirmDialog } = useConfirm();
+ * // ...
+ * if (!(await confirm({ title: "Delete this?", description: "...", confirmLabel: "Delete" })) ) return;
+ * // ...
+ * return <>{content}{confirmDialog}</>;
+ * ```
+ *
+ * Cancelling, pressing Escape and clicking away all answer `false`, so the
+ * caller only ever has to handle the two answers.
+ */
+export function useConfirm(): {
+  confirm: (request: ConfirmRequest) => Promise<boolean>;
+  confirmDialog: ReactNode;
+} {
+  // `request` outlives `open` on purpose: Radix keeps the content mounted for
+  // its close animation, and clearing the wording at the same moment would
+  // flash an empty dialog on the way out.
+  const [request, setRequest] = useState<ConfirmRequest | null>(null);
+  const [open, setOpen] = useState(false);
+  const resolveRef = useRef<((answer: boolean) => void) | null>(null);
+
+  const settle = useCallback((answer: boolean) => {
+    const resolve = resolveRef.current;
+    resolveRef.current = null;
+    setOpen(false);
+    resolve?.(answer);
+  }, []);
+
+  const confirm = useCallback((next: ConfirmRequest) => {
+    // A second question while one is still open would strand the first
+    // caller's promise forever, and an awaited promise that never settles is a
+    // flow that stops halfway with no error and nothing on screen. Answer the
+    // old question "no" and let the new one take the dialog.
+    resolveRef.current?.(false);
+    setRequest(next);
+    setOpen(true);
+    return new Promise<boolean>((resolve) => {
+      resolveRef.current = resolve;
+    });
+  }, []);
+
+  // Navigating away with a question open strands the caller the same way.
+  useEffect(
+    () => () => {
+      const resolve = resolveRef.current;
+      resolveRef.current = null;
+      resolve?.(false);
+    },
+    [],
+  );
+
+  const confirmDialog = request ? (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) settle(false);
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{request.title}</AlertDialogTitle>
+          <AlertDialogDescription>{request.description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        {request.details?.length ? (
+          <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+            {request.details.map((line) => (
+              <li key={line}>{line}</li>
+            ))}
+          </ul>
+        ) : null}
+        {request.footnote ? (
+          <p className="text-sm text-muted-foreground">{request.footnote}</p>
+        ) : null}
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => settle(false)}>
+            {request.cancelLabel ?? "Cancel"}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            className={
+              request.destructive
+                ? "bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                : undefined
+            }
+            onClick={() => settle(true)}
+          >
+            {request.confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ) : null;
+
+  return { confirm, confirmDialog };
+}

--- a/src/hooks/use-confirm.tsx
+++ b/src/hooks/use-confirm.tsx
@@ -154,3 +154,27 @@ export function useConfirm(): {
 
   return { confirm, confirmDialog };
 }
+
+/**
+ * The one question four different editors ask, in one place so all four ask it
+ * the same way.
+ *
+ * This one IS a hard stop, even though the click that triggers it (go back,
+ * open another version, start a new article) is otherwise ordinary. What it
+ * guards is text somebody typed and has not saved, and no second click brings
+ * that back: "never lose someone's input" outranks "don't gate a reversible
+ * action" when the thing at stake is the input. It also only ever appears when
+ * the editor is genuinely dirty, so it is not on anybody's common path.
+ *
+ * `what` names the click, and reads on from "Your edits ... have not been
+ * saved." So: "Going back", "Opening this section", "Starting a new article".
+ */
+export function discardUnsavedChanges(what: string): ConfirmRequest {
+  return {
+    title: "Discard your unsaved changes?",
+    description: `Your edits here have not been saved. ${what} loses them, and there is no way to get them back.`,
+    confirmLabel: "Discard changes",
+    cancelLabel: "Keep editing",
+    destructive: true,
+  };
+}

--- a/src/lib/waiver-approval.test.ts
+++ b/src/lib/waiver-approval.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  approvalConfirmation,
   approvalFailureMessage,
   approvalRefreshFailureMessage,
   runApproval,
@@ -182,5 +183,41 @@ describe("approvalRefreshFailureMessage", () => {
     expect(approvalRefreshFailureMessage(new Error(""))).toBe(
       "Saved, but the page could not be refreshed.",
     );
+  });
+});
+
+describe("approvalConfirmation", () => {
+  const copy = approvalConfirmation("Sam Tanaka");
+
+  it("asks about the person in front of the manager", () => {
+    expect(copy.title).toBe("Approve Sam Tanaka's waiver?");
+  });
+
+  it("names every outward-facing thing a first approval does", () => {
+    // The three steps that reach past this site: the email, the login and the
+    // trial. A manager who has not been told about the email cannot choose not
+    // to send it, and it is the one that cannot be pulled back.
+    expect(copy.details).toEqual([
+      "emails them to say their account is ready",
+      "unlocks their login so they can sign in",
+      "starts their free trial",
+    ]);
+  });
+
+  it("says plainly that revoking approval does not take any of it back", () => {
+    expect(copy.footnote).toContain("cannot be unsent");
+    expect(copy.footnote).toContain("does not take back the email, the login or the trial");
+  });
+
+  it("names the action on the button rather than saying OK", () => {
+    expect(copy.confirmLabel).toBe("Approve waiver");
+  });
+
+  it("keeps the em dash out of copy a manager reads", () => {
+    // AGENTS.md: no em dashes in user-facing copy, this screen included.
+    const everything = [copy.title, copy.description, copy.footnote, copy.confirmLabel]
+      .concat(copy.details)
+      .join(" ");
+    expect(everything).not.toContain("\u2014");
   });
 });

--- a/src/lib/waiver-approval.ts
+++ b/src/lib/waiver-approval.ts
@@ -129,3 +129,38 @@ export function supersedesMediaConsent({
   if (profileMediaConsentUpdatedAt === null) return true;
   return new Date(waiverSignedAt).getTime() > new Date(profileMediaConsentUpdatedAt).getTime();
 }
+
+// ---- What a manager is told before they approve ----
+//
+// Approving is the one manager action on this site that reaches a person
+// directly and cannot be pulled back: it emails them. Both screens ask the
+// same question in the same words, because it is the same action and the
+// wording is the part that has to be right. Kept here, next to the sequence it
+// describes, so a change to what approving DOES has the sentence about it in
+// the same file.
+
+/**
+ * The confirmation shown before a first approval, ready to hand to `useConfirm`.
+ *
+ * The list is hedged with "if it is their first approved waiver" because that
+ * is the truth: the unban, the email and the trial are all skipped for someone
+ * who can already log in, and the screen cannot tell which case this is
+ * without asking the server. Over-promising here is the safer error. A manager
+ * who expects an email that does not go out loses nothing, while one who does
+ * not expect it has already sent it.
+ */
+export function approvalConfirmation(name: string) {
+  return {
+    title: `Approve ${name}'s waiver?`,
+    description:
+      "This copies what they signed onto their member record. If it is their first approved waiver, it also:",
+    details: [
+      "emails them to say their account is ready",
+      "unlocks their login so they can sign in",
+      "starts their free trial",
+    ],
+    footnote:
+      "That email cannot be unsent. Revoking approval afterwards puts the waiver back to pending, but it does not take back the email, the login or the trial.",
+    confirmLabel: "Approve waiver",
+  };
+}

--- a/src/lib/waiver.functions.ts
+++ b/src/lib/waiver.functions.ts
@@ -1787,7 +1787,7 @@ export const uploadPaperWaiver = createServerFn({ method: "POST" })
 // onto the person's profile (the club's current record), and if they are still
 // a locked applicant (banned auth user, no credentials) the ban is lifted and
 // they're emailed to say their account is active (applicant -> visitor).
-// Unapprove only reverts the waiver's status; the profile and login are left
+// Revoking approval only reverts the waiver's status; the profile and login are left
 // as they are.
 export const setWaiverApproval = createServerFn({ method: "POST" })
   .middleware([requireSupabaseAuth])

--- a/src/routes/_authenticated/manager.blog_.$id.test.tsx
+++ b/src/routes/_authenticated/manager.blog_.$id.test.tsx
@@ -6,7 +6,7 @@
 // exactly what was saved rather than reverting or re-wiping the field.
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 
 const getBlogPostForEdit = vi.fn();
@@ -56,6 +56,16 @@ vi.mock("react-markdown", () => ({
 const { Route } = await import("./manager.blog_.$id");
 const EditBlogPostPage = (Route as unknown as { component: () => ReactNode }).component;
 
+// Radix's Select measures and captures the pointer on its trigger, and jsdom
+// implements neither. Stubbed here rather than in vitest.setup.ts because this
+// is the only suite that opens one.
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = vi.fn(() => false);
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
 beforeEach(() => {
   getBlogPostForEdit.mockReset().mockResolvedValue(post);
   updateBlogPost.mockReset().mockResolvedValue({ ok: true, slug: post.slug });
@@ -88,5 +98,53 @@ describe("/manager/blog/:id", () => {
     // The post-save re-seed effect (baseline now matches what was typed)
     // must not wipe the field back to the pre-save/original body.
     expect(await screen.findByLabelText(/Body/)).toHaveValue("Rewritten body");
+  });
+
+  it("leaves without a word when nothing has been typed", async () => {
+    const user = userEvent.setup();
+    render(<EditBlogPostPage />);
+
+    await screen.findByLabelText("Title");
+    await user.click(screen.getByRole("button", { name: "Back to posts" }));
+
+    // Nothing to lose, so nothing to ask about.
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("asks before Back throws away what has been typed, and keeps it when told to", async () => {
+    const user = userEvent.setup();
+    render(<EditBlogPostPage />);
+
+    const title = await screen.findByLabelText("Title");
+    await user.type(title, " updated");
+    await user.click(screen.getByRole("button", { name: "Back to posts" }));
+
+    const dialog = await screen.findByRole("alertdialog");
+    expect(dialog).toHaveTextContent("Discard your unsaved changes?");
+    expect(dialog).toHaveTextContent("no way to get them back");
+
+    await user.click(screen.getByRole("button", { name: "Keep editing" }));
+    expect(screen.getByLabelText("Title")).toHaveValue("Hello world updated");
+  });
+
+  it("saves a published post straight to draft, with no modal in the way", async () => {
+    // Taking a post off the blog is undone by publishing it again from this
+    // same form, so the friction belongs on the screen (the notice under the
+    // status picker), not in a dialog.
+    getBlogPostForEdit.mockResolvedValue({ ...post, status: "published" });
+    const user = userEvent.setup();
+    render(<EditBlogPostPage />);
+
+    await screen.findByLabelText("Title");
+    await user.click(screen.getByRole("combobox", { name: "Status" }));
+    await user.click(await screen.findByRole("option", { name: "Draft" }));
+    expect(screen.getByText(/takes this post off the public blog/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    await waitFor(() => expect(updateBlogPost).toHaveBeenCalledTimes(1));
+    const sent = updateBlogPost.mock.calls[0][0] as { data: { status: string } };
+    expect(sent.data.status).toBe("draft");
   });
 });

--- a/src/routes/_authenticated/manager.blog_.$id.tsx
+++ b/src/routes/_authenticated/manager.blog_.$id.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { BlogPostEditor, type BlogPostEditorValue } from "@/components/site/BlogPostEditor";
 import { getBlogPostForEdit, updateBlogPost } from "@/lib/blog.functions";
 import { useAuth, useRoles } from "@/hooks/useAuth";
+import { discardUnsavedChanges, useConfirm } from "@/hooks/use-confirm";
 
 export const Route = createFileRoute("/_authenticated/manager/blog_/$id")({
   head: () => ({
@@ -28,6 +29,7 @@ function EditBlogPostPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
+  const { confirm, confirmDialog } = useConfirm();
 
   useEffect(() => {
     if (!rolesLoading && user && !isManager) navigate({ to: "/account" });
@@ -41,8 +43,8 @@ function EditBlogPostPage() {
       .finally(() => setLoading(false));
   }, [isManager, id, fetchPost]);
 
-  function goBack() {
-    if (dirty && !window.confirm("Discard your unsaved changes?")) return;
+  async function goBack() {
+    if (dirty && !(await confirm(discardUnsavedChanges("Going back")))) return;
     navigate({ to: "/manager/blog" });
   }
 
@@ -114,7 +116,7 @@ function EditBlogPostPage() {
     <section className="mx-auto max-w-6xl space-y-6 px-4 py-10">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-3xl font-black">Edit post</h1>
-        <Button variant="outline" onClick={goBack}>
+        <Button variant="outline" onClick={() => void goBack()}>
           Back to posts
         </Button>
       </div>
@@ -125,6 +127,7 @@ function EditBlogPostPage() {
         onSave={onSave}
         onDirtyChange={setDirty}
       />
+      {confirmDialog}
     </section>
   );
 }

--- a/src/routes/_authenticated/manager.blog_.new.tsx
+++ b/src/routes/_authenticated/manager.blog_.new.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { BlogPostEditor, type BlogPostEditorValue } from "@/components/site/BlogPostEditor";
 import { createBlogPost } from "@/lib/blog.functions";
 import { useAuth, useRoles } from "@/hooks/useAuth";
+import { discardUnsavedChanges, useConfirm } from "@/hooks/use-confirm";
 
 export const Route = createFileRoute("/_authenticated/manager/blog_/new")({
   head: () => ({
@@ -21,13 +22,14 @@ function NewBlogPostPage() {
   const create = useServerFn(createBlogPost);
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
+  const { confirm, confirmDialog } = useConfirm();
 
   useEffect(() => {
     if (!rolesLoading && user && !isManager) navigate({ to: "/account" });
   }, [rolesLoading, isManager, user, navigate]);
 
-  function goBack() {
-    if (dirty && !window.confirm("Discard your unsaved changes?")) return;
+  async function goBack() {
+    if (dirty && !(await confirm(discardUnsavedChanges("Going back")))) return;
     navigate({ to: "/manager/blog" });
   }
 
@@ -74,11 +76,12 @@ function NewBlogPostPage() {
     <section className="mx-auto max-w-6xl space-y-6 px-4 py-10">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-3xl font-black">New post</h1>
-        <Button variant="outline" onClick={goBack}>
+        <Button variant="outline" onClick={() => void goBack()}>
           Back to posts
         </Button>
       </div>
       <BlogPostEditor initial={initial} saving={saving} onSave={onSave} onDirtyChange={setDirty} />
+      {confirmDialog}
     </section>
   );
 }

--- a/src/routes/_authenticated/manager.calendar.tsx
+++ b/src/routes/_authenticated/manager.calendar.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { useAuth, useRoles } from "@/hooks/useAuth";
+import { useConfirm } from "@/hooks/use-confirm";
 import {
   CLUB_TIME_ZONE,
   DEFAULT_EVENT_LOCATION,
@@ -126,6 +127,7 @@ function ManagerCalendarPage() {
   const [events, setEvents] = useState<EventRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
+  const { confirm, confirmDialog } = useConfirm();
   const [form, setForm] = useState({ ...emptyEntry });
   // Whether "Ends" holds the manager's own answer rather than the one derived
   // from "Starts". Kept out of `form` because it describes the editing session,
@@ -296,13 +298,15 @@ function ManagerCalendarPage() {
 
   async function stopRepeats(ev: EventRow) {
     if (!ev.series_id) return;
-    if (
-      !window.confirm(
-        `Stop "${ev.title}" repeating? Future dates are removed. Past ones stay on the record.`,
-      )
-    ) {
-      return;
-    }
+    // Not reversible by clicking again: the future dates go, and putting them
+    // back means setting the repeat up from scratch.
+    const ok = await confirm({
+      title: `Stop "${ev.title}" repeating?`,
+      description:
+        "Every future date comes off the calendar. Dates that have already happened stay on the record, with their check-ins.",
+      confirmLabel: "Stop repeating",
+    });
+    if (!ok) return;
     setBusy(true);
     try {
       await endRepeat({ data: { series_id: ev.series_id } });
@@ -316,7 +320,15 @@ function ManagerCalendarPage() {
   }
 
   async function remove(ev: EventRow) {
-    if (!window.confirm(`Delete "${ev.title}"? Cancel it instead to keep the record.`)) return;
+    const ok = await confirm({
+      title: `Delete "${ev.title}"?`,
+      description:
+        "This takes it off the calendar completely, as though it had never been on it. There is no way to get it back.",
+      footnote: "To call the class off and keep the record of it, cancel it instead.",
+      confirmLabel: "Delete",
+      destructive: true,
+    });
+    if (!ok) return;
     setBusy(true);
     try {
       await removeEvent({ data: { id: ev.id } });
@@ -827,6 +839,7 @@ function ManagerCalendarPage() {
           </div>
         )}
       </div>
+      {confirmDialog}
     </section>
   );
 }

--- a/src/routes/_authenticated/manager.kb.test.tsx
+++ b/src/routes/_authenticated/manager.kb.test.tsx
@@ -10,7 +10,7 @@
 // blank values, and stored THOSE blank values as the baseline — so nothing on
 // screen looked dirty, and the next "Save as new version" wrote the blanks
 // straight to the database. This pins that autoload shows the real placement.
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
@@ -274,22 +274,38 @@ describe("/manager/kb section editing", () => {
   // about whichever one is VISIBLE. Consulting the article's dirty flag alone
   // would throw away a half-typed section name without a word.
   it("warns before throwing away a half-typed section name", async () => {
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(false);
-    try {
-      render(<KnowledgeBaseManager />);
+    render(<KnowledgeBaseManager />);
 
-      await screen.findByLabelText(/sidebar label/i);
-      await userEvent.click(screen.getByRole("button", { name: "About the club" }));
-      await userEvent.type(screen.getByLabelText(/name/i), " and its people");
-      expect(screen.getByRole("button", { name: /save the name/i })).toBeEnabled();
+    await screen.findByLabelText(/sidebar label/i);
+    await userEvent.click(screen.getByRole("button", { name: "About the club" }));
+    await userEvent.type(screen.getByLabelText(/name/i), " and its people");
+    expect(screen.getByRole("button", { name: /save the name/i })).toBeEnabled();
 
-      await userEvent.click(screen.getByRole("button", { name: /^Syllabus/ }));
-      expect(confirm).toHaveBeenCalledWith(expect.stringMatching(/discard your unsaved changes/i));
-      // The prompt was declined, so the section editor is still on screen.
-      expect(screen.getByLabelText(/name/i)).toHaveValue("About the club and its people");
-    } finally {
-      confirm.mockRestore();
-    }
+    await userEvent.click(screen.getByRole("button", { name: /^Syllabus/ }));
+    const dialog = await screen.findByRole("alertdialog");
+    expect(dialog).toHaveTextContent(/discard your unsaved changes/i);
+
+    // Keeping the edits is the way out, and it leaves the section editor as it
+    // was rather than half-navigated.
+    await userEvent.click(screen.getByRole("button", { name: "Keep editing" }));
+    expect(screen.getByLabelText(/name/i)).toHaveValue("About the club and its people");
+  });
+
+  it("throws the half-typed name away once, and only once, it is confirmed", async () => {
+    render(<KnowledgeBaseManager />);
+
+    await screen.findByLabelText(/sidebar label/i);
+    await userEvent.click(screen.getByRole("button", { name: "About the club" }));
+    await userEvent.type(screen.getByLabelText(/name/i), " and its people");
+
+    await userEvent.click(screen.getByRole("button", { name: /^Syllabus/ }));
+    await screen.findByRole("alertdialog");
+    await userEvent.click(screen.getByRole("button", { name: "Discard changes" }));
+
+    // The click that was held up goes through: the section editor is gone.
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /save the name/i })).not.toBeInTheDocument(),
+    );
   });
 });
 

--- a/src/routes/_authenticated/manager.kb.tsx
+++ b/src/routes/_authenticated/manager.kb.tsx
@@ -66,6 +66,7 @@ import {
 } from "@/lib/kb.functions";
 import { kbMarkdownComponents, kbRemarkPlugins } from "@/lib/kb-markdown";
 import { articleVisibilities, visibilityAudience } from "@/lib/kb";
+import { discardUnsavedChanges, useConfirm } from "@/hooks/use-confirm";
 import type { ArticleVisibility } from "@/lib/kb";
 import { buildKbNav, UNSECTIONED_TITLE } from "@/lib/kb-nav";
 import type { KbNavEntry } from "@/lib/kb-nav";
@@ -253,6 +254,7 @@ function KnowledgeBaseManager() {
   const [saving, setSaving] = useState(false);
   const [promoting, setPromoting] = useState(false);
   const [busy, setBusy] = useState(false);
+  const { confirm, confirmDialog } = useConfirm();
 
   /**
    * The arrangement a drag is producing, held while it is in flight and until
@@ -436,7 +438,7 @@ function KnowledgeBaseManager() {
     // even when `slug` already names this article, so the early return above
     // would leave the click doing nothing.
     if (!opts.force && !retrying && next === slug && !creating && !sectionEdit) return;
-    if (unsaved && !window.confirm("Discard your unsaved changes and open this?")) {
+    if (unsaved && !(await confirm(discardUnsavedChanges("Opening this")))) {
       return;
     }
     setSectionEdit(null);
@@ -564,9 +566,9 @@ function KnowledgeBaseManager() {
     }
   }
 
-  function startNew(nextKind: EntryKind) {
-    const what = nextKind === "link" ? "add a link" : "start a new article";
-    if (unsaved && !window.confirm(`Discard your unsaved changes and ${what}?`)) return;
+  async function startNew(nextKind: EntryKind) {
+    const what = nextKind === "link" ? "Adding a link" : "Starting a new article";
+    if (unsaved && !(await confirm(discardUnsavedChanges(what)))) return;
     claim();
     setSectionEdit(null);
     setCreating(true);
@@ -594,9 +596,9 @@ function KnowledgeBaseManager() {
   }
 
   /** Open a section in the main window, where it is renamed and deleted. */
-  function openSection(row: SectionRow) {
+  async function openSection(row: SectionRow) {
     if (sectionEdit?.slug === row.slug) return;
-    if (unsaved && !window.confirm("Discard your unsaved changes and open this section?")) {
+    if (unsaved && !(await confirm(discardUnsavedChanges("Opening this section")))) {
       return;
     }
     claim();
@@ -696,9 +698,11 @@ function KnowledgeBaseManager() {
     const widening = wideningVisibility(baseVisibility, visibility);
     if (
       widening &&
-      !window.confirm(
-        `This will change who can read "${title}" from ${widening.from} to ${widening.to}. Everyone in the wider group will be able to read every word of it, including any earlier wording still in the current version. Continue?`,
-      )
+      !(await confirm({
+        title: `Let ${visibilityAudience[widening.to].toLowerCase()} read "${title}"?`,
+        description: `Only ${visibilityAudience[widening.from].toLowerCase()} can read it right now. Saving opens it to everyone in the wider group, including any earlier wording still in the current version.`,
+        confirmLabel: "Save and open it up",
+      }))
     ) {
       return;
     }
@@ -798,21 +802,15 @@ function KnowledgeBaseManager() {
     // matters most to the manager who has just rewritten a passage: without it
     // they read "now live", see their own edit still in the box, and believe it
     // is what members are reading.
-    if (
-      dirty &&
-      !window.confirm(
-        `Your unsaved changes will be discarded, and they are not part of version ${version.version} so they will not go live. Save them as a new version first, or continue to publish the stored version ${version.version} and lose them?`,
-      )
-    ) {
-      return;
-    }
-    if (
-      !window.confirm(
-        `Publish version ${version.version}? ${visibilityAudience[baseVisibility ?? visibility]} will read it from now on. Comments stay attached to the version they were written against.`,
-      )
-    ) {
-      return;
-    }
+    const ok = await confirm({
+      title: `Publish version ${version.version}?`,
+      description: `${visibilityAudience[baseVisibility ?? visibility]} read it from now on. Comments stay attached to the version they were written against.`,
+      footnote: dirty
+        ? `Your unsaved edits are discarded by this, and they are not part of version ${version.version} so they will not go live either. Save them as a new version first if you want to keep them.`
+        : undefined,
+      confirmLabel: "Publish it",
+    });
+    if (!ok) return;
     const token = claim();
     const target = slug;
     setPromoting(true);
@@ -1159,15 +1157,16 @@ function KnowledgeBaseManager() {
 
   async function onDeleteSection(target: SectionRow) {
     const inside = articles.filter((a) => a.section === target.slug).length;
-    if (
-      !window.confirm(
-        inside
-          ? `Delete the section "${target.title}"? The ${inside} entr${inside === 1 ? "y" : "ies"} in it are kept, and drop to the "Everything else" group at the bottom of the sidebar until you file them somewhere.`
-          : `Delete the section "${target.title}"?`,
-      )
-    ) {
-      return;
-    }
+    const ok = await confirm({
+      title: `Delete the section "${target.title}"?`,
+      description: inside
+        ? `The ${inside} entr${inside === 1 ? "y" : "ies"} in it are kept, and drop to the "Everything else" group at the bottom of the sidebar until you file them somewhere.`
+        : "It is empty, so nothing members read changes.",
+      footnote: "The section itself goes for good.",
+      confirmLabel: "Delete section",
+      destructive: true,
+    });
+    if (!ok) return;
     const token = claim();
     setBusy(true);
     try {
@@ -1242,7 +1241,7 @@ function KnowledgeBaseManager() {
             type="button"
             variant="outline"
             disabled={saving || promoting || busy || ordering}
-            onClick={() => startNew("article")}
+            onClick={() => void startNew("article")}
           >
             <Plus className="mr-1.5 h-4 w-4" />
             New article
@@ -1255,7 +1254,7 @@ function KnowledgeBaseManager() {
             type="button"
             variant="outline"
             disabled={saving || promoting || busy || ordering}
-            onClick={() => startNew("link")}
+            onClick={() => void startNew("link")}
           >
             <Link2 className="mr-1.5 h-4 w-4" />
             New link
@@ -1318,7 +1317,7 @@ function KnowledgeBaseManager() {
                         sectionCount={groups.filter((g) => g.slug !== "").length}
                         onOpen={() => {
                           const row = sections.find((s) => s.slug === group.slug);
-                          if (row) openSection(row);
+                          if (row) void openSection(row);
                         }}
                       >
                         {group.entries.map((entry, entryIndex) => (
@@ -1512,20 +1511,22 @@ function KnowledgeBaseManager() {
                       variant="outline"
                       size="sm"
                       disabled={saving || busy}
+                      // No confirm: this only swaps what the editor is
+                      // showing. Nothing members read changes until a save, and
+                      // leaving without saving puts the link back.
                       onClick={() => {
-                        if (
-                          !window.confirm(
-                            "Turn this link into an article? It keeps its place in the reading order, and you write its text here. The link is only replaced when you save.",
-                          )
-                        ) {
-                          return;
-                        }
                         setKind("article");
                         setLinkPath("");
                       }}
                     >
                       Turn this into an article
                     </Button>
+                  )}
+                  {stored?.link_path && (
+                    <p className="text-xs text-muted-foreground">
+                      It keeps its place in the reading order, and you write its text here. The link
+                      is only replaced when you save.
+                    </p>
                   )}
                 </div>
               ) : (
@@ -1844,6 +1845,7 @@ function KnowledgeBaseManager() {
           )}
         </div>
       </div>
+      {confirmDialog}
     </section>
   );
 }

--- a/src/routes/_authenticated/manager.users_.$userId.tsx
+++ b/src/routes/_authenticated/manager.users_.$userId.tsx
@@ -49,8 +49,9 @@ import {
 } from "@/lib/club-user.functions";
 import { attachCheckInCoverage, transferCheckInCoverage } from "@/lib/checkin.functions";
 import { getWaiverPdfUrl, setWaiverApproval } from "@/lib/waiver.functions";
-import { runApproval } from "@/lib/waiver-approval";
+import { approvalConfirmation, runApproval } from "@/lib/waiver-approval";
 import { useAuth, useRoles } from "@/hooks/useAuth";
+import { useConfirm } from "@/hooks/use-confirm";
 
 export const Route = createFileRoute("/_authenticated/manager/users_/$userId")({
   head: () => ({
@@ -447,6 +448,7 @@ function ManagerUserPage() {
   const [open, setOpen] = useState<Set<string>>(new Set());
   const [pdfs, setPdfs] = useState<Record<string, SignedUrlEntry>>({});
   const [approvingIds, setApprovingIds] = useState<Set<string>>(new Set());
+  const { confirm, confirmDialog } = useConfirm();
   // Only the newest load's result may land: back-to-back approvals each trigger
   // their own refetch. (A different person is a different component instance —
   // see remountDeps above.)
@@ -614,7 +616,15 @@ function ManagerUserPage() {
     });
   }
 
-  async function setApproval(id: string, status: WaiverApprovalStatus) {
+  async function setApproval(
+    waiver: { id: string; full_name: string },
+    status: WaiverApprovalStatus,
+  ) {
+    // Approving emails the person and opens their login, and nothing on this
+    // page can take either back. Revoking only flips the row's status, so it
+    // goes through on the click.
+    if (status === "approved" && !(await confirm(approvalConfirmation(waiver.full_name)))) return;
+    const id = waiver.id;
     markApproving(id, true);
     // Statuses are derived per person (active vs superseded), so refresh by
     // refetching the whole person rather than patching one waiver. `load`
@@ -1007,21 +1017,17 @@ function ManagerUserPage() {
                   </CollapsibleTrigger>
                   <div className="flex flex-wrap items-center gap-2">
                     {w.status === "pending" ? (
-                      <Button
-                        size="sm"
-                        onClick={() => setApproval(w.id, "approved")}
-                        disabled={busy}
-                      >
+                      <Button size="sm" onClick={() => setApproval(w, "approved")} disabled={busy}>
                         {busy ? "Approving..." : "Approve"}
                       </Button>
                     ) : (
                       <Button
                         size="sm"
                         variant="outline"
-                        onClick={() => setApproval(w.id, "pending")}
+                        onClick={() => setApproval(w, "pending")}
                         disabled={busy}
                       >
-                        {busy ? "Updating..." : "Unapprove"}
+                        {busy ? "Updating..." : "Revoke approval"}
                       </Button>
                     )}
                     {w.has_pdf ? (
@@ -1114,6 +1120,7 @@ function ManagerUserPage() {
           })
         )}
       </div>
+      {confirmDialog}
     </section>
   );
 }

--- a/src/routes/_authenticated/manager.waiver-template.tsx
+++ b/src/routes/_authenticated/manager.waiver-template.tsx
@@ -19,6 +19,7 @@ import {
 import type { AcknowledgementDef } from "@/lib/validation";
 import { buildHealthPlaceholders, healthQuestions } from "@/lib/waiver-health";
 import { useAuth, useRoles } from "@/hooks/useAuth";
+import { discardUnsavedChanges, useConfirm } from "@/hooks/use-confirm";
 import { cn } from "@/lib/utils";
 import {
   hasMediaAcknowledgement,
@@ -111,6 +112,7 @@ function EditorPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [promoting, setPromoting] = useState(false);
+  const { confirm, confirmDialog } = useConfirm();
 
   const selected = templates.find((t) => t.id === selectedId) ?? null;
 
@@ -157,9 +159,9 @@ function EditorPage() {
   // immediately, before `meaningfulAcks` would silently drop the row on save.
   const mediaAckMissing = !hasMediaAcknowledgement(acks);
 
-  function selectVersion(template: TemplateVersion) {
+  async function selectVersion(template: TemplateVersion) {
     if (template.id === selectedId) return;
-    if (dirty && !window.confirm("Discard your unsaved changes and open this version?")) return;
+    if (dirty && !(await confirm(discardUnsavedChanges("Opening another version")))) return;
     load(template);
   }
 
@@ -169,19 +171,15 @@ function EditorPage() {
     // matters most to the manager who has just rewritten a clause: without this
     // they read "now live", see their own edit still on screen, and believe it
     // is what people are signing.
-    if (
-      dirty &&
-      !window.confirm(
-        `Your unsaved changes are not part of version ${selected.version} and will not go live. Save them as a new version first, or continue to make the stored version ${selected.version} live?`,
-      )
-    )
-      return;
-    if (
-      !window.confirm(
-        `Make version ${selected.version} the waiver everyone signs from now on? Waivers already signed keep the version they were signed against.`,
-      )
-    )
-      return;
+    const ok = await confirm({
+      title: `Make version ${selected.version} the waiver people sign?`,
+      description: `Everyone who signs from now on signs version ${selected.version}. Waivers already signed keep the version they were signed against.`,
+      footnote: dirty
+        ? `Your unsaved edits are not part of version ${selected.version}, so they will not go live. Save them as a new version first if you want them.`
+        : undefined,
+      confirmLabel: "Make it live",
+    });
+    if (!ok) return;
     setPromoting(true);
     try {
       await promote({ data: { id: selected.id } });
@@ -389,7 +387,7 @@ function EditorPage() {
                   <button
                     key={t.id}
                     type="button"
-                    onClick={() => selectVersion(t)}
+                    onClick={() => void selectVersion(t)}
                     aria-current={t.id === selectedId}
                     className={cn(
                       "flex w-full flex-col gap-1 rounded-md border px-3 py-2 text-left text-sm hover:bg-muted",
@@ -470,6 +468,7 @@ function EditorPage() {
           </CardContent>
         </Card>
       </section>
+      {confirmDialog}
     </>
   );
 }

--- a/src/routes/_authenticated/manager.waivers.tsx
+++ b/src/routes/_authenticated/manager.waivers.tsx
@@ -7,7 +7,7 @@ import { Pill } from "@/components/site/StatusPill";
 import { waiverClass } from "@/lib/status-colours";
 import { formatDateTime } from "@/lib/dates";
 import { listWaivers, getWaiverPdfUrl, setWaiverApproval } from "@/lib/waiver.functions";
-import { runApproval } from "@/lib/waiver-approval";
+import { approvalConfirmation, runApproval } from "@/lib/waiver-approval";
 import type { WaiverApprovalStatus } from "@/lib/validation";
 import {
   getGoogleDriveStatus,
@@ -15,6 +15,7 @@ import {
   uploadWaiverToDrive,
 } from "@/lib/google-drive.functions";
 import { useAuth, useRoles } from "@/hooks/useAuth";
+import { useConfirm } from "@/hooks/use-confirm";
 import { Download, Cloud, CloudCheck, Upload } from "lucide-react";
 
 export const Route = createFileRoute("/_authenticated/manager/waivers")({
@@ -64,6 +65,7 @@ function WaiversPage() {
   const [driveFolderReady, setDriveFolderReady] = useState(false);
   const [uploads, setUploads] = useState<Record<string, DriveUpload>>({});
   const [uploadingId, setUploadingId] = useState<string | null>(null);
+  const { confirm, confirmDialog } = useConfirm();
 
   useEffect(() => {
     if (!rolesLoading && user && !isManager) navigate({ to: "/account" });
@@ -107,7 +109,12 @@ function WaiversPage() {
     }
   }
 
-  async function setApproval(id: string, status: WaiverApprovalStatus) {
+  async function setApproval(row: Row, status: WaiverApprovalStatus) {
+    // Approving emails the person and opens their login, and nothing on this
+    // page can take either back. Revoking only flips the row's status, so it
+    // goes through on the click.
+    if (status === "approved" && !(await confirm(approvalConfirmation(row.full_name)))) return;
+    const id = row.id;
     setApprovingId(id);
     // Statuses are derived per person (active vs superseded), so refresh by
     // refetching the list rather than patching one row locally.
@@ -228,7 +235,7 @@ function WaiversPage() {
                           {r.status === "pending" ? (
                             <Button
                               size="sm"
-                              onClick={() => setApproval(r.id, "approved")}
+                              onClick={() => setApproval(r, "approved")}
                               disabled={approvingId === r.id}
                             >
                               {approvingId === r.id ? "Approving..." : "Approve"}
@@ -237,10 +244,10 @@ function WaiversPage() {
                             <Button
                               size="sm"
                               variant="outline"
-                              onClick={() => setApproval(r.id, "pending")}
+                              onClick={() => setApproval(r, "pending")}
                               disabled={approvingId === r.id}
                             >
-                              {approvingId === r.id ? "Updating..." : "Unapprove"}
+                              {approvingId === r.id ? "Updating..." : "Revoke approval"}
                             </Button>
                           )}
                           {r.pdf_path ? (
@@ -283,6 +290,7 @@ function WaiversPage() {
           </div>
         )}
       </section>
+      {confirmDialog}
     </>
   );
 }


### PR DESCRIPTION
Closes #53. Also addresses **item 2 only** of #33 (does not close it: items 1 and 3, load-error and loading-a11y states, are being done separately).

## What the user will feel

**A manager approving a waiver** now gets one question before it happens, naming the three things they cannot take back: the member is emailed to say their account is ready, their login is unlocked, and their free trial starts. Cancel and nothing has happened. It is the same question in the same words on both screens that can approve (`/manager/waivers` and a person's page), so it does not matter which one they are on.

The **Unapprove** button is now **Revoke approval**. It never undid the email, the login or the trial, and the old label promised it did. Revoking still happens on the click, with no dialog: it puts the waiver back to pending and approving again restores it.

**Everywhere else, the friction moved to match what a second click undoes.** Managers lose a dialog on two things that were never worth stopping for (saving a live blog post back to draft, turning a knowledge base link back into an article) and get a proper, readable, phone-sized dialog instead of the browser's grey box on the things that are genuinely one-way: deleting a comment or a section, deleting a calendar entry, stopping a repeat, publishing a template or article version, opening an article up to a wider audience.

Nobody outside the manager area sees a change, except one: a member deleting their own knowledge base comment now gets the app's dialog rather than the browser's, and it says the replies go with it.

## Product decisions I made, for you to correct

1. **The six "Discard your unsaved changes?" guards stay, converted to the app's dialog rather than removed.** #53 item 2 asks for them to go. I kept them because what they guard is text somebody typed, and no second click brings that back, which fails the reversibility test the rule turns on. They also only appear when the editor is actually dirty, so they are not on the common path the rule is protecting. The better answer is the one the issue offers as the alternative: stash the draft and offer an undo instead of asking. That is a bigger change than this, and worth its own issue if you want it.
2. **Renamed Unapprove to Revoke approval** (#53 item 3, which says "consider"). One word, easy to revert.
3. **The approval dialog hedges**: "If it is their first approved waiver, it also...". The unban, email and trial are all skipped for someone who can already log in, and the screen cannot tell which case it is without asking the server. Over-promising is the safer error here: a manager who expects an email that does not go out loses nothing, one who does not expect it has already sent it.
4. **Two confirms in a row became one question** on both "publish this version" flows. The unsaved-edits warning is now a line inside the same dialog rather than a separate box nobody reads.

## How it is built

`useConfirm` (`src/hooks/use-confirm.tsx`) is the app's `AlertDialog` asked as `await confirm({ ... })`. A promise rather than a `pendingX` state plus a block of JSX, because most of these questions are asked in the middle of a flow where the old code read `if (!window.confirm(...)) return;` — that keeps each call site a two-line edit and the wording next to the action it is about. `manager.blog.tsx` and `MembershipRowActions` keep their own dialogs: they already use the same primitive, and the second has to stay open to show a failure and offer a retry, which a yes/no promise cannot express.

The approval wording lives in `src/lib/waiver-approval.ts` next to the sequence it describes, so a change to what approving does has the sentence about it in the same file.

No `window.confirm` is left in `src/`.

## Testing

- `src/hooks/use-confirm.test.tsx` — new: what the dialog shows, all four ways to answer no (Cancel, Escape, click away, unmount mid-question), and that a second question does not strand the first caller's promise.
- `src/lib/waiver-approval.test.ts` — the approval copy names all three outward-facing effects and says revoking takes none of them back.
- `src/components/site/KbArticleReader.test.tsx` — comment vs reply wording, and that nothing is deleted until the question is answered yes.
- `src/routes/_authenticated/manager.blog_.$id.test.tsx` — Back asks only when there is something to lose; unpublishing saves with no dialog in the way.
- `src/routes/_authenticated/manager.kb.test.tsx` — the existing section-discard test now drives the dialog, plus its other half (confirming actually discards).
- `e2e/manager/new-member-journey.spec.ts` — the approval step walks the dialog, so the PR gallery photographs it.
- `bun run lint`, `typecheck`, `test` (2048 passing) and `build` all pass.

## Docs

`docs/waivers.md` (the confirm and the rename), `docs/blog.md` (unpublish is a notice, not a dialog), and the one line in `CLAUDE.md`'s UX bar that named the pattern to copy, which now points at `useConfirm`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMPv594yGjDAkGJsibtTJs)_