### PR TITLE
Knowledge base: link to a section of another article

### DIFF
--- a/.claude/skills/uts-manager-agent/SKILL.md
+++ b/.claude/skills/uts-manager-agent/SKILL.md
@@ -589,11 +589,52 @@ scripts/agent.sh list_kb_articles '{}'
 
 ### `get_kb_article` — read one article's markdown
 
-Returns the live version unless you pass `version`.
+Returns the live version unless you pass `version`, plus `sections`: every
+heading in it, with the link that goes straight to that heading.
 
 ```bash
-scripts/agent.sh get_kb_article '{"slug":"our-history"}'
+scripts/agent.sh get_kb_article '{"slug":"belts"}'
 ```
+
+```json
+{
+  "sections": [
+    {
+      "id": "grading",
+      "text": "How grading works",
+      "depth": 2,
+      "pinned": true,
+      "url": "/kb/belts#grading"
+    },
+    { "id": "fees", "text": "Fees", "depth": 3, "pinned": false, "url": "/kb/belts#fees" }
+  ]
+}
+```
+
+### Linking to a section of another article
+
+An article points at one section of another with an **ordinary markdown link**
+carrying the heading's anchor. There is no special syntax:
+
+```markdown
+Bring the fee in cash, see [the fees](/kb/belts#fees).
+```
+
+Read the article you are pointing at with `get_kb_article` and copy the `url`
+out of its `sections`. Do not work the fragment out from the heading yourself:
+it is the heading's own words lowercased and hyphenated, which is right until
+somebody rewords the heading, and a wrong one fails silently.
+
+**Pin the heading you just linked to** by ending it with `{#anchor}`, the
+attribute syntax Pandoc and Docusaurus use. The anchor then stays put however
+the heading is reworded, and readers never see the suffix:
+
+```markdown
+## How grading works {#grading}
+```
+
+`sections[].pinned` says which anchors are already pinned. `#section` on its own
+links within the same article.
 
 ### `save_kb_article` — write, or place in the sidebar
 
@@ -644,6 +685,9 @@ scripts/agent.sh save_kb_article '{
 >   is; passing `members` on what was a managers-only draft publishes it to every
 >   member of the club. New articles default to `members`. There is no `public`
 >   level: the whole knowledge base needs a login.
+> - **A cross-reference is not checked when you save it.** A link to an article
+>   or a section that does not exist is stored exactly as written, and only a
+>   reader following it finds out. Read the target before linking to it.
 > - **`link_path` takes site-relative paths only** (`/faq`, not
 >   `https://...`), needs a `nav_title`, and cannot be combined with
 >   `title`/`body_md`. An article that already has versions cannot be turned
@@ -703,7 +747,7 @@ scripts/agent.sh list_kb_comments '{"slug":"our-history"}'
   correct to retry unchanged, and it carries a `Retry-After` header — obey it
   rather than retrying immediately. Nothing was filed. Retryable failures are 5xx;
   a 4xx means the request itself needs to change before it will ever succeed.
-- The manifest's `version` tells generations apart (currently `"11"`), and its
+- The manifest's `version` tells generations apart (currently `"13"`), and its
   `changes` array says what each version actually moved, newest first, with
   `breaking: true` on any version that turns calls which used to succeed into
   errors. **There is no way to pin an older version** — the contract is

--- a/docs/knowledge-base.md
+++ b/docs/knowledge-base.md
@@ -125,6 +125,45 @@ the entry became a link.
   that, because the sidebar already owns the left from `lg` and three columns on
   a 1024px laptop leaves a reading column too narrow for a syllabus.
 
+### Linking to a section, in this article or another one
+
+An article can point at one **section** of another, which is what makes the
+knowledge base a handbook rather than a stack of pages: the syllabus can send a
+reader to the fees part of the grading article without them having to find it.
+
+- **Every heading has an anchor**, and it is the heading's own words, lowercased
+  with anything else turned into hyphens. `## How grading works` answers to
+  `#how-grading-works`. Two headings with the same words get `-2`, `-3`.
+- **Link to one with an ordinary Markdown link.** `[the fees](/kb/belts#fees)`
+  from another article, `[the fees](#fees)` inside the same one. There is no
+  special syntax, because there does not need to be.
+- **Pin an anchor by ending the heading with `{#your-anchor}`**, the attribute
+  syntax Pandoc and Docusaurus use: `## How grading works {#grading}` answers to
+  `#grading` for as long as that suffix is there, whatever the heading is
+  reworded to. Otherwise the anchor is the wording, so rewriting a heading
+  quietly breaks every link aimed at it. Pin the ones other articles point at.
+  The suffix never reaches the reader; `remark-kb-anchors` takes it off.
+- **The reader gets there.** An article's text is fetched after the page loads,
+  so by the time the browser looks for the fragment there is nothing in the
+  document with that id yet: `/kb/$slug` scrolls to it once the text is on
+  screen, and moves focus there too, so a keyboard or a screen reader carries on
+  from the section rather than from the top of the page.
+- **A link at a section that is gone says so.** Renamed heading, deleted
+  passage: the reader is told which fragment could not be found and pointed at
+  "On this page" for what the article has now, rather than being dropped
+  silently at the top of a syllabus.
+- **Every heading offers its own link.** "Link to this section" sits under the
+  heading in the reader (always on a touch screen, on hover or focus on a wide
+  one) and copies the whole address, so a member can paste one into a message
+  and a manager can paste one into another article.
+
+Two things to know before relying on it. Adding `{#anchor}` to a heading
+**changes that block's text**, so comments anchored to the heading itself detach
+the same way any other edit to a passage detaches them (they are shown under "On
+earlier wording", not lost). And nothing validates a cross-reference at save
+time: a link to `/kb/no-such-article#x` is an ordinary broken link until
+somebody follows it.
+
 **Markdown tables render.** `| Belt | Time |` is a table, in the reader and in
 the manager's preview, and a wide one scrolls inside its own box rather than
 scrolling the page sideways on a phone. Alignment markers (`| :-: |`) work, and
@@ -412,6 +451,15 @@ sections and all, and it is rearranged by dragging.
   site. An existing link entry can be turned back into an article, and the
   editor says the link is only replaced when you save.
 
+**"Link to a section" lists what this article offers.** Every heading in the
+body being edited, with the exact link another article should use
+(`/kb/belts#fees`), a Copy button on each, and a `Pinned` badge on the ones
+written as `## Heading {#anchor}`. It reads off the text in the editor rather
+than the saved version, so a heading just typed can be linked to straight away
+and a manager can see what renaming one did to its link before publishing it.
+That panel is the only place the fragment is discoverable: it comes out of the
+heading's wording, which is not something to ask anybody to derive by hand.
+
 Everything here does the same thing to the same data as the agent API, through
 the same code (`kb-admin.ts`). Neither is the "real" one.
 
@@ -438,6 +486,13 @@ Four things that bite:
 - **Omitting a field leaves it alone.** That is what stops an agent editing the
   text of a managers-only draft from publishing it to the world, or moving it to
   the top of the sidebar, by not mentioning a field.
+- **Cross-references are read off `get_kb_article`, not derived.** Its result
+  carries `sections`: every heading in the version read, with its `id`, `text`,
+  `depth`, `pinned` flag and a ready-made `url` (`/kb/belts#fees`). Read the
+  article being pointed at and use that `url`. An anchor worked out from the
+  heading's wording is right until it is not, and a wrong one fails silently.
+  Pin any heading being linked to (`## How grading works {#grading}`) so the
+  link survives the club rewording it later.
 - **An unknown `section` is refused**, unlike everything else. Accepting it would
   drop the article into "Everything else", and a typo there is invisible until
   somebody notices an article has gone missing from its group. Send an empty
@@ -485,6 +540,7 @@ it as a marketing page or a blog post instead.
 | Wire schemas                                | `src/lib/validation.ts`                             |
 | Article typography                          | `src/lib/kb-markdown.tsx`                           |
 | Markdown tables                             | `src/lib/remark-kb-tables.ts` (pure, tested)        |
+| Section anchors (`{#id}` stripping)         | `src/lib/remark-kb-anchors.ts` (pure, tested)       |
 | Shell (top bar, sidebar, search, progress)  | `src/components/site/KbLayout.tsx`                  |
 | Reader UI                                   | `src/components/site/KbArticleReader.tsx`           |
 | Sign-in gate + reader routes                | `src/routes/kb/route.tsx`, `index.tsx`, `$slug.tsx` |

--- a/docs/manager-agent-api.md
+++ b/docs/manager-agent-api.md
@@ -118,6 +118,21 @@ An "invoice" is a `memberships` row — its price/reference/status _are_ the inv
   check lives in `filePaperWaiver`, so the manager's own upload form gets the
   same speed bump.
 
+- `list_kb_sections` / `save_kb_section` / `delete_kb_section` /
+  `list_kb_articles` / `get_kb_article` / `save_kb_article` / `list_kb_comments`
+  — the knowledge base, the agent's equivalent of `/manager/kb`. Both go through
+  `src/lib/kb-admin.ts`, so an agent-published article and a manager's own are
+  the same row written the same way. The rules that are not guessable are in
+  `docs/knowledge-base.md`; the one that belongs here is **cross-references**:
+  an article links to a section of another with an ordinary markdown link
+  carrying the heading's anchor (`[the fees](/kb/belts#fees)`), and
+  `get_kb_article` reports every anchor the article has in `sections`
+  (`id`, `text`, `depth`, `pinned`, `url`). Take the `url` from there rather
+  than deriving a fragment from the heading's wording, which is right until
+  somebody rewords the heading. Ending a heading with the attribute syntax
+  `## How grading works {#grading}` pins its anchor so the rewording does not
+  break the link; the suffix is stripped before a reader sees it, and
+  `sections[].pinned` says which anchors were set that way.
 - `list_waiver_templates` / `get_waiver_template` / `save_waiver_template` /
   `publish_waiver_template` — the waiver everyone signs, the agent's equivalent
   of `/manager/waiver-template`. They go through `listWaiverTemplateRows`,
@@ -232,7 +247,7 @@ wrapper never needs hand-syncing beyond the human-readable docs above.
 changes**, not only when an action is added or removed. A guard that starts
 refusing a call that used to succeed, or a new field in a response, is exactly
 what a client needs the version to tell it about. The version is pinned by a
-test so the bump is a deliberate edit, and the current value is `"12"`.
+test so the bump is a deliberate edit, and the current value is `"13"`.
 
 **Responses carry `version` too**, not just the manifest, so a client that
 cached the manifest at the start of a long run can notice a bump per call

--- a/src/components/site/KbArticleReader.test.tsx
+++ b/src/components/site/KbArticleReader.test.tsx
@@ -73,6 +73,33 @@ describe("KbArticleReader", () => {
     expect(screen.getByText("Wash your gi.")).toBeInTheDocument();
   });
 
+  // Another article links to a section of this one, so the block that opens a
+  // section has to carry the id that link aims at.
+  it("puts each heading's anchor on the passage that opens it", () => {
+    renderReader({
+      article: { ...article, body_md: "# House rules\n\nWash your gi.\n\n## Nails {#nails}" },
+    });
+    expect(document.getElementById("house-rules")?.textContent).toContain("House rules");
+    expect(document.getElementById("nails")?.textContent).toContain("Nails");
+  });
+
+  it("offers a link to a section, and copies the whole address for pasting", async () => {
+    renderReader({});
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const link = screen.getByRole("link", { name: /Link to this section, House rules/i });
+    expect(link).toHaveAttribute("href", "#house-rules");
+    await userEvent.click(link);
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("#house-rules"));
+    expect(await screen.findByText("Link copied")).toBeInTheDocument();
+  });
+
+  it("offers no section link on a passage that is not a heading", () => {
+    renderReader({ article: { ...article, body_md: "Just prose, no headings." } });
+    expect(screen.queryByRole("link", { name: /Link to this section/i })).not.toBeInTheDocument();
+  });
+
   it("tells a signed-out reader to sign in rather than showing a composer", () => {
     renderReader({
       viewer: { signed_in: false, user_id: null, is_manager: false, can_annotate: false },

--- a/src/components/site/KbArticleReader.tsx
+++ b/src/components/site/KbArticleReader.tsx
@@ -11,7 +11,8 @@
 // wrong instead of two.
 import { useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
-import { Lock, MessageSquare, Check, Trash2, Pencil, CornerDownRight } from "lucide-react";
+import { toast } from "sonner";
+import { Lock, MessageSquare, Check, Trash2, Pencil, CornerDownRight, Link2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
@@ -19,7 +20,7 @@ import { cn } from "@/lib/utils";
 import { formatDate } from "@/lib/dates";
 import { groupThreads, resolveAnchors, splitBlocks } from "@/lib/kb";
 import type { AnnotationVisibility } from "@/lib/kb";
-import { extractHeadings } from "@/lib/kb-nav";
+import { extractHeadings, type KbHeading } from "@/lib/kb-nav";
 import { kbMarkdownComponents, kbRemarkPlugins } from "@/lib/kb-markdown";
 
 /** One annotation, exactly as `listAnnotations` returns it. */
@@ -101,9 +102,9 @@ export function KbArticleReader({
   // mean reaching into the rendered nodes. Hanging it on the block's wrapper
   // instead lands the reader in the same place and keeps both sides deriving the
   // id from `extractHeadings`, so the anchor and the link cannot disagree.
-  const headingIdByBlock = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const heading of extractHeadings(article.body_md)) map.set(heading.blockId, heading.id);
+  const headingByBlock = useMemo(() => {
+    const map = new Map<string, KbHeading>();
+    for (const heading of extractHeadings(article.body_md)) map.set(heading.blockId, heading);
     return map;
   }, [article.body_md]);
 
@@ -125,10 +126,11 @@ export function KbArticleReader({
           const shared = onBlock.filter((a) => a.visibility === "shared" && !a.parent_id).length;
           const notes = onBlock.filter((a) => a.visibility === "private").length;
           const isSelected = block.id === selected;
+          const heading = headingByBlock.get(block.id) ?? null;
           return (
             <div
               key={block.id}
-              id={headingIdByBlock.get(block.id)}
+              id={heading?.id}
               className={cn(
                 "group relative scroll-mt-24 rounded-md border border-transparent px-3 py-1 transition-colors",
                 isSelected ? "border-primary/40 bg-muted/60" : "hover:bg-muted/40",
@@ -152,44 +154,49 @@ export function KbArticleReader({
                 {block.markdown}
               </ReactMarkdown>
 
-              {/* Always rendered when there is anything to show OR the reader
-                  could add something. Gating this on `shared + notes > 0` (as it
-                  used to be) left phone users with no way to start a comment on
-                  a passage at all, since the gutter marker above is hidden
-                  there: the feature's headline capability, unreachable on a
-                  phone. */}
-              {(shared > 0 || notes > 0 || viewer.can_annotate) && (
-                <button
-                  type="button"
-                  aria-pressed={isSelected}
-                  onClick={() => setSelected(isSelected ? null : block.id)}
-                  className={cn(
-                    "mt-1 flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground",
-                    // With no comments yet the control is only worth the space
-                    // where it is the ONLY way in, i.e. below `xl`.
-                    shared === 0 && notes === 0 && "xl:hidden",
-                  )}
-                >
-                  {shared > 0 && (
-                    <span className="flex items-center gap-1">
-                      <MessageSquare className="h-3 w-3" />
-                      {shared}
-                    </span>
-                  )}
-                  {notes > 0 && (
-                    <span className="flex items-center gap-1">
-                      <Lock className="h-3 w-3" />
-                      {notes}
-                    </span>
-                  )}
-                  {shared === 0 && notes === 0 && (
-                    <span className="flex items-center gap-1">
-                      <MessageSquare className="h-3 w-3" />
-                      Comment
-                    </span>
-                  )}
-                </button>
-              )}
+              {/* The controls under a passage: how many comments are on it, and,
+                  when it opens a section, the link to that section. */}
+              <div className="flex flex-wrap items-center gap-4">
+                {/* Always rendered when there is anything to show OR the reader
+                    could add something. Gating this on `shared + notes > 0` (as
+                    it used to be) left phone users with no way to start a
+                    comment on a passage at all, since the gutter marker above is
+                    hidden there: the feature's headline capability, unreachable
+                    on a phone. */}
+                {(shared > 0 || notes > 0 || viewer.can_annotate) && (
+                  <button
+                    type="button"
+                    aria-pressed={isSelected}
+                    onClick={() => setSelected(isSelected ? null : block.id)}
+                    className={cn(
+                      "mt-1 flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground",
+                      // With no comments yet the control is only worth the space
+                      // where it is the ONLY way in, i.e. below `xl`.
+                      shared === 0 && notes === 0 && "xl:hidden",
+                    )}
+                  >
+                    {shared > 0 && (
+                      <span className="flex items-center gap-1">
+                        <MessageSquare className="h-3 w-3" />
+                        {shared}
+                      </span>
+                    )}
+                    {notes > 0 && (
+                      <span className="flex items-center gap-1">
+                        <Lock className="h-3 w-3" />
+                        {notes}
+                      </span>
+                    )}
+                    {shared === 0 && notes === 0 && (
+                      <span className="flex items-center gap-1">
+                        <MessageSquare className="h-3 w-3" />
+                        Comment
+                      </span>
+                    )}
+                  </button>
+                )}
+                {heading && <SectionLink heading={heading} />}
+              </div>
             </div>
           );
         })}
@@ -319,6 +326,52 @@ export function KbArticleReader({
         )}
       </aside>
     </div>
+  );
+}
+
+/**
+ * "Link to this section": the way somebody gets the address of one heading.
+ *
+ * It is a real `<a href="#id">`, so it behaves like a link everywhere a link is
+ * expected — the address bar ends up on the section, "copy link address" works,
+ * and a keyboard reaches it. The click ALSO puts the full URL on the clipboard,
+ * because the thing people actually want here is to paste it into another
+ * article or a message, and asking them to select it out of the address bar on
+ * a phone is asking them not to bother.
+ *
+ * Kept quiet until it is wanted: visible on hover or keyboard focus within the
+ * passage on a pointer screen, and always visible on a touch one, where there
+ * is no hover to reveal it with.
+ */
+function SectionLink({ heading }: { heading: KbHeading }) {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <a
+      href={`#${heading.id}`}
+      aria-label={`Link to this section, ${heading.text}`}
+      onClick={async () => {
+        // The href still does its job if this fails, so a refused clipboard
+        // (no secure context, a dismissed permission prompt) costs the copy and
+        // nothing else. The URL is in the error so it can be taken by hand.
+        const url = `${window.location.href.split("#")[0]}#${heading.id}`;
+        try {
+          await navigator.clipboard.writeText(url);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        } catch {
+          toast.error("Couldn't copy that link automatically.", {
+            description: `Select this and copy it by hand: ${url}`,
+            duration: Infinity,
+            closeButton: true,
+          });
+        }
+      }}
+      className="mt-1 flex items-center gap-1 text-xs text-muted-foreground opacity-100 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 xl:opacity-0"
+    >
+      {copied ? <Check className="h-3 w-3" /> : <Link2 className="h-3 w-3" />}
+      {copied ? "Link copied" : "Link to this section"}
+    </a>
   );
 }
 

--- a/src/lib/kb-admin.test.ts
+++ b/src/lib/kb-admin.test.ts
@@ -11,10 +11,12 @@ import { describe, expect, it } from "vitest";
 import {
   deleteKbSection,
   listSharedAnnotations,
+  projectArticle,
   promoteArticleVersion,
   saveKbArticle,
   saveKbSection,
 } from "./kb-admin";
+import type { KbArticleRow, KbArticleVersionRow } from "./kb-types";
 import type { KbClient } from "./kb-types";
 import type { SaveKbArticleInput } from "./validation";
 
@@ -661,5 +663,47 @@ describe("saveKbArticle link entry transitions", () => {
       saveKbArticle(db, { slug: "common-questions", nav_title: "" }, null),
     ).rejects.toThrow(/a link needs a name to show in the sidebar/);
     expect(writes(calls)).toHaveLength(0);
+  });
+});
+
+describe("projectArticle", () => {
+  // An agent asked to cross-reference an article needs the fragment, and the
+  // one thing it must not do is derive it from the heading's wording itself:
+  // that is how a link ends up pointing at a section that does not exist.
+  const loaded = (body: string) => ({
+    article: {
+      slug: "belts",
+      visibility: "members",
+      annotations_enabled: true,
+      nav_title: null,
+    } as unknown as KbArticleRow,
+    version: {
+      title: "Belts",
+      body_md: body,
+      version: 4,
+      is_current: true,
+      change_note: null,
+      created_at: "2026-08-01T00:00:00Z",
+    } as unknown as KbArticleVersionRow,
+  });
+
+  it("reports every heading with a link that goes straight to it", () => {
+    const projected = projectArticle(
+      loaded("## How grading works {#grading}\n\nText.\n\n### Fees\n\nMore."),
+    );
+    expect(projected.sections).toEqual([
+      {
+        id: "grading",
+        text: "How grading works",
+        depth: 2,
+        pinned: true,
+        url: "/kb/belts#grading",
+      },
+      { id: "fees", text: "Fees", depth: 3, pinned: false, url: "/kb/belts#fees" },
+    ]);
+  });
+
+  it("reports an empty list for an article with no headings", () => {
+    expect(projectArticle(loaded("Just prose.")).sections).toEqual([]);
   });
 });

--- a/src/lib/kb-admin.ts
+++ b/src/lib/kb-admin.ts
@@ -17,6 +17,7 @@ import type {
 } from "@/lib/kb-types";
 import type { SaveKbArticleInput, SaveKbSectionInput } from "@/lib/validation";
 import { actorUserId } from "@/lib/manager-agent";
+import { extractHeadings } from "@/lib/kb-nav";
 
 /** An article together with the version being read. */
 export type LoadedArticle = {
@@ -500,6 +501,17 @@ export function projectArticle({ article, version }: LoadedArticle) {
     annotations_enabled: article.annotations_enabled,
     nav_title: article.nav_title,
     updated_at: version.created_at,
+    // The anchors this article offers, so an agent writing a cross-reference
+    // into another article does not have to re-derive a fragment from the
+    // heading wording and get it subtly wrong. `pinned` marks the ones written
+    // as `## Heading {#anchor}`, which are the ones that survive a rewording.
+    sections: extractHeadings(version.body_md).map((heading) => ({
+      id: heading.id,
+      text: heading.text,
+      depth: heading.depth,
+      pinned: heading.pinned,
+      url: `/kb/${article.slug}#${heading.id}`,
+    })),
   };
 }
 

--- a/src/lib/kb-markdown.tsx
+++ b/src/lib/kb-markdown.tsx
@@ -16,6 +16,7 @@
 // a manager's markdown never produces a second `<h1>` competing with the page's
 // own title, keeping the heading outline correct for assistive tech.
 import type { Components } from "react-markdown";
+import { remarkKbAnchors } from "@/lib/remark-kb-anchors";
 import { remarkKbTables } from "@/lib/remark-kb-tables";
 
 /**
@@ -26,7 +27,7 @@ import { remarkKbTables } from "@/lib/remark-kb-tables";
  * that renders for a member but not in the preview a manager checked it in is
  * the version of this bug that is hardest to notice.
  */
-export const kbRemarkPlugins = [remarkKbTables];
+export const kbRemarkPlugins = [remarkKbTables, remarkKbAnchors];
 
 export const kbMarkdownComponents: Components = {
   h1: ({ children }) => (

--- a/src/lib/kb-nav.test.ts
+++ b/src/lib/kb-nav.test.ts
@@ -299,6 +299,13 @@ describe("findHeadingForHash", () => {
     expect(findHeadingForHash("", headings)).toBeNull();
   });
 
+  // A cross-reference typed by eye off the heading's own capitals. The section
+  // is right there, so finding it beats telling somebody it was renamed away.
+  it("matches a fragment whatever case it was typed in", () => {
+    expect(findHeadingForHash("#Belts", headings)?.text).toBe("Belts");
+    expect(findHeadingForHash("#GRADING", headings)?.text).toBe("Grading");
+  });
+
   it("does not throw on a malformed escape", () => {
     expect(findHeadingForHash("#100%", headings)).toBeNull();
   });
@@ -323,6 +330,10 @@ describe("missingSectionFragment", () => {
     expect(
       missingSectionFragment("#comment-2a0f6e4c-0000-4000-8000-000000000000", headings),
     ).toBeNull();
+  });
+
+  it("says nothing about a section that is there under different capitals", () => {
+    expect(missingSectionFragment("#Grading", headings)).toBeNull();
   });
 
   it("says nothing about a fragment that is not shaped like an anchor", () => {

--- a/src/lib/kb-nav.test.ts
+++ b/src/lib/kb-nav.test.ts
@@ -5,6 +5,7 @@ import {
   entryBreadcrumbs,
   entryHref,
   extractHeadings,
+  findHeadingForHash,
   flattenKbNav,
   headingSlug,
   kbProgress,
@@ -157,18 +158,45 @@ describe("headingSlug", () => {
 
 describe("parseHeading", () => {
   it("reads the level and the text", () => {
-    expect(parseHeading("## The blue belt")).toEqual({ depth: 2, text: "The blue belt" });
+    expect(parseHeading("## The blue belt")).toEqual({
+      depth: 2,
+      text: "The blue belt",
+      anchor: null,
+    });
   });
 
   it("strips inline markdown so a table of contents reads as words", () => {
     expect(parseHeading("### The **blue** `belt` and [more](/x)")).toEqual({
       depth: 3,
       text: "The blue belt and more",
+      anchor: null,
     });
   });
 
   it("ignores a closing run of hashes", () => {
-    expect(parseHeading("## Grading ##")).toEqual({ depth: 2, text: "Grading" });
+    expect(parseHeading("## Grading ##")).toEqual({ depth: 2, text: "Grading", anchor: null });
+  });
+
+  it("reads a pinned anchor and keeps it out of the heading text", () => {
+    expect(parseHeading("## How grading works {#grading}")).toEqual({
+      depth: 2,
+      text: "How grading works",
+      anchor: "grading",
+    });
+  });
+
+  it("puts a pinned anchor through the same slug rules as a derived one", () => {
+    expect(parseHeading("## Fees {#Fees & Costs}")?.anchor).toBeNull();
+    expect(parseHeading("## Fees {#Fees_2026}")?.anchor).toBe("fees-2026");
+  });
+
+  it("leaves a heading that is nothing but an anchor alone", () => {
+    // Stripping it would leave a heading with no words in it at all.
+    expect(parseHeading("## {#orphan}")).toEqual({
+      depth: 2,
+      text: "{#orphan}",
+      anchor: null,
+    });
   });
 
   it("is not fooled by a hash that is not a heading", () => {
@@ -211,6 +239,53 @@ describe("extractHeadings", () => {
 
   it("finds nothing in an article that is all prose", () => {
     expect(extractHeadings("Just a paragraph.\n\nAnd another.")).toEqual([]);
+  });
+
+  // The whole point of pinning: another article links to `#grading`, and the
+  // link survives the club rewriting the heading above it.
+  it("uses a pinned anchor instead of the wording, and says it was pinned", () => {
+    const headings = extractHeadings("## What happens at a grading {#grading}\n\nDetails.");
+    expect(headings[0].id).toBe("grading");
+    expect(headings[0].pinned).toBe(true);
+    expect(headings[0].text).toBe("What happens at a grading");
+
+    const reworded = extractHeadings("## Your first grading day {#grading}\n\nDetails.");
+    expect(reworded[0].id).toBe("grading");
+  });
+
+  it("marks an id taken from the wording as not pinned", () => {
+    expect(extractHeadings("## Grading\n\nx.")[0].pinned).toBe(false);
+  });
+
+  it("keeps two headings pinned to the same anchor apart", () => {
+    const ids = extractHeadings("## A {#same}\n\nx.\n\n## B {#same}\n\ny.").map((h) => h.id);
+    expect(ids).toEqual(["same", "same-2"]);
+  });
+});
+
+describe("findHeadingForHash", () => {
+  const headings = extractHeadings("## Grading {#grading}\n\nx.\n\n## Belts\n\ny.");
+
+  it("finds the heading a fragment names, with or without the hash", () => {
+    expect(findHeadingForHash("#grading", headings)?.text).toBe("Grading");
+    expect(findHeadingForHash("belts", headings)?.text).toBe("Belts");
+  });
+
+  it("decodes a percent-encoded fragment", () => {
+    expect(findHeadingForHash("%23belts".replace("%23", "#"), headings)?.text).toBe("Belts");
+    expect(findHeadingForHash("#bel%74s", headings)?.text).toBe("Belts");
+  });
+
+  // A cross-reference written months ago against wording that has since been
+  // rewritten. Null is what makes the reader SAY so instead of landing silently
+  // at the top of a long article.
+  it("reports nothing for a section the article no longer has", () => {
+    expect(findHeadingForHash("#throws", headings)).toBeNull();
+    expect(findHeadingForHash("", headings)).toBeNull();
+  });
+
+  it("does not throw on a malformed escape", () => {
+    expect(findHeadingForHash("#100%", headings)).toBeNull();
   });
 });
 

--- a/src/lib/kb-nav.test.ts
+++ b/src/lib/kb-nav.test.ts
@@ -6,6 +6,7 @@ import {
   entryHref,
   extractHeadings,
   findHeadingForHash,
+  missingSectionFragment,
   flattenKbNav,
   headingSlug,
   kbProgress,
@@ -257,6 +258,20 @@ describe("extractHeadings", () => {
     expect(extractHeadings("## Grading\n\nx.")[0].pinned).toBe(false);
   });
 
+  // The reason pinning exists at all is that other articles point at the
+  // anchor. A heading added later whose words happen to slugify to the same
+  // thing must not take it: every cross-reference in the club would quietly
+  // land on the wrong passage.
+  it("gives a pinned anchor to the heading that pinned it, wherever it sits", () => {
+    const headings = extractHeadings(
+      "## What happens on the day {#grading}\n\nx.\n\n## Grading\n\ny.",
+    );
+    expect(headings.map((h) => [h.text, h.id])).toEqual([
+      ["What happens on the day", "grading"],
+      ["Grading", "grading-2"],
+    ]);
+  });
+
   it("keeps two headings pinned to the same anchor apart", () => {
     const ids = extractHeadings("## A {#same}\n\nx.\n\n## B {#same}\n\ny.").map((h) => h.id);
     expect(ids).toEqual(["same", "same-2"]);
@@ -286,6 +301,40 @@ describe("findHeadingForHash", () => {
 
   it("does not throw on a malformed escape", () => {
     expect(findHeadingForHash("#100%", headings)).toBeNull();
+  });
+});
+
+describe("missingSectionFragment", () => {
+  const headings = extractHeadings("## Grading {#grading}\n\nx.\n\n## Belts\n\ny.");
+
+  it("names the section a stale cross-reference asked for", () => {
+    expect(missingSectionFragment("#throws", headings)).toBe("throws");
+  });
+
+  it("says nothing when the section is there, or no fragment was given", () => {
+    expect(missingSectionFragment("#grading", headings)).toBeNull();
+    expect(missingSectionFragment("", headings)).toBeNull();
+  });
+
+  // A notification about a comment links to /kb/<slug>#comment-<id>
+  // (`kbAnnotationHref`). That link is working as designed, and telling the
+  // member their section was renamed away would be wrong and alarming.
+  it("says nothing about the app's own comment links", () => {
+    expect(
+      missingSectionFragment("#comment-2a0f6e4c-0000-4000-8000-000000000000", headings),
+    ).toBeNull();
+  });
+
+  it("says nothing about a fragment that is not shaped like an anchor", () => {
+    expect(
+      missingSectionFragment("#error=access_denied&error_code=otp_expired", headings),
+    ).toBeNull();
+  });
+
+  it("truncates a very long fragment rather than printing it whole", () => {
+    const long = missingSectionFragment(`#${"a".repeat(200)}`, headings);
+    expect(long).toHaveLength(60);
+    expect(long?.endsWith("…")).toBe(true);
   });
 });
 

--- a/src/lib/kb-nav.ts
+++ b/src/lib/kb-nav.ts
@@ -235,6 +235,12 @@ export type KbHeading = {
   text: string;
   /** The `id` to link to, unique within the article. */
   id: string;
+  /**
+   * Whether the author pinned this id with `{#an-anchor}` rather than letting it
+   * fall out of the wording. Shown to managers, because a pinned anchor is the
+   * one that survives rewording the heading.
+   */
+  pinned: boolean;
   /** The `kb.ts` block this heading opens, so the reader can hang the id on it. */
   blockId: string;
 };
@@ -255,6 +261,31 @@ export function headingSlug(text: string): string {
 }
 
 /**
+ * The anchor a heading pins for itself, and the heading text without it.
+ *
+ * `## Grading {#grading}` is the attribute syntax Pandoc, Docusaurus and
+ * markdown-it-attrs all spell the same way, which is as close to idiomatic as
+ * Markdown gets for this: the heading still reads as a heading everywhere else,
+ * and anything that does not understand the suffix shows it rather than losing
+ * the heading.
+ *
+ * It exists because the id a heading gets otherwise is its own wording, so
+ * rewording "Grading" to "How grading works" silently breaks every link another
+ * article aimed at it. A pinned anchor is the author saying "other pages point
+ * here", and it survives the rewrite.
+ *
+ * The id is put through `headingSlug` rather than taken literally, so there is
+ * one id vocabulary and an anchor can never carry a space or a `#` into a URL.
+ * A heading that is NOTHING but an anchor (`## {#x}`) is left alone: stripping
+ * it would leave an empty heading, so the braces are treated as the text.
+ */
+export function splitHeadingAnchor(text: string): { text: string; anchor: string | null } {
+  const match = /^(.*?)[ \t]*\{#([^{}\s]+)\}[ \t]*$/.exec(text);
+  if (!match || !match[1].trim()) return { text, anchor: null };
+  return { text: match[1], anchor: headingSlug(match[2]) };
+}
+
+/**
  * Read a heading off the start of a block, with the inline markdown stripped.
  *
  * `## The **blue** belt` is the heading "The blue belt": the emphasis is styling,
@@ -263,13 +294,19 @@ export function headingSlug(text: string): string {
  * a ``` block never reaches here as a heading because `splitBlocks` keeps it
  * whole and its first line is a fence, not a `#`.
  */
-export function parseHeading(blockMarkdown: string): { depth: number; text: string } | null {
+export function parseHeading(
+  blockMarkdown: string,
+): { depth: number; text: string; anchor: string | null } | null {
   const firstLine = blockMarkdown.split("\n", 1)[0] ?? "";
   const match = /^ {0,3}(#{1,6})\s+(.*)$/.exec(firstLine);
   if (!match) return null;
-  const text = stripInlineMarkdown(match[2].replace(/\s+#+\s*$/, "")).trim();
+  // The pinned anchor comes off BEFORE the inline markdown is stripped, so a
+  // `{#id}` is never mistaken for part of a link or a code span, and what is
+  // left is the heading a reader sees.
+  const withoutAnchor = splitHeadingAnchor(match[2].replace(/\s+#+\s*$/, ""));
+  const text = stripInlineMarkdown(withoutAnchor.text).trim();
   if (!text) return null;
-  return { depth: match[1].length, text };
+  return { depth: match[1].length, text, anchor: withoutAnchor.anchor };
 }
 
 function stripInlineMarkdown(text: string): string {
@@ -305,11 +342,43 @@ export function extractHeadings(markdown: string): KbHeading[] {
   for (const block of splitBlocks(markdown)) {
     const heading = parseHeading(block.markdown);
     if (!heading) continue;
-    const base = headingSlug(heading.text);
+    const base = heading.anchor ?? headingSlug(heading.text);
     let id = base;
     for (let n = 2; used.has(id); n++) id = `${base}-${n}`;
     used.add(id);
-    headings.push({ depth: heading.depth, text: heading.text, id, blockId: block.id });
+    headings.push({
+      depth: heading.depth,
+      text: heading.text,
+      id,
+      pinned: heading.anchor !== null,
+      blockId: block.id,
+    });
   }
   return headings;
+}
+
+/**
+ * The heading a URL fragment points at, or null when nothing in the article
+ * answers to it.
+ *
+ * Null is a state the reader has to SHOW rather than ignore. A cross-reference
+ * from another article is a link somebody wrote by hand months ago, against
+ * wording that may since have been rewritten; landing silently at the top of a
+ * long syllabus looks exactly like the link having worked, and the reader hunts
+ * for a section that is no longer called that.
+ *
+ * The fragment is decoded first, so a heading with a percent-encoded character
+ * in its id still matches, and a malformed escape is treated as no match rather
+ * than throwing on a page that was only trying to scroll.
+ */
+export function findHeadingForHash(hash: string, headings: KbHeading[]): KbHeading | null {
+  const raw = hash.replace(/^#/, "");
+  if (!raw) return null;
+  let id = raw;
+  try {
+    id = decodeURIComponent(raw);
+  } catch {
+    // A fragment that is not valid percent-encoding is matched as typed.
+  }
+  return headings.find((heading) => heading.id === id) ?? null;
 }

--- a/src/lib/kb-nav.ts
+++ b/src/lib/kb-nav.ts
@@ -393,7 +393,11 @@ export function extractHeadings(markdown: string): KbHeading[] {
  * than throwing on a page that was only trying to scroll.
  */
 export function findHeadingForHash(hash: string, headings: KbHeading[]): KbHeading | null {
-  const id = decodeFragment(hash);
+  // Matched case-insensitively. Every id `headingSlug` mints is lowercase, so
+  // this makes nothing ambiguous — but a cross-reference typed by eye, copying
+  // the heading's own capitals ("#Grading"), would otherwise miss a section
+  // that is right there and be reported as renamed away.
+  const id = decodeFragment(hash).toLowerCase();
   if (!id) return null;
   return headings.find((heading) => heading.id === id) ?? null;
 }

--- a/src/lib/kb-nav.ts
+++ b/src/lib/kb-nav.ts
@@ -294,9 +294,10 @@ export function splitHeadingAnchor(text: string): { text: string; anchor: string
  * a ``` block never reaches here as a heading because `splitBlocks` keeps it
  * whole and its first line is a fence, not a `#`.
  */
-export function parseHeading(
-  blockMarkdown: string,
-): { depth: number; text: string; anchor: string | null } | null {
+/** What `parseHeading` reads off a heading line. */
+type Heading = { depth: number; text: string; anchor: string | null };
+
+export function parseHeading(blockMarkdown: string): Heading | null {
   const firstLine = blockMarkdown.split("\n", 1)[0] ?? "";
   const match = /^ {0,3}(#{1,6})\s+(.*)$/.exec(firstLine);
   if (!match) return null;
@@ -330,30 +331,50 @@ function stripInlineMarkdown(text: string): string {
  * two different belts still gives two working links.
  */
 export function extractHeadings(markdown: string): KbHeading[] {
-  // Uniqueness is checked against every id ALREADY EMITTED, not against a
+  const parsed: { heading: Heading; blockId: string }[] = [];
+  for (const block of splitBlocks(markdown)) {
+    const heading = parseHeading(block.markdown);
+    if (heading) parsed.push({ heading, blockId: block.id });
+  }
+
+  // Uniqueness is checked against every id ALREADY TAKEN, not against a
   // per-base counter. A counter alone collides with a heading that ends in a
   // number the author wrote: "Grading", "Grading 2", "Grading" would mint
   // `grading`, `grading-2`, and `grading-2` again, which puts two links in the
   // contents list pointing at the same place and two elements in the document
   // sharing an id.
   const used = new Set<string>();
-  const headings: KbHeading[] = [];
 
-  for (const block of splitBlocks(markdown)) {
-    const heading = parseHeading(block.markdown);
-    if (!heading) continue;
-    const base = heading.anchor ?? headingSlug(heading.text);
+  // PINNED ANCHORS ARE ALLOCATED FIRST, before anything derived from wording.
+  // A pinned anchor is the author saying "other articles point here", so it has
+  // to win: in document order a later heading whose words happen to slugify to
+  // `grading` would otherwise take that id and push the pinned one to
+  // `grading-2`, silently re-aiming every cross-reference in the club at the
+  // wrong passage. Two headings pinned to the SAME anchor still fall back to
+  // the suffix — that is an article contradicting itself, and the first one
+  // wins.
+  const take = (base: string) => {
     let id = base;
     for (let n = 2; used.has(id); n++) id = `${base}-${n}`;
     used.add(id);
+    return id;
+  };
+
+  const ids: (string | undefined)[] = parsed.map(({ heading }) =>
+    heading.anchor === null ? undefined : take(heading.anchor),
+  );
+
+  const headings: KbHeading[] = [];
+  parsed.forEach(({ heading, blockId }, index) => {
+    const id = ids[index] ?? take(headingSlug(heading.text));
     headings.push({
       depth: heading.depth,
       text: heading.text,
       id,
       pinned: heading.anchor !== null,
-      blockId: block.id,
+      blockId,
     });
-  }
+  });
   return headings;
 }
 
@@ -372,13 +393,45 @@ export function extractHeadings(markdown: string): KbHeading[] {
  * than throwing on a page that was only trying to scroll.
  */
 export function findHeadingForHash(hash: string, headings: KbHeading[]): KbHeading | null {
-  const raw = hash.replace(/^#/, "");
-  if (!raw) return null;
-  let id = raw;
-  try {
-    id = decodeURIComponent(raw);
-  } catch {
-    // A fragment that is not valid percent-encoding is matched as typed.
-  }
+  const id = decodeFragment(hash);
+  if (!id) return null;
   return headings.find((heading) => heading.id === id) ?? null;
+}
+
+/** A URL fragment with its `#` and its percent-encoding taken off. */
+function decodeFragment(hash: string): string {
+  const raw = hash.replace(/^#/, "");
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    // Not valid percent-encoding, so it is used exactly as it arrived.
+    return raw;
+  }
+}
+
+/**
+ * Fragments this app mints for something that is NOT a section of an article.
+ *
+ * A notification about a comment links to `/kb/<slug>#comment-<id>`
+ * (`kbAnnotationHref`), which is an ordinary, working link — telling somebody
+ * who followed one that a section has been renamed away would be both wrong and
+ * alarming.
+ */
+const NOT_A_SECTION = /^comment-/;
+
+/**
+ * The fragment to tell the reader about, when a link named a section this
+ * article does not have. Null when there is nothing worth saying.
+ *
+ * Only a fragment SHAPED like an anchor is worth a message: ids are words and
+ * hyphens, so anything carrying `=` or `&` came from somewhere else entirely
+ * (an auth callback's `#error=...`, a tracking parameter) and is not a broken
+ * cross-reference. Truncated because the fragment is shown back on screen and a
+ * hand-typed novel in the address bar must not push the article off it.
+ */
+export function missingSectionFragment(hash: string, headings: KbHeading[]): string | null {
+  const id = decodeFragment(hash);
+  if (!id || findHeadingForHash(hash, headings)) return null;
+  if (NOT_A_SECTION.test(id) || !/^[A-Za-z0-9-]+$/.test(id)) return null;
+  return id.length > 60 ? `${id.slice(0, 59)}…` : id;
 }

--- a/src/lib/manager-agent.test.ts
+++ b/src/lib/manager-agent.test.ts
@@ -454,7 +454,7 @@ describe("AGENT_MANIFEST", () => {
   // Round 2 of the dev probes noted that the manifest still said "1" after the
   // behaviour changed, leaving a client no way to tell the generations apart.
   it("advertises a version a client can branch on", () => {
-    expect(AGENT_MANIFEST.version).toBe("12");
+    expect(AGENT_MANIFEST.version).toBe("13");
   });
 
   // The changelog is only worth having if it cannot fall behind the version it

--- a/src/lib/manager-agent.ts
+++ b/src/lib/manager-agent.ts
@@ -141,7 +141,7 @@ export const AGENT_MANIFEST: {
   service: "uts-jitsu-manager-agent",
   // Bumped when the behaviour a client can rely on changes, not just the action
   // list. See `changes` for what each version actually moved.
-  version: "12",
+  version: "13",
   // What changed in each version, newest first.
   //
   // A bare version number tells a client THAT something moved, never what — and
@@ -154,6 +154,19 @@ export const AGENT_MANIFEST: {
   // moves between versions is the behaviour INSIDE an action — a new refusal, a
   // new response field — which is what these notes name.
   changes: [
+    {
+      version: "13",
+      // Additive: a new response field and a new piece of markdown syntax.
+      // Nothing that worked before fails or means anything different, and an
+      // article with no `{#anchor}` in it behaves exactly as it did.
+      breaking: false,
+      notes: [
+        "Articles can link to a SECTION of another article. Every heading has an anchor, and an ordinary markdown link carries it: [how grading works](/kb/belts#how-grading-works). The anchor is the heading's own words, lowercased with hyphens for anything else.",
+        "get_kb_article gained `sections`: every heading in the version you read, with its `id`, `text`, `depth`, `pinned` flag and ready-made `url`. Read the target article and use the `url` it reports rather than deriving a fragment from the heading yourself.",
+        "A heading can PIN its anchor with the attribute syntax `## How grading works {#grading}`, which fixes the link so rewording the heading later does not break it. The suffix is stripped when the article is rendered, and `sections[].pinned` says which anchors were set this way. Prefer pinning any heading you have just linked to from somewhere else.",
+        "A link to a section that no longer exists is not silently ignored: the reader is told the section is gone and shown what the article has now.",
+      ],
+    },
     {
       version: "12",
       // Five new optional fields on one action. Nothing that worked before
@@ -742,7 +755,7 @@ export const AGENT_MANIFEST: {
       name: "get_kb_article",
       method: "POST",
       summary:
-        "Read one article's full markdown. Returns the live version unless you name one. Read this before saving an edit: save_kb_article replaces the whole body, so an edit built without reading first silently drops everything it did not include.",
+        "Read one article's full markdown. Returns the live version unless you name one. Read this before saving an edit: save_kb_article replaces the whole body, so an edit built without reading first silently drops everything it did not include. The result also carries `sections`, every heading in it with the `url` that links straight to that heading — read the article you are about to point at and copy the url, rather than guessing the anchor.",
       params: [
         { name: "slug", required: true, description: "The article's URL key, e.g. our-history." },
         {
@@ -774,7 +787,7 @@ export const AGENT_MANIFEST: {
           name: "body_md",
           required: false,
           description:
-            "The whole article as markdown, up to 200000 characters. This REPLACES the previous body.",
+            "The whole article as markdown, up to 200000 characters. This REPLACES the previous body. Link to another article with an ordinary markdown link (/kb/<slug>), and to a SECTION of one by adding its anchor (/kb/belts#how-grading-works) — read that article with get_kb_article and take the anchor from its `sections`, rather than deriving it. Pin a heading's own anchor by ending it with the attribute syntax `## How grading works {#grading}`, so the link keeps working if the heading is reworded; the suffix is not shown to readers.",
         },
         {
           name: "section",

--- a/src/lib/remark-kb-anchors.test.tsx
+++ b/src/lib/remark-kb-anchors.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ReactMarkdown from "react-markdown";
+import { kbMarkdownComponents, kbRemarkPlugins } from "./kb-markdown";
+
+function renderMarkdown(markdown: string) {
+  return render(
+    <ReactMarkdown components={kbMarkdownComponents} remarkPlugins={kbRemarkPlugins}>
+      {markdown}
+    </ReactMarkdown>,
+  );
+}
+
+describe("remarkKbAnchors", () => {
+  // The anchor is plumbing. A member reading the syllabus must never see it.
+  it("takes a pinned anchor off the heading it is shown with", () => {
+    renderMarkdown("## How grading works {#grading}");
+    expect(screen.getByRole("heading", { name: "How grading works" })).toBeInTheDocument();
+    expect(screen.queryByText(/\{#grading\}/)).not.toBeInTheDocument();
+  });
+
+  // The anchor lands in a text node of its own when the heading ends in
+  // emphasis or a link, which is the case a naive "strip the last text node"
+  // gets wrong in the other direction.
+  it("strips it from a heading that ends in emphasis", () => {
+    renderMarkdown("## The **blue** belt {#blue}");
+    const heading = screen.getByRole("heading", { name: "The blue belt" });
+    expect(heading.textContent).toBe("The blue belt");
+  });
+
+  it("strips it from a heading whose last word is emphasised", () => {
+    renderMarkdown("## The blue **belt** {#blue}");
+    expect(screen.getByRole("heading", { name: "The blue belt" }).textContent).toBe(
+      "The blue belt",
+    );
+  });
+
+  it("leaves ordinary braces in a heading alone", () => {
+    renderMarkdown("## Using {{first_name}} in an email");
+    expect(
+      screen.getByRole("heading", { name: "Using {{first_name}} in an email" }),
+    ).toBeInTheDocument();
+  });
+
+  // Stripping this would leave a heading with no words in it, so the braces are
+  // the heading's text. `parseHeading` agrees, which is what keeps the contents
+  // list and the page showing the same thing.
+  it("leaves a heading that is nothing but an anchor alone", () => {
+    renderMarkdown("## {#orphan}");
+    expect(screen.getByRole("heading", { name: "{#orphan}" })).toBeInTheDocument();
+  });
+
+  it("does not touch braces in a paragraph", () => {
+    renderMarkdown("Write {#grading} at the end of a heading to pin its link.");
+    expect(screen.getByText(/\{#grading\}/)).toBeInTheDocument();
+  });
+});

--- a/src/lib/remark-kb-anchors.test.tsx
+++ b/src/lib/remark-kb-anchors.test.tsx
@@ -50,6 +50,14 @@ describe("remarkKbAnchors", () => {
     expect(screen.getByRole("heading", { name: "{#orphan}" })).toBeInTheDocument();
   });
 
+  // `parseHeading` only reads the first line of a block, so a heading nested in
+  // a blockquote or a list item never gets an id. Stripping its suffix would
+  // make a dead link look like a live one.
+  it("leaves an anchor alone where no id is ever minted for it", () => {
+    renderMarkdown("> ## Grading {#grading}");
+    expect(screen.getByRole("heading", { name: "Grading {#grading}" })).toBeInTheDocument();
+  });
+
   it("does not touch braces in a paragraph", () => {
     renderMarkdown("Write {#grading} at the end of a heading to pin its link.");
     expect(screen.getByText(/\{#grading\}/)).toBeInTheDocument();

--- a/src/lib/remark-kb-anchors.ts
+++ b/src/lib/remark-kb-anchors.ts
@@ -1,0 +1,63 @@
+// A remark plugin that takes a pinned anchor off a heading before it is shown.
+//
+// `## Grading {#grading}` gives the heading a stable id another article can link
+// to (see `splitHeadingAnchor` in `kb-nav.ts` for why that syntax). The id is
+// plumbing, not prose: a member reading the syllabus should see "Grading", not
+// "Grading {#grading}".
+//
+// It lives in `kbRemarkPlugins` rather than being stripped by each caller, for
+// the same reason the table plugin does: the reader renders one block at a time
+// and the manager's preview renders a whole body, and a suffix that disappears
+// in one but not the other is a difference nobody notices until a manager
+// publishes an article with the plumbing showing.
+//
+// Stripping only. The id itself is NOT set here, because the reader renders each
+// block through its own `react-markdown` pass: a plugin has no way to see the
+// headings in the rest of the article, so it could not tell a second "Grading"
+// from the first. `extractHeadings` does that once over the whole body, and the
+// reader hangs the id it produces on the block.
+import type { Heading, Root, RootContent } from "mdast";
+import { splitHeadingAnchor } from "@/lib/kb-nav";
+
+/** Every node in the tree that is a heading, however deeply it is nested. */
+function headings(nodes: RootContent[]): Heading[] {
+  const found: Heading[] = [];
+  for (const node of nodes) {
+    if (node.type === "heading") found.push(node);
+    // A heading can sit inside a blockquote or a list item, and one written
+    // there carries an anchor just as usefully as one at the top level.
+    if ("children" in node && Array.isArray(node.children)) {
+      found.push(...headings(node.children as RootContent[]));
+    }
+  }
+  return found;
+}
+
+/** A text node that is nothing but the anchor, e.g. the ` {#blue}` after emphasis. */
+const ONLY_ANCHOR = /^[ \t]*\{#[^{}\s]+\}[ \t]*$/;
+
+export function remarkKbAnchors() {
+  return (tree: Root) => {
+    for (const heading of headings(tree.children)) {
+      const last = heading.children.at(-1);
+      // The anchor is the last thing on the line, so it is always in the final
+      // text node — either at the end of it (`## Grading {#grading}`) or as the
+      // whole of it, when the heading ends in emphasis or a link
+      // (`## The **blue** belt {#blue}` splits the anchor into a node of its own).
+      if (!last || last.type !== "text") continue;
+
+      if (heading.children.length > 1 && ONLY_ANCHOR.test(last.value)) {
+        heading.children.pop();
+        const previous = heading.children.at(-1);
+        if (previous?.type === "text") previous.value = previous.value.replace(/[ \t]+$/, "");
+        continue;
+      }
+
+      const { text, anchor } = splitHeadingAnchor(last.value);
+      // `splitHeadingAnchor` leaves a heading that is NOTHING but an anchor
+      // alone, so this never empties a heading of its text.
+      if (anchor === null) continue;
+      last.value = text.replace(/[ \t]+$/, "");
+    }
+  };
+}

--- a/src/lib/remark-kb-anchors.ts
+++ b/src/lib/remark-kb-anchors.ts
@@ -16,21 +16,22 @@
 // headings in the rest of the article, so it could not tell a second "Grading"
 // from the first. `extractHeadings` does that once over the whole body, and the
 // reader hangs the id it produces on the block.
-import type { Heading, Root, RootContent } from "mdast";
+import type { Heading, Root } from "mdast";
 import { splitHeadingAnchor } from "@/lib/kb-nav";
 
-/** Every node in the tree that is a heading, however deeply it is nested. */
-function headings(nodes: RootContent[]): Heading[] {
-  const found: Heading[] = [];
-  for (const node of nodes) {
-    if (node.type === "heading") found.push(node);
-    // A heading can sit inside a blockquote or a list item, and one written
-    // there carries an anchor just as usefully as one at the top level.
-    if ("children" in node && Array.isArray(node.children)) {
-      found.push(...headings(node.children as RootContent[]));
-    }
-  }
-  return found;
+/**
+ * The headings this plugin may touch: TOP-LEVEL ones only, matching exactly
+ * what `parseHeading` reads.
+ *
+ * Deliberately not recursive. `parseHeading` looks at the first line of a
+ * block, so a heading nested inside a blockquote or a list item never gets an
+ * id at all — and stripping its anchor there would be the worst of both worlds:
+ * the suffix disappears, so it looks like it worked, while the link it promised
+ * points at nothing. Left alone, the braces stay on screen, which is the
+ * article telling its author that an anchor does not belong there.
+ */
+function headings(tree: Root): Heading[] {
+  return tree.children.filter((node): node is Heading => node.type === "heading");
 }
 
 /** A text node that is nothing but the anchor, e.g. the ` {#blue}` after emphasis. */
@@ -38,7 +39,7 @@ const ONLY_ANCHOR = /^[ \t]*\{#[^{}\s]+\}[ \t]*$/;
 
 export function remarkKbAnchors() {
   return (tree: Root) => {
-    for (const heading of headings(tree.children)) {
+    for (const heading of headings(tree)) {
       const last = heading.children.at(-1);
       // The anchor is the last thing on the line, so it is always in the final
       // text node — either at the end of it (`## Grading {#grading}`) or as the

--- a/src/routes/_authenticated/manager.kb.test.tsx
+++ b/src/routes/_authenticated/manager.kb.test.tsx
@@ -157,6 +157,9 @@ describe("/manager/kb section links", () => {
 
     await screen.findByLabelText(/sidebar label/i);
     expect(screen.getByText("/kb/our-history#our-history")).toBeInTheDocument();
+    // The worked example is built from this article's own first heading, so its
+    // link text and its target agree.
+    expect(screen.getByText("[our-history](/kb/our-history#our-history)")).toBeInTheDocument();
     expect(screen.getByText("/kb/our-history#grading")).toBeInTheDocument();
     // The pinned one is marked, because that is the link that survives the
     // heading being reworded.

--- a/src/routes/_authenticated/manager.kb.test.tsx
+++ b/src/routes/_authenticated/manager.kb.test.tsx
@@ -103,7 +103,7 @@ vi.mock("@/lib/kb.functions", () => ({
     Promise.resolve({
       slug: data.slug,
       title: data.slug === article.slug ? article.title : data.slug,
-      body_md: `# ${data.slug}`,
+      body_md: `# ${data.slug}\n\nText.\n\n## How grading works {#grading}`,
       version: article.version,
       is_current_version: true,
       change_note: null,
@@ -146,6 +146,24 @@ describe("/manager/kb autoload", () => {
 
     await screen.findByLabelText(/sidebar label/i);
     expect(screen.queryByText(/unsaved changes/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("/manager/kb section links", () => {
+  // The fragment is the part a manager cannot guess: it comes out of the
+  // heading's wording, so the editor has to tell them what it currently is.
+  it("lists the link to every heading in the article", async () => {
+    render(<KnowledgeBaseManager />);
+
+    await screen.findByLabelText(/sidebar label/i);
+    expect(screen.getByText("/kb/our-history#our-history")).toBeInTheDocument();
+    expect(screen.getByText("/kb/our-history#grading")).toBeInTheDocument();
+    // The pinned one is marked, because that is the link that survives the
+    // heading being reworded.
+    expect(screen.getByText("Pinned")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Copy the link to How grading works/i }),
+    ).toBeInTheDocument();
   });
 });
 

--- a/src/routes/_authenticated/manager.kb.tsx
+++ b/src/routes/_authenticated/manager.kb.tsx
@@ -45,6 +45,7 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { MarkdownEditor } from "@/components/site/MarkdownEditor";
+import { CopyButton } from "@/components/site/CopyButton";
 import { Badge } from "@/components/ui/badge";
 import {
   Select,
@@ -67,7 +68,7 @@ import {
 import { kbMarkdownComponents, kbRemarkPlugins } from "@/lib/kb-markdown";
 import { articleVisibilities, visibilityAudience } from "@/lib/kb";
 import type { ArticleVisibility } from "@/lib/kb";
-import { buildKbNav, UNSECTIONED_TITLE } from "@/lib/kb-nav";
+import { buildKbNav, extractHeadings, UNSECTIONED_TITLE } from "@/lib/kb-nav";
 import type { KbNavEntry } from "@/lib/kb-nav";
 import {
   isArticleDirty,
@@ -326,6 +327,15 @@ function KnowledgeBaseManager() {
    */
   const unsaved = sectionEdit ? isSectionDirty({ title: sectionTitle }, sectionEdit) : dirty;
   const liveVersion = versions.find((v) => v.is_current)?.version ?? null;
+
+  /**
+   * The sections this article offers other articles a link to.
+   *
+   * Read off the text in the editor rather than the saved version, so a heading
+   * just typed can be linked to straight away and a manager can see what
+   * renaming one did to its link before publishing it.
+   */
+  const sectionAnchors = useMemo(() => extractHeadings(body), [body]);
 
   /**
    * The knowledge base as a member will read it, built from the manager's own
@@ -1199,6 +1209,9 @@ function KnowledgeBaseManager() {
     [kind, navTitle, title],
   );
 
+  /** The address this article will have, which is what a link to it must use. */
+  const articleSlug = slug || proposedSlug;
+
   /**
    * How the reading order can be dragged.
    *
@@ -1803,6 +1816,67 @@ function KnowledgeBaseManager() {
             </Card>
           )}
 
+          {/* How one article points at a section of another. Managers asked for
+              cross-references, and the fragment is the part they cannot guess:
+              it comes from the wording of the heading, so this is where they
+              find out what it currently is and copy it. */}
+          {!sectionEdit && kind === "article" && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Link to a section</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <p className="text-xs text-muted-foreground">
+                  Paste one of these into another article as an ordinary Markdown link, for example{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 font-mono">
+                    [how grading works](
+                    {sectionAnchors[0]
+                      ? anchorPath(articleSlug, sectionAnchors[0].id)
+                      : "/kb/belts#grading"}
+                    )
+                  </code>
+                  . Add{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 font-mono">{"{#your-anchor}"}</code>{" "}
+                  to the end of a heading to pin its link, and it will keep working even if you
+                  reword the heading later.
+                </p>
+                {sectionAnchors.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    This article has no headings yet, so there is nothing to link to inside it.
+                    Start a line with ## to make one.
+                  </p>
+                ) : (
+                  <ul className="space-y-1.5">
+                    {sectionAnchors.map((heading) => (
+                      <li
+                        key={heading.id}
+                        className="flex flex-wrap items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm"
+                        style={{ marginLeft: `${(heading.depth - 1) * 0.75}rem` }}
+                      >
+                        <span className="min-w-0">
+                          <span className="block truncate font-medium">{heading.text}</span>
+                          <span className="block truncate font-mono text-xs text-muted-foreground">
+                            {anchorPath(articleSlug, heading.id)}
+                          </span>
+                        </span>
+                        <span className="flex shrink-0 items-center gap-1.5">
+                          {/* Says which links survive a rewrite and which do not,
+                              which is the whole reason to pin one. */}
+                          {heading.pinned && <Badge variant="outline">Pinned</Badge>}
+                          <CopyButton
+                            text={anchorPath(articleSlug, heading.id)}
+                            label="Copy"
+                            ariaLabel={`Copy the link to ${heading.text}`}
+                          />
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </CardContent>
+            </Card>
+          )}
+
           {!sectionEdit && (
             <Card>
               <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2">
@@ -1846,6 +1920,18 @@ function KnowledgeBaseManager() {
       </div>
     </section>
   );
+}
+
+/**
+ * The link that points at one section of an article.
+ *
+ * Falls back to the bare fragment while an article is being composed and has no
+ * slug yet, which is honest: a `/kb/#grading` with the slug missing is a link
+ * that goes to the wrong place, and half a link a manager can see is unfinished
+ * is better than a whole one that is wrong.
+ */
+function anchorPath(slug: string, id: string): string {
+  return slug ? `/kb/${slug}#${id}` : `#${id}`;
 }
 
 /**

--- a/src/routes/_authenticated/manager.kb.tsx
+++ b/src/routes/_authenticated/manager.kb.tsx
@@ -1213,6 +1213,19 @@ function KnowledgeBaseManager() {
   const articleSlug = slug || proposedSlug;
 
   /**
+   * The worked example above the anchor list, built from THIS article's first
+   * heading.
+   *
+   * A fixed label ("how grading works") pointed at whatever the real first
+   * heading happened to be, so on most articles the words and the target
+   * disagreed ("[how grading works](/kb/about-us#our-mission)") — an example of
+   * the syntax that contradicts itself.
+   */
+  const anchorExample = sectionAnchors[0]
+    ? `[${sectionAnchors[0].text}](${anchorPath(articleSlug, sectionAnchors[0].id)})`
+    : "[how grading works](/kb/belts#grading)";
+
+  /**
    * How the reading order can be dragged.
    *
    * The keyboard sensor is not a nicety: it is the ONLY way to reorder without a
@@ -1828,14 +1841,8 @@ function KnowledgeBaseManager() {
               <CardContent className="space-y-3">
                 <p className="text-xs text-muted-foreground">
                   Paste one of these into another article as an ordinary Markdown link, for example{" "}
-                  <code className="rounded bg-muted px-1 py-0.5 font-mono">
-                    [how grading works](
-                    {sectionAnchors[0]
-                      ? anchorPath(articleSlug, sectionAnchors[0].id)
-                      : "/kb/belts#grading"}
-                    )
-                  </code>
-                  . Add{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 font-mono">{anchorExample}</code>.
+                  Add{" "}
                   <code className="rounded bg-muted px-1 py-0.5 font-mono">{"{#your-anchor}"}</code>{" "}
                   to the end of a heading to pin its link, and it will keep working even if you
                   reword the heading later.

--- a/src/routes/kb/$slug.test.tsx
+++ b/src/routes/kb/$slug.test.tsx
@@ -1,0 +1,130 @@
+// Following a cross-reference from one article to a section of another.
+//
+// The browser cannot do this part on its own: the article's text arrives after
+// the page has loaded, so at the moment the browser looks for `#grading` there
+// is nothing in the document with that id, and the reader lands at the top of a
+// long syllabus with no sign that anything went wrong. These pin the two halves
+// of the fix — the jump once the text is there, and what a reader is told when
+// the section has been renamed away since the link was written.
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => ({
+    ...opts,
+    useParams: () => ({ slug: "belts" }),
+  }),
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock("@tanstack/react-start", () => ({
+  useServerFn: (fn: unknown) => fn,
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "member-1" }, loading: false }),
+}));
+
+vi.mock("@/hooks/useKbNav", () => ({
+  useKbNav: () => ({ nav: [], loading: false }),
+}));
+
+const BODY = [
+  "# Belts",
+  "",
+  "The club grades three times a year.",
+  "",
+  "## How grading works {#grading}",
+  "",
+  "You are graded on what you can show.",
+  "",
+  "## Fees",
+  "",
+  "Twenty dollars.",
+].join("\n");
+
+vi.mock("@/lib/kb.functions", () => ({
+  getKbArticle: () =>
+    Promise.resolve({
+      article: {
+        slug: "belts",
+        title: "Belts",
+        body_md: BODY,
+        version: 2,
+        visibility: "members",
+        change_note: null,
+        updated_at: "2026-08-01T00:00:00Z",
+      },
+      viewer: { signed_in: true, user_id: "member-1", is_manager: false, can_annotate: true },
+      redirect_to: null,
+    }),
+  listAnnotations: () => Promise.resolve([]),
+  createAnnotation: vi.fn(),
+  updateAnnotation: vi.fn(),
+  deleteAnnotation: vi.fn(),
+  resolveAnnotation: vi.fn(),
+  markKbArticleRead: () => Promise.resolve({ recorded: false }),
+}));
+
+const { Route } = await import("./$slug");
+const ArticlePage = (Route as unknown as { component: () => ReactNode }).component;
+
+function renderArticle(hash: string) {
+  window.location.hash = hash;
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <ArticlePage />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  window.location.hash = "";
+  // jsdom implements neither, and the article page uses both to put the reader
+  // where the link pointed.
+  Element.prototype.scrollIntoView = vi.fn();
+  // The read-progress observer at the foot of the article; jsdom has no such
+  // API, and this test is not about reading progress.
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    },
+  );
+  window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  }) as typeof window.requestAnimationFrame;
+});
+
+describe("/kb/$slug section anchors", () => {
+  it("scrolls to the section a cross-reference names, and puts focus there", async () => {
+    renderArticle("#grading");
+
+    await waitFor(() => expect(document.getElementById("grading")).not.toBeNull());
+    const section = document.getElementById("grading");
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    // Focus, not just scroll: without it a keyboard or screen reader carries on
+    // from the top of the page, wherever the viewport happens to be.
+    await waitFor(() => expect(document.activeElement).toBe(section));
+  });
+
+  it("says so when the link points at a section the article no longer has", async () => {
+    renderArticle("#throws");
+
+    expect(await screen.findByText(/does not have/i)).toBeInTheDocument();
+    expect(screen.getByText("#throws")).toBeInTheDocument();
+  });
+
+  it("says nothing about sections when the reader arrived without a fragment", async () => {
+    renderArticle("");
+
+    await screen.findByRole("heading", { name: "Belts", level: 1 });
+    expect(screen.queryByText(/does not have/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/routes/kb/$slug.test.tsx
+++ b/src/routes/kb/$slug.test.tsx
@@ -121,6 +121,15 @@ describe("/kb/$slug section anchors", () => {
     expect(screen.getByText("#throws")).toBeInTheDocument();
   });
 
+  // A notification about a comment sends the member to /kb/<slug>#comment-<id>.
+  // That is not a stale cross-reference, and saying it is would be alarming.
+  it("says nothing when the fragment is one of the app's own comment links", async () => {
+    renderArticle("#comment-2a0f6e4c-0000-4000-8000-000000000000");
+
+    await screen.findByRole("heading", { name: "Belts", level: 1 });
+    expect(screen.queryByText(/does not have/i)).not.toBeInTheDocument();
+  });
+
   it("says nothing about sections when the reader arrived without a fragment", async () => {
     renderArticle("");
 

--- a/src/routes/kb/$slug.tsx
+++ b/src/routes/kb/$slug.tsx
@@ -37,6 +37,7 @@ import {
   entryBreadcrumbs,
   extractHeadings,
   findHeadingForHash,
+  missingSectionFragment,
   readState,
   type KbNavEntry,
 } from "@/lib/kb-nav";
@@ -121,8 +122,8 @@ function ArticlePage() {
   }, [slug]);
 
   const target = useMemo(() => findHeadingForHash(hash, headings), [hash, headings]);
-  /** What the reader asked for, for a message about a section that is gone. */
-  const missingSection = hash && article && !target ? decodeFragment(hash) : null;
+  /** What the reader asked for, when it is worth saying the section is gone. */
+  const missingSection = article ? missingSectionFragment(hash, headings) : null;
 
   useEffect(() => {
     if (!target) return;
@@ -387,22 +388,6 @@ function ArticlePage() {
       )}
     </article>
   );
-}
-
-/**
- * A URL fragment, as it is worth showing back to somebody: decoded, and short
- * enough that a hand-typed novel in the address bar cannot push the article off
- * the screen.
- */
-function decodeFragment(hash: string): string {
-  const raw = hash.replace(/^#/, "");
-  let text = raw;
-  try {
-    text = decodeURIComponent(raw);
-  } catch {
-    // Not valid percent-encoding, so it is shown exactly as it arrived.
-  }
-  return text.length > 60 ? `${text.slice(0, 59)}…` : text;
 }
 
 /**

--- a/src/routes/kb/$slug.tsx
+++ b/src/routes/kb/$slug.tsx
@@ -36,6 +36,7 @@ import {
   adjacentEntries,
   entryBreadcrumbs,
   extractHeadings,
+  findHeadingForHash,
   readState,
   type KbNavEntry,
 } from "@/lib/kb-nav";
@@ -97,6 +98,49 @@ function ArticlePage() {
   }, [redirectTo]);
 
   const headings = useMemo(() => (article ? extractHeadings(article.body_md) : []), [article]);
+
+  /**
+   * The `#section` a reader arrived with, and the heading it names.
+   *
+   * The browser cannot do this on its own here: the article is fetched after the
+   * page loads, so at the moment the browser looks for the fragment there is
+   * nothing in the document to scroll to, and a cross-reference from another
+   * article lands silently at the top of the syllabus. Tracked in state rather
+   * than read at render because `window` does not exist during SSR and a
+   * same-page jump (the contents list, another article's `#link`) changes the
+   * fragment without React hearing about it.
+   */
+  const [hash, setHash] = useState(() =>
+    typeof window === "undefined" ? "" : window.location.hash,
+  );
+  useEffect(() => {
+    const sync = () => setHash(window.location.hash);
+    sync();
+    window.addEventListener("hashchange", sync);
+    return () => window.removeEventListener("hashchange", sync);
+  }, [slug]);
+
+  const target = useMemo(() => findHeadingForHash(hash, headings), [hash, headings]);
+  /** What the reader asked for, for a message about a section that is gone. */
+  const missingSection = hash && article && !target ? decodeFragment(hash) : null;
+
+  useEffect(() => {
+    if (!target) return;
+    // After paint: the block carrying the id is rendered by this same commit,
+    // and scrolling before the browser has laid it out lands short of it.
+    const frame = requestAnimationFrame(() => {
+      const element = document.getElementById(target.id);
+      if (!element) return;
+      element.scrollIntoView({ block: "start" });
+      // Move the reading position too, not just the viewport. Without this a
+      // screen reader carries on from wherever it was, and the next Tab starts
+      // at the top of the page, so following a cross-reference puts a keyboard
+      // reader somewhere other than where the link said.
+      element.setAttribute("tabindex", "-1");
+      element.focus({ preventScroll: true });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [target, article?.version]);
   const crumbs = entryBreadcrumbs(nav, slug);
   const { previous, next } = adjacentEntries(nav, slug);
   const entry = crumbs?.entry ?? null;
@@ -247,6 +291,20 @@ function ArticlePage() {
         )}
       </header>
 
+      {missingSection && (
+        <p
+          role="status"
+          className="mb-6 rounded-md border border-dashed px-3 py-2 text-sm text-muted-foreground"
+        >
+          The link you followed points at a section this article does not have:{" "}
+          <code className="font-mono">#{missingSection}</code>. It was probably renamed after that
+          link was written.{" "}
+          {headings.length >= MIN_HEADINGS_FOR_CONTENTS
+            ? "On this page, below, lists the sections it has now."
+            : "The whole article is below."}
+        </p>
+      )}
+
       {headings.length >= MIN_HEADINGS_FOR_CONTENTS && (
         <Collapsible defaultOpen className="mb-8 rounded-lg border">
           <CollapsibleTrigger className="flex w-full items-center gap-2 px-4 py-3 text-sm font-medium">
@@ -329,6 +387,22 @@ function ArticlePage() {
       )}
     </article>
   );
+}
+
+/**
+ * A URL fragment, as it is worth showing back to somebody: decoded, and short
+ * enough that a hand-typed novel in the address bar cannot push the article off
+ * the screen.
+ */
+function decodeFragment(hash: string): string {
+  const raw = hash.replace(/^#/, "");
+  let text = raw;
+  try {
+    text = decodeURIComponent(raw);
+  } catch {
+    // Not valid percent-encoding, so it is shown exactly as it arrived.
+  }
+  return text.length > 60 ? `${text.slice(0, 59)}…` : text;
 }
 
 /**


### PR DESCRIPTION
## What changes for people

**Members reading the knowledge base.** An article can now send you to one
*section* of another article, not just to the top of it: "bring the fee in cash,
see [the fees](/kb/belts#fees)" lands you on the fees heading, with the reading
position moved there too, so a keyboard or screen reader carries on from that
section rather than from the top of the page. Every heading also offers a **Link
to this section** control that copies the whole address, so a member can paste
one into a message.

If a link points at a section that has since been renamed away, the article says
so and names the fragment it could not find, instead of quietly dropping you at
the top of a long syllabus.

**Managers writing articles.** The editor has a new **Link to a section** panel:
every heading in the article you are editing, the exact link another article
should use (`/kb/belts#fees`), a Copy button on each, and a `Pinned` badge on the
ones whose anchor is fixed. It reads off the text in the editor, so a heading you
just typed can be linked to straight away, and you can see what renaming one did
to its link before publishing.

Nothing existing changes: an article with no cross-references behaves exactly as
it did, and nobody is emailed or interrupted by this.

## The syntax

As idiomatic as Markdown gets:

- Link with an ordinary link. `[the fees](/kb/belts#fees)` across articles,
  `[the fees](#fees)` within one.
- Anchors are the heading's own words, lowercased with hyphens
  (`## How grading works` → `#how-grading-works`), which is the convention
  GitHub and every static site generator already use.
- A heading can **pin** its anchor with the attribute syntax Pandoc and
  Docusaurus share: `## How grading works {#grading}`. The link then survives the
  heading being reworded. The suffix is stripped before a reader sees it, in the
  reader and in the manager's preview alike.

## Documented on both surfaces

- **UI:** the "Link to a section" panel above, plus a line in the panel spelling
  out both the link form and the `{#anchor}` pin. The fragment comes out of the
  heading's wording, so this is the only place it is discoverable.
- **API:** `get_kb_article` now returns `sections` — every heading with its `id`,
  `text`, `depth`, `pinned` flag and a ready-made `url` — so an agent copies the
  anchor instead of deriving it and getting it silently wrong. Manifest bumped to
  version `13` with a `changes` entry, and all four sync points updated together:
  the manifest, `save_kb_article`'s `body_md` docs, `docs/manager-agent-api.md`
  and the `uts-manager-agent` skill.
- `docs/knowledge-base.md` covers the reader side.

## Worth knowing

- Adding `{#anchor}` to a heading **edits that heading's block**, so comments
  anchored to the heading itself detach exactly as any other edit to a passage
  detaches them. They are shown under "On earlier wording", not lost.
- **Nothing validates a cross-reference at save time.** A link to
  `/kb/no-such-article#x` is an ordinary broken link until somebody follows it.
  Both docs say so; adding a check would be a separate decision.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (2051 passing) and
`bun run build` all clean. New coverage: pinned-anchor parsing and
`findHeadingForHash` in `kb-nav.test.ts`, the stripping plugin in
`remark-kb-anchors.test.tsx`, the section link and its anchors in
`KbArticleReader.test.tsx`, the scroll/renamed-section states in a new
`src/routes/kb/$slug.test.tsx`, the `sections` projection in `kb-admin.test.ts`,
and the manager panel in `manager.kb.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHUFz4EAEU4PbrFVbvzqga


---
_Generated by [Claude Code](https://claude.ai/code/session_01JHUFz4EAEU4PbrFVbvzqga)_