### PR TITLE
Keep a failed load on screen, everywhere a signed-in screen has an empty state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -834,9 +834,28 @@ Then hold the change to this:
   that catches a fetch error with only `toast.error(...)` and then renders an
   empty table is indistinguishable from "there's nothing here" once the toast
   fades — the manager has no way to tell a genuinely empty list from a broken
-  one. Keep the error on screen (a `loadError`-style state) with a retry
-  action; `manager.contact-messages.tsx` is the pattern to copy, not the
-  `toast.error()` + empty-table pattern most manager list pages default to.
+  one. Hold a `loadError` state and render **`components/site/LoadFailure`** in
+  place of the content: it is the panel, the "this is not the same as having
+  none" line, the `role="alert"`, and the retry button, so no screen writes its
+  own. `manager.contact-messages.tsx` is the shortest example. Use
+  `describeLoadError(e, "…")` for the message rather than an inline
+  `instanceof Error` ternary, so an Error with an empty body still says
+  something.
+  - Where an empty screen is not merely ambiguous but **invites a destructive
+    action** — an editor that would save blanks over a live document, an "add"
+    form for a list that failed to load — put the panel in place of the whole
+    screen rather than beside it, and say in the copy why not to work around
+    it. `manager.waiver-template.tsx`, `manager.membership-plans.tsx` and
+    `manager.settings.tsx` all do this.
+  - A query-backed screen has the same trap in a different shape:
+    `useQuery`'s `isLoading` is **false** once a query has rejected, so a hook
+    that reports only `isLoading` leaves the page on "Loading..." for good.
+    Surface `isError` too (`useKbNav` is the worked example).
+- **A bare `Loading...` is not a loading state.** Use
+  **`components/site/Loading`**, which carries the `role="status"` /
+  `aria-live="polite"` wiring `AuthPending` and `SubmitStatus` already have.
+  Without it a screen-reader user gets no signal that a page started fetching
+  or finished.
 - **Never lose someone's input.** A failed submit keeps the form filled and
   offers the retry. Ask for as little as possible in the first place, and prefill
   what we already know (the waiver does this with `getMyLatestWaiver`). Every

--- a/docs/knowledge-base.md
+++ b/docs/knowledge-base.md
@@ -37,6 +37,13 @@ This is the club's reading for the people who train here, not marketing. So:
   and the top bar carries the same link. On a phone the drawer is the only
   navigation on screen, so the way out cannot live only in the top bar. Neither
   of them waits on the article list loading.
+- The contents has **three** states, not two. "Loading", "there is nothing in
+  the knowledge base yet", and "the contents could not be loaded". The third
+  one used to be folded into the second: `useKbNav` reported only
+  `query.isLoading`, which is false once a query has rejected, so `/kb` sat on
+  "Loading..." for good and the sidebar told a member the club had written
+  nothing. It now returns `error` and `refetch`, and both `/kb` and the sidebar
+  render a failure panel with a retry in place of the empty state.
 
 The gate is enforced twice on purpose, and the two are not the same thing. The
 route redirect is a courtesy for a person; `canReadArticle` (`src/lib/kb.ts`)

--- a/src/components/site/KbLayout.test.tsx
+++ b/src/components/site/KbLayout.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { KbNavSection } from "@/lib/kb-nav";
 
@@ -78,6 +79,23 @@ describe("KbLayout sidebar", () => {
       );
       unmount();
     }
+  });
+
+  // The sidebar had two answers for three situations, and "there is nothing in
+  // the knowledge base yet" is the wrong one to give a reader whose fetch
+  // failed: it reads as a club that has written nothing.
+  it("says the contents could not be loaded rather than showing the empty state", async () => {
+    const refetch = vi.fn();
+    mockUseKbNav.mockReturnValue({ nav: [], loading: false, error: "Failed to fetch", refetch });
+    render(<KbLayout>article</KbLayout>);
+
+    const alerts = screen.getAllByRole("alert");
+    expect(alerts[0]).toHaveTextContent("The contents could not be loaded.");
+    expect(alerts[0]).toHaveTextContent("Failed to fetch");
+    expect(screen.queryByText(/nothing in the knowledge base yet/i)).not.toBeInTheDocument();
+
+    await userEvent.click(within(alerts[0]).getByRole("button", { name: /try again/i }));
+    expect(refetch).toHaveBeenCalled();
   });
 
   it("ticks off an article this member has read, and flags one rewritten since", () => {

--- a/src/components/site/KbLayout.tsx
+++ b/src/components/site/KbLayout.tsx
@@ -30,6 +30,8 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import logoAsset from "@/assets/UTS_JITSU_CMYK.png.asset.json";
@@ -40,7 +42,7 @@ import type { KbNavEntry, KbNavSection } from "@/lib/kb-nav";
 import { searchKnowledgeBase } from "@/lib/kb.functions";
 
 export function KbLayout({ children }: { children: React.ReactNode }) {
-  const { nav, loading } = useKbNav();
+  const { nav, loading, error, refetch } = useKbNav();
   const [menuOpen, setMenuOpen] = useState(false);
   const location = useLocation();
 
@@ -63,7 +65,7 @@ export function KbLayout({ children }: { children: React.ReactNode }) {
             <SheetContent side="left" className="w-[85vw] max-w-xs overflow-y-auto p-0">
               <SheetTitle className="border-b px-4 py-4 text-base">Knowledge base</SheetTitle>
               <div className="p-4">
-                <KbNavList nav={nav} loading={loading} />
+                <KbNavList nav={nav} loading={loading} error={error} onRetry={refetch} />
               </div>
             </SheetContent>
           </Sheet>
@@ -97,7 +99,7 @@ export function KbLayout({ children }: { children: React.ReactNode }) {
       <div className="mx-auto flex w-full max-w-7xl flex-1 gap-8 px-4 py-8">
         <aside className="hidden w-60 shrink-0 lg:block">
           <div className="sticky top-24 max-h-[calc(100vh-8rem)] overflow-y-auto pr-2">
-            <KbNavList nav={nav} loading={loading} />
+            <KbNavList nav={nav} loading={loading} error={error} onRetry={refetch} />
           </div>
         </aside>
         <main className="min-w-0 flex-1">{children}</main>
@@ -120,7 +122,17 @@ export function KbLayout({ children }: { children: React.ReactNode }) {
 }
 
 /** The sidebar itself, shared by the desktop rail and the phone drawer. */
-function KbNavList({ nav, loading }: { nav: KbNavSection[]; loading: boolean }) {
+function KbNavList({
+  nav,
+  loading,
+  error,
+  onRetry,
+}: {
+  nav: KbNavSection[];
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+}) {
   const location = useLocation();
 
   // Above everything, including the loading and empty states: the way out is
@@ -145,7 +157,24 @@ function KbNavList({ nav, loading }: { nav: KbNavSection[]; loading: boolean }) 
     return (
       <>
         {backToMemberSpace}
-        <p className="text-sm text-muted-foreground">Loading...</p>
+        <Loading />
+      </>
+    );
+  }
+
+  // The third answer the sidebar used to fold into the second one: the list
+  // could not be fetched. Left as an empty knowledge base, a reader has no
+  // reason to try again and no way to.
+  if (error) {
+    return (
+      <>
+        {backToMemberSpace}
+        <LoadFailure
+          what="The contents"
+          message={error}
+          hint="The articles are still there."
+          onRetry={onRetry}
+        />
       </>
     );
   }

--- a/src/components/site/LoadFailure.test.tsx
+++ b/src/components/site/LoadFailure.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { LoadFailure } from "./LoadFailure";
+
+describe("LoadFailure", () => {
+  it("stays on screen as an alert rather than fading like a toast", () => {
+    render(<LoadFailure what="The contact messages" onRetry={() => {}} />);
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "The contact messages could not be loaded.",
+    );
+  });
+
+  it("says what failed alongside the line that separates it from an empty list", () => {
+    render(
+      <LoadFailure
+        what="The waivers"
+        message="Failed to fetch"
+        hint="This is not the same as nobody having signed one."
+        onRetry={() => {}}
+      />,
+    );
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Failed to fetch");
+    expect(alert).toHaveTextContent("This is not the same as nobody having signed one.");
+  });
+
+  it("gives the person something to press", async () => {
+    const onRetry = vi.fn();
+    render(<LoadFailure what="The plans" onRetry={onRetry} />);
+    await userEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/site/LoadFailure.tsx
+++ b/src/components/site/LoadFailure.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  /**
+   * What did not arrive, in the reader's words: "The contact messages". The
+   * component writes the sentence around it, so every screen says it the same
+   * way.
+   */
+  what: string;
+  /** Whatever the failure itself said. Shown as-is when there is one. */
+  message?: string | null;
+  /**
+   * The line that stops a broken load reading as an empty one: "This is not the
+   * same as having no messages." Worth writing per screen, because what the
+   * empty state would have claimed differs every time.
+   */
+  hint?: ReactNode;
+  onRetry: () => void;
+  /** Extra content under the message, above the button. */
+  children?: ReactNode;
+  className?: string;
+};
+
+/**
+ * The panel a screen shows in place of its content when the content could not
+ * be fetched.
+ *
+ * This exists because a `toast.error` is not a UI for a failed load. It fades,
+ * and what it leaves behind is the ordinary empty state: no messages, no
+ * members, everything reconciled. A manager who looks away for four seconds is
+ * then reading a confident, wrong answer with no way to tell and nothing to
+ * press. So the failure stays on screen, says it is not the same as having
+ * nothing, and carries the retry.
+ *
+ * `role="alert"` for the same reason `SubmitStatus` carries one: this replaces
+ * content that was expected to appear, and a screen-reader user gets no other
+ * signal that it did not.
+ */
+export function LoadFailure({ what, message, hint, onRetry, children, className }: Props) {
+  return (
+    <div
+      role="alert"
+      className={cn("rounded-lg border border-destructive/40 bg-destructive/5 p-4", className)}
+    >
+      <p className="flex items-start gap-2 text-sm font-medium">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" aria-hidden="true" />
+        {what} could not be loaded.
+      </p>
+      {(message || hint) && (
+        <p className="mt-1 text-sm text-muted-foreground">
+          {message ? `${message} ` : ""}
+          {hint}
+        </p>
+      )}
+      {children}
+      <Button className="mt-3" size="sm" variant="outline" onClick={onRetry}>
+        <RefreshCw className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" /> Try again
+      </Button>
+    </div>
+  );
+}

--- a/src/components/site/Loading.test.tsx
+++ b/src/components/site/Loading.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { Loading } from "./Loading";
+
+describe("Loading", () => {
+  it("announces the wait politely instead of rendering bare text", () => {
+    render(<Loading />);
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveTextContent("Loading...");
+  });
+
+  it("takes a label for screens that can say what they are waiting on", () => {
+    render(<Loading label="Loading the roster" />);
+    expect(screen.getByRole("status")).toHaveTextContent("Loading the roster");
+  });
+});

--- a/src/components/site/Loading.tsx
+++ b/src/components/site/Loading.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * The "this has not arrived yet" line, for the screens that show a plain one
+ * rather than `AuthPending`'s full-page spinner.
+ *
+ * The markup is the point. Dozens of screens rendered the same bare
+ * `Loading...` text with no live region, so a screen-reader user got no signal
+ * that the page had started fetching or had finished: the text simply appeared
+ * and vanished with nothing announcing either. `role="status"` plus
+ * `aria-live="polite"` is what `AuthPending` and `SubmitStatus` already do, and
+ * this is that same wiring for a one-line state.
+ */
+export function Loading({
+  label = "Loading...",
+  className,
+}: {
+  label?: string;
+  className?: string;
+}) {
+  return (
+    <p role="status" aria-live="polite" className={cn("text-sm text-muted-foreground", className)}>
+      {label}
+    </p>
+  );
+}

--- a/src/hooks/useKbNav.test.tsx
+++ b/src/hooks/useKbNav.test.tsx
@@ -1,0 +1,40 @@
+// `/kb` used to sit on "Loading..." for good when the nav fetch failed: the
+// hook reported `query.isLoading`, which is false once a query has rejected,
+// and nothing downstream could see the rejection. What is pinned here is that
+// a failed fetch stops being a load and starts being an error.
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const fetchNav = vi.fn();
+
+vi.mock("@tanstack/react-start", () => ({ useServerFn: () => fetchNav }));
+vi.mock("@/hooks/useAuth", () => ({ useAuth: () => ({ user: { id: "u1" }, loading: false }) }));
+vi.mock("@/lib/kb.functions", () => ({ listKnowledgeBase: vi.fn() }));
+
+const { useKbNav } = await import("./useKbNav");
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useKbNav", () => {
+  it("reports the failure instead of loading forever", async () => {
+    fetchNav.mockRejectedValue(new Error("Failed to fetch"));
+    const { result } = renderHook(() => useKbNav(), { wrapper });
+
+    await waitFor(() => expect(result.current.error).toBe("Failed to fetch"));
+    expect(result.current.loading).toBe(false);
+    expect(result.current.nav).toEqual([]);
+  });
+
+  it("has no error once the nav lands", async () => {
+    fetchNav.mockResolvedValue({ sections: [], entries: [] });
+    const { result } = renderHook(() => useKbNav(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/hooks/useKbNav.ts
+++ b/src/hooks/useKbNav.ts
@@ -12,11 +12,18 @@ import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
 import { useAuth } from "@/hooks/useAuth";
+import { describeLoadError } from "@/lib/load-error";
 import { buildKbNav } from "@/lib/kb-nav";
 import type { KbNavSection } from "@/lib/kb-nav";
 import { listKnowledgeBase } from "@/lib/kb.functions";
 
-export function useKbNav(): { nav: KbNavSection[]; loading: boolean } {
+export function useKbNav(): {
+  nav: KbNavSection[];
+  loading: boolean;
+  /** Set when the fetch rejected. Null while it is in flight and once it lands. */
+  error: string | null;
+  refetch: () => void;
+} {
   const { user, loading: authLoading } = useAuth();
   const fetchNav = useServerFn(listKnowledgeBase);
   const query = useQuery({
@@ -41,5 +48,15 @@ export function useKbNav(): { nav: KbNavSection[]; loading: boolean } {
     () => (query.data ? buildKbNav(query.data.sections, query.data.entries) : []),
     [query.data],
   );
-  return { nav, loading: authLoading || query.isLoading };
+  // `isLoading` is false once a query has failed, and it was the only thing
+  // reported here: /kb sat on "Loading..." for good, with no error and no way
+  // out, because nothing downstream could see that the fetch had rejected.
+  return {
+    nav,
+    loading: authLoading || query.isLoading,
+    error: query.isError
+      ? describeLoadError(query.error, "Could not load the knowledge base")
+      : null,
+    refetch: () => void query.refetch(),
+  };
 }

--- a/src/lib/load-error.test.ts
+++ b/src/lib/load-error.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { describeLoadError } from "./load-error";
+
+describe("describeLoadError", () => {
+  it("uses what the failure said", () => {
+    expect(describeLoadError(new Error("Forbidden"), "Fallback")).toBe("Forbidden");
+  });
+
+  it("falls back when the Error carries no message", () => {
+    expect(describeLoadError(new Error("   "), "Could not load the waivers")).toBe(
+      "Could not load the waivers",
+    );
+  });
+
+  it("falls back for anything that is not an Error", () => {
+    expect(describeLoadError("boom", "Could not load the waivers")).toBe(
+      "Could not load the waivers",
+    );
+    expect(describeLoadError(undefined, "Could not load the waivers")).toBe(
+      "Could not load the waivers",
+    );
+  });
+});

--- a/src/lib/load-error.ts
+++ b/src/lib/load-error.ts
@@ -1,0 +1,13 @@
+/**
+ * What to put on screen when a fetch rejected.
+ *
+ * Every load path had its own `e instanceof Error ? e.message : "Failed to
+ * load"`, which is fine until the thrown thing is a string, or an Error with an
+ * empty message (TanStack's client throws `new Error(await response.text())`,
+ * and an empty body makes an Error with nothing in it). Both of those printed a
+ * sentence with a hole in it. This returns the caller's fallback instead.
+ */
+export function describeLoadError(error: unknown, fallback: string): string {
+  const message = error instanceof Error ? error.message.trim() : "";
+  return message || fallback;
+}

--- a/src/routes/_authenticated/account.test.tsx
+++ b/src/routes/_authenticated/account.test.tsx
@@ -297,6 +297,24 @@ describe("/account", () => {
     expect(screen.queryByText("We couldn't load your details")).toBeNull();
   });
 
+  // "No waivers on file yet." is the one sentence on that card a member acts
+  // on, by going and signing a waiver they have already signed. It has to be
+  // true when it is said.
+  it("does not claim a member has no waivers when the list failed to load", async () => {
+    const user = userEvent.setup();
+    const { listMyWaivers } = await import("@/lib/waiver.functions");
+    vi.mocked(listMyWaivers).mockRejectedValueOnce(new Error("network"));
+
+    render(<AccountPage />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Your waivers could not be loaded.");
+    expect(screen.queryByText("No waivers on file yet.")).toBeNull();
+
+    await user.click(within(alert).getByRole("button", { name: /try again/i }));
+    expect(await screen.findByText("No waivers on file yet.")).toBeInTheDocument();
+  });
+
   it("offers nothing that would edit the legal name, date of birth or email", async () => {
     await renderLoaded();
     // These are evidence a signed waiver froze, or the person's identity. The

--- a/src/routes/_authenticated/account.tsx
+++ b/src/routes/_authenticated/account.tsx
@@ -4,6 +4,9 @@ import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -382,7 +385,7 @@ function AboutYouCard({ profile, loading, onSaved }: DetailsCardProps) {
       </CardHeader>
       <CardContent>
         {loading ? (
-          <p className="text-sm text-muted-foreground">Loading...</p>
+          <Loading />
         ) : (
           <form onSubmit={onSubmit} className="space-y-4">
             <div>
@@ -473,7 +476,7 @@ function KitSizingCard({ profile, loading, onSaved }: DetailsCardProps) {
       </CardHeader>
       <CardContent>
         {loading ? (
-          <p className="text-sm text-muted-foreground">Loading...</p>
+          <Loading />
         ) : (
           <form onSubmit={onSubmit} className="space-y-4">
             <div>
@@ -596,7 +599,7 @@ function ContactCard({ profile, loading, onSaved }: DetailsCardProps) {
       </CardHeader>
       <CardContent>
         {loading ? (
-          <p className="text-sm text-muted-foreground">Loading...</p>
+          <Loading />
         ) : (
           <form onSubmit={onSubmit} className="space-y-4">
             <div>
@@ -738,7 +741,7 @@ function MediaConsentCard({ profile, loading, onSaved }: DetailsCardProps) {
       </CardHeader>
       <CardContent>
         {loading ? (
-          <p className="text-sm text-muted-foreground">Loading...</p>
+          <Loading />
         ) : (
           <form onSubmit={onSubmit} className="space-y-4">
             <div className="flex flex-wrap items-center gap-2">
@@ -797,13 +800,28 @@ function WaiversCard() {
   const getUrl = useServerFn(getWaiverPdfUrl);
   const [waivers, setWaivers] = useState<MyWaiver[]>([]);
   const [loading, setLoading] = useState(true);
+  // "No waivers on file yet." is the one sentence on this card that a member
+  // acts on, by going and signing one they have already signed. It has to be
+  // true when it is said.
+  const [loadError, setLoadError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchMine()
-      .then((rows) => setWaivers(rows as MyWaiver[]))
-      .catch(() => setWaivers([]))
+  const load = useCallback(() => {
+    setLoading(true);
+    return fetchMine()
+      .then((rows) => {
+        setWaivers(rows as MyWaiver[]);
+        setLoadError(null);
+      })
+      .catch((e) => {
+        setWaivers([]);
+        setLoadError(describeLoadError(e, "Could not load your waivers"));
+      })
       .finally(() => setLoading(false));
   }, [fetchMine]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
 
   async function download(id: string) {
     try {
@@ -824,7 +842,14 @@ function WaiversCard() {
       </CardHeader>
       <CardContent className="space-y-3">
         {loading ? (
-          <p className="text-sm text-muted-foreground">Loading...</p>
+          <Loading />
+        ) : loadError ? (
+          <LoadFailure
+            what="Your waivers"
+            message={loadError}
+            hint="This is not the same as having none on file, so there is nothing to sign again."
+            onRetry={() => void load()}
+          />
         ) : waivers.length === 0 ? (
           <p className="text-sm text-muted-foreground">No waivers on file yet.</p>
         ) : (
@@ -876,20 +901,29 @@ function CodeOfConductCard() {
   const [acceptedAt, setAcceptedAt] = useState<string | null>(null);
   const [acceptedVersion, setAcceptedVersion] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
+  // Swallowed, this card fell back to the "please read and agree" prompt, which
+  // asks somebody who agreed last month to do it again.
+  const [loadError, setLoadError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchSigner({ data: { token: "" } })
+  const load = useCallback(() => {
+    setLoading(true);
+    return fetchSigner({ data: { token: "" } })
       .then((res) => {
+        setLoadError(null);
         if (!res.status) return;
         setState(res.status.state);
         setAcceptedAt(res.status.accepted_at);
         setAcceptedVersion(res.status.accepted_version);
       })
-      .catch(() => {
-        /* nothing to show is the honest fallback here */
+      .catch((e) => {
+        setLoadError(describeLoadError(e, "Could not load your code of conduct"));
       })
       .finally(() => setLoading(false));
   }, [fetchSigner]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
 
   return (
     <Card>
@@ -902,7 +936,14 @@ function CodeOfConductCard() {
       </CardHeader>
       <CardContent className="space-y-3">
         {loading ? (
-          <p className="text-sm text-muted-foreground">Loading...</p>
+          <Loading />
+        ) : loadError ? (
+          <LoadFailure
+            what="Whether you have agreed to this"
+            message={loadError}
+            hint="If you have already agreed, that still stands."
+            onRetry={() => void load()}
+          />
         ) : state === "signed" ? (
           <p className="text-sm text-muted-foreground">
             You agreed to version {acceptedVersion} on {formatDate(acceptedAt)}.
@@ -934,6 +975,7 @@ function GoogleDriveCard() {
   const saveFolderFromPicker = useServerFn(setGoogleDriveFolderFromPicker);
 
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
   const [email, setEmail] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -942,21 +984,28 @@ function GoogleDriveCard() {
   const [folderBusy, setFolderBusy] = useState(false);
   const [pickerBusy, setPickerBusy] = useState(false);
 
-  const refresh = () =>
-    status()
+  const refresh = () => {
+    setLoading(true);
+    return status()
       .then((s) => {
+        setLoadError(null);
         setConnected(s.connected);
         setEmail(s.connected ? (s.email ?? null) : null);
         const name = s.connected ? (s.folderName ?? null) : null;
         setSavedFolderName(name);
         setFolderNameInput(name ?? DEFAULT_FOLDER_NAME);
       })
-      .catch(() => {
+      .catch((e) => {
+        // Not "not connected". That offers a manager the Google consent screen
+        // for an account that is already linked, and a folder box that would
+        // overwrite the folder they already chose.
+        setLoadError(describeLoadError(e, "Could not check your Drive connection"));
         setConnected(false);
         setEmail(null);
         setSavedFolderName(null);
       })
       .finally(() => setLoading(false));
+  };
 
   useEffect(() => {
     refresh();
@@ -1050,7 +1099,14 @@ function GoogleDriveCard() {
       </CardHeader>
       <CardContent className="space-y-3">
         {loading ? (
-          <p className="text-sm text-muted-foreground">Loading...</p>
+          <Loading />
+        ) : loadError ? (
+          <LoadFailure
+            what="Your Drive connection"
+            message={loadError}
+            hint="This is not the same as it being disconnected, so any folder you set is still set."
+            onRetry={() => void refresh()}
+          />
         ) : connected ? (
           <div className="space-y-4">
             <div className="flex flex-wrap items-center justify-between gap-3">

--- a/src/routes/_authenticated/manager.api-tokens.tsx
+++ b/src/routes/_authenticated/manager.api-tokens.tsx
@@ -4,6 +4,9 @@ import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { KeyRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
@@ -43,6 +46,7 @@ function ApiTokensPage() {
 
   const [tokens, setTokens] = useState<TokenRow[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [label, setLabel] = useState("");
   const [creating, setCreating] = useState(false);
   // The raw token is shown exactly once, right after creation.
@@ -57,9 +61,17 @@ function ApiTokensPage() {
   }, [rolesLoading, isManager, user, navigate]);
 
   const load = useCallback(() => {
+    setLoading(true);
     fetchTokens()
-      .then((rows) => setTokens(rows))
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load tokens"))
+      .then((rows) => {
+        setTokens(rows);
+        setLoadError(null);
+      })
+      .catch((e) => {
+        const message = describeLoadError(e, "Could not load the tokens");
+        setLoadError(message);
+        toast.error(message);
+      })
       .finally(() => setLoading(false));
   }, [fetchTokens]);
 
@@ -97,13 +109,7 @@ function ApiTokensPage() {
     }
   }
 
-  if (loading) {
-    return (
-      <>
-        <div className="p-8">Loading...</div>
-      </>
-    );
-  }
+  if (loading) return <Loading className="p-8" />;
 
   return (
     <>
@@ -186,7 +192,14 @@ function ApiTokensPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            {tokens.length === 0 ? (
+            {loadError ? (
+              <LoadFailure
+                what="The tokens"
+                message={loadError}
+                hint="This is not the same as having none, so a token you issued earlier may well still be live."
+                onRetry={load}
+              />
+            ) : tokens.length === 0 ? (
               <p className="text-sm text-muted-foreground">No tokens yet.</p>
             ) : (
               <ul className="divide-y">

--- a/src/routes/_authenticated/manager.blog-comments.tsx
+++ b/src/routes/_authenticated/manager.blog-comments.tsx
@@ -1,11 +1,14 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Pill } from "@/components/site/StatusPill";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import {
   Dialog,
   DialogContent,
@@ -49,6 +52,7 @@ function BlogCommentsPage() {
   const [comments, setComments] = useState<CommentRow[]>([]);
   const [blocked, setBlocked] = useState<BlockedRow[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   // Two separate id-spaces — a comment id and its author's user id are never
   // the same value, but keying both actions off one shared `busyId` state
   // meant blocking an author never disabled anything in the Blocked
@@ -72,13 +76,29 @@ function BlogCommentsPage() {
     ]);
   }
 
+  // `refresh()` on its own is called after a hide or a block, where the action's
+  // own handler reports a failure; this wrapper is the one the screen loads
+  // through and the one "Try again" repeats.
+  const load = useMemo(
+    () => () => {
+      setLoading(true);
+      return refresh()
+        .then(() => setLoadError(null))
+        .catch((e) => {
+          const message = describeLoadError(e, "Could not load comments");
+          setLoadError(message);
+          toast.error(message);
+        })
+        .finally(() => setLoading(false));
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
   useEffect(() => {
     if (!isManager) return;
-    refresh()
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Could not load comments"))
-      .finally(() => setLoading(false));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isManager]);
+    void load();
+  }, [isManager, load]);
 
   async function confirmHide() {
     if (!hideTarget) return;
@@ -138,7 +158,7 @@ function BlogCommentsPage() {
     }
   }
 
-  if (loading) return <div className="p-8">Loading...</div>;
+  if (loading) return <Loading className="p-8" />;
 
   const blockedUserIds = new Set(blocked.map((b) => b.user_id));
   const replyCountByParent = countRepliesByParent(comments);
@@ -153,7 +173,14 @@ function BlogCommentsPage() {
         </p>
       </div>
 
-      {comments.length === 0 ? (
+      {loadError ? (
+        <LoadFailure
+          what="The comments"
+          message={loadError}
+          hint="This is not the same as there being nothing to moderate."
+          onRetry={() => void load()}
+        />
+      ) : comments.length === 0 ? (
         <p className="text-sm text-muted-foreground">No comments yet.</p>
       ) : (
         <div className="overflow-x-auto rounded-lg border">
@@ -278,7 +305,11 @@ function BlogCommentsPage() {
         <p className="text-sm text-muted-foreground">
           People blocked from commenting anywhere on the blog.
         </p>
-        {blocked.length === 0 ? (
+        {loadError ? (
+          <p className="mt-3 text-sm text-muted-foreground">
+            This list could not be loaded either, so it is not saying nobody is blocked.
+          </p>
+        ) : blocked.length === 0 ? (
           <p className="mt-3 text-sm text-muted-foreground">Nobody is blocked.</p>
         ) : (
           <div className="mt-3 overflow-x-auto rounded-lg border">

--- a/src/routes/_authenticated/manager.blog.tsx
+++ b/src/routes/_authenticated/manager.blog.tsx
@@ -1,8 +1,11 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import { Pill } from "@/components/site/StatusPill";
 import {
   AlertDialog,
@@ -39,6 +42,7 @@ function BlogPostsPage() {
 
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<Row | null>(null);
 
@@ -46,13 +50,28 @@ function BlogPostsPage() {
     if (!rolesLoading && user && !isManager) navigate({ to: "/account" });
   }, [rolesLoading, isManager, user, navigate]);
 
+  const load = useMemo(
+    () => () => {
+      setLoading(true);
+      return fetchList()
+        .then((data) => {
+          setRows(data);
+          setLoadError(null);
+        })
+        .catch((e) => {
+          const message = describeLoadError(e, "Could not load posts");
+          setLoadError(message);
+          toast.error(message);
+        })
+        .finally(() => setLoading(false));
+    },
+    [fetchList],
+  );
+
   useEffect(() => {
     if (!isManager) return;
-    fetchList()
-      .then(setRows)
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Could not load posts"))
-      .finally(() => setLoading(false));
-  }, [isManager, fetchList]);
+    void load();
+  }, [isManager, load]);
 
   async function onDelete(row: Row) {
     setDeletingId(row.id);
@@ -68,7 +87,7 @@ function BlogPostsPage() {
     }
   }
 
-  if (loading) return <div className="p-8">Loading...</div>;
+  if (loading) return <Loading className="p-8" />;
 
   return (
     <section className="mx-auto max-w-5xl space-y-6 px-4 py-10">
@@ -84,7 +103,14 @@ function BlogPostsPage() {
         </Button>
       </div>
 
-      {rows.length === 0 ? (
+      {loadError ? (
+        <LoadFailure
+          what="The posts"
+          message={loadError}
+          hint="This is not the same as having written none, so do not start a post over the top of one."
+          onRetry={() => void load()}
+        />
+      ) : rows.length === 0 ? (
         <p className="text-sm text-muted-foreground">No posts yet.</p>
       ) : (
         <div className="overflow-x-auto rounded-lg border">

--- a/src/routes/_authenticated/manager.blog_.$id.tsx
+++ b/src/routes/_authenticated/manager.blog_.$id.tsx
@@ -1,8 +1,11 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import { BlogPostEditor, type BlogPostEditorValue } from "@/components/site/BlogPostEditor";
 import { getBlogPostForEdit, updateBlogPost } from "@/lib/blog.functions";
 import { useAuth, useRoles } from "@/hooks/useAuth";
@@ -28,18 +31,31 @@ function EditBlogPostPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!rolesLoading && user && !isManager) navigate({ to: "/account" });
   }, [rolesLoading, isManager, user, navigate]);
 
+  const load = useCallback(() => {
+    setLoading(true);
+    return fetchPost({ data: { id } })
+      .then((row) => {
+        setPost(row);
+        setLoadError(null);
+      })
+      .catch((e) => {
+        const message = describeLoadError(e, "Could not load that post");
+        setLoadError(message);
+        toast.error(message);
+      })
+      .finally(() => setLoading(false));
+  }, [id, fetchPost]);
+
   useEffect(() => {
     if (!isManager) return;
-    fetchPost({ data: { id } })
-      .then(setPost)
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Could not load that post"))
-      .finally(() => setLoading(false));
-  }, [isManager, id, fetchPost]);
+    void load();
+  }, [isManager, load]);
 
   function goBack() {
     if (dirty && !window.confirm("Discard your unsaved changes?")) return;
@@ -107,7 +123,26 @@ function EditBlogPostPage() {
     [post],
   );
 
-  if (loading) return <div className="p-8">Loading...</div>;
+  if (loading) return <Loading className="p-8" />;
+
+  // Previously a blank page: the toast faded and `post` was null, so the route
+  // rendered nothing at all with no way back and nothing to press.
+  if (loadError)
+    return (
+      <section className="mx-auto max-w-2xl space-y-4 px-4 py-10">
+        <h1 className="text-3xl font-black">Edit post</h1>
+        <LoadFailure
+          what="That post"
+          message={loadError}
+          hint="It has not been changed or deleted, so there is nothing to rewrite."
+          onRetry={() => void load()}
+        />
+        <Button variant="outline" onClick={goBack}>
+          Back to posts
+        </Button>
+      </section>
+    );
+
   if (!post || !initial) return null;
 
   return (

--- a/src/routes/_authenticated/manager.calendar.tsx
+++ b/src/routes/_authenticated/manager.calendar.tsx
@@ -3,6 +3,9 @@ import { Fragment, useCallback, useEffect, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { useAuth, useRoles } from "@/hooks/useAuth";
@@ -151,21 +154,27 @@ function ManagerCalendarPage() {
   const [openRsvpEvent, setOpenRsvpEvent] = useState<string | null>(null);
   const [rsvpRows, setRsvpRows] = useState<RsvpRow[]>([]);
   const [rsvpLoading, setRsvpLoading] = useState(false);
+  const [rsvpError, setRsvpError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!rolesLoading && user && !isManager) navigate({ to: "/account" });
   }, [rolesLoading, isManager, user, navigate]);
 
+  const [loadError, setLoadError] = useState<string | null>(null);
+
   const reload = useCallback(() => {
+    setLoading(true);
     return fetchEvents()
       .then((e) => {
         setEvents(e as EventRow[]);
-        setLoading(false);
+        setLoadError(null);
       })
       .catch((err) => {
-        toast.error(err instanceof Error ? err.message : "Could not load the calendar");
-        setLoading(false);
-      });
+        const message = describeLoadError(err, "Could not load the calendar");
+        setLoadError(message);
+        toast.error(message);
+      })
+      .finally(() => setLoading(false));
   }, [fetchEvents]);
 
   useEffect(() => {
@@ -328,13 +337,20 @@ function ManagerCalendarPage() {
     }
   }
 
-  async function toggleRsvpList(eventId: string) {
+  function toggleRsvpList(eventId: string) {
     if (openRsvpEvent === eventId) {
       setOpenRsvpEvent(null);
       return;
     }
     setOpenRsvpEvent(eventId);
+    void loadRsvps(eventId);
+  }
+
+  // Split out of the toggle so "Try again" refetches the open row rather than
+  // collapsing it, which is what calling the toggle again would do.
+  async function loadRsvps(eventId: string) {
     setRsvpRows([]);
+    setRsvpError(null);
     setRsvpLoading(true);
     try {
       const rows = await fetchRsvps({ data: { event_id: eventId } });
@@ -345,7 +361,9 @@ function ManagerCalendarPage() {
         return current;
       });
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Could not load who's coming");
+      const message = describeLoadError(e, "Could not load who's coming");
+      setRsvpError(message);
+      toast.error(message);
       setRsvpRows([]);
     } finally {
       setRsvpLoading(false);
@@ -546,7 +564,14 @@ function ManagerCalendarPage() {
       <div className="space-y-4">
         <h2 className="text-xl font-bold">What's coming up</h2>
         {loading ? (
-          <p className="text-muted-foreground">Loading...</p>
+          <Loading />
+        ) : loadError ? (
+          <LoadFailure
+            what="The calendar"
+            message={loadError}
+            hint="This is not the same as the calendar being empty, so adding an entry from here risks putting on a class twice."
+            onRetry={() => void reload()}
+          />
         ) : events.length === 0 ? (
           <p className="text-sm text-muted-foreground">Nothing on the calendar yet.</p>
         ) : (
@@ -794,7 +819,14 @@ function ManagerCalendarPage() {
                         <tr className="border-t bg-muted/30">
                           <td colSpan={6} className="px-3 py-3">
                             {rsvpLoading ? (
-                              <p className="text-xs text-muted-foreground">Loading...</p>
+                              <Loading className="text-xs" />
+                            ) : rsvpError ? (
+                              <LoadFailure
+                                what="Who is coming"
+                                message={rsvpError}
+                                hint="Nobody is listed because the replies could not be read."
+                                onRetry={() => void loadRsvps(ev.id)}
+                              />
                             ) : rsvpRows.length === 0 ? (
                               <p className="text-xs text-muted-foreground">
                                 Nobody has replied yet.

--- a/src/routes/_authenticated/manager.check-in.tsx
+++ b/src/routes/_authenticated/manager.check-in.tsx
@@ -3,6 +3,8 @@ import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { describeLoadError } from "@/lib/load-error";
 import { Input } from "@/components/ui/input";
 import { Pill } from "@/components/site/StatusPill";
 import { coverageClass, UNREAD_CLASS } from "@/lib/status-colours";
@@ -110,6 +112,11 @@ function CheckInPage() {
   const [board, setBoard] = useState<Board | null>(null);
   const [uncovered, setUncovered] = useState<UncoveredRow[]>([]);
   const [loading, setLoading] = useState(true);
+  // Two loads, two failures, and they mean different things: no classes on the
+  // calendar is a reason to add one, and no roster means nobody is in the room.
+  // Both used to fade with a toast and leave the ordinary empty state saying so.
+  const [eventsError, setEventsError] = useState<string | null>(null);
+  const [boardError, setBoardError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [search, setSearch] = useState("");
   const [openAttach, setOpenAttach] = useState<string | null>(null);
@@ -120,26 +127,40 @@ function CheckInPage() {
   }, [rolesLoading, isManager, user, navigate]);
 
   // The class list, and the one the screen opens on: today's, or the nearest.
-  useEffect(() => {
-    if (!isManager) return;
-    fetchEvents()
+  const loadEvents = useCallback(() => {
+    setLoading(true);
+    return fetchEvents()
       .then((rows) => {
         const list = rows as EventRow[];
         setEvents(list);
         setEventId((current) => current ?? pickDefaultEvent(list, new Date())?.id ?? null);
-        setLoading(false);
+        setEventsError(null);
       })
       .catch((e) => {
-        toast.error(e instanceof Error ? e.message : "Could not load the classes");
-        setLoading(false);
-      });
-  }, [isManager, fetchEvents]);
+        const message = describeLoadError(e, "Could not load the classes");
+        setEventsError(message);
+        toast.error(message);
+      })
+      .finally(() => setLoading(false));
+  }, [fetchEvents]);
+
+  useEffect(() => {
+    if (!isManager) return;
+    void loadEvents();
+  }, [isManager, loadEvents]);
 
   const reloadBoard = useCallback(() => {
     if (!eventId) return Promise.resolve();
     return fetchBoard({ data: { event_id: eventId } })
-      .then((b) => setBoard(b as Board))
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Could not load the roster"));
+      .then((b) => {
+        setBoard(b as Board);
+        setBoardError(null);
+      })
+      .catch((e) => {
+        const message = describeLoadError(e, "Could not load the roster");
+        setBoardError(message);
+        toast.error(message);
+      });
   }, [eventId, fetchBoard]);
 
   const reloadUncovered = useCallback(() => {
@@ -304,7 +325,17 @@ function CheckInPage() {
             This class was cancelled, so nobody can be checked in to it.
           </p>
         )}
-        {events.length === 0 && !loading && (
+        {eventsError && !loading && (
+          <LoadFailure
+            className="mt-3"
+            what="The class list"
+            message={eventsError}
+            hint="This is not the same as there being no classes on the calendar, so do not add one from here."
+            onRetry={() => void loadEvents()}
+          />
+        )}
+
+        {events.length === 0 && !eventsError && !loading && (
           <p className="mt-3 text-sm text-muted-foreground">
             A check-in has to belong to a class on the calendar.{" "}
             <Link className="underline" to="/manager/calendar">
@@ -318,6 +349,14 @@ function CheckInPage() {
       {/* ---- Here now ---- */}
       <div className="space-y-2">
         <h2 className="text-xl font-bold">Here now{board ? ` (${board.checkins.length})` : ""}</h2>
+        {boardError && (
+          <LoadFailure
+            what="The roster"
+            message={boardError}
+            hint="Nobody is listed because it could not be read, not because the mat is empty."
+            onRetry={() => void reloadBoard()}
+          />
+        )}
         <div className="overflow-x-auto rounded-lg border">
           <table className="w-full text-sm">
             <thead className="bg-muted/50 text-left">

--- a/src/routes/_authenticated/manager.contact-messages.tsx
+++ b/src/routes/_authenticated/manager.contact-messages.tsx
@@ -3,6 +3,9 @@ import { useEffect, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { Pill } from "@/components/site/StatusPill";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import { UNREAD_CLASS } from "@/lib/status-colours";
 import { formatDateTime } from "@/lib/dates";
 import { cn } from "@/lib/utils";
@@ -13,7 +16,6 @@ import {
 } from "@/lib/contact-messages.functions";
 import { useAuth, useRoles } from "@/hooks/useAuth";
 import { useNotifications } from "@/hooks/useNotifications";
-import { Button } from "@/components/ui/button";
 
 export const Route = createFileRoute("/_authenticated/manager/contact-messages")({
   head: () => ({
@@ -81,7 +83,7 @@ function ContactMessagesPage() {
         }
       })
       .catch((e) => {
-        const message = e instanceof Error ? e.message : "Could not load the contact messages";
+        const message = describeLoadError(e, "Could not load the contact messages");
         if (isCancelled()) return;
         setLoadError(message);
         toast.error(message);
@@ -101,7 +103,7 @@ function ContactMessagesPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isManager]);
 
-  if (loading) return <div className="p-8">Loading...</div>;
+  if (loading) return <Loading className="p-8" />;
 
   return (
     <section className="mx-auto max-w-6xl space-y-6 px-4 py-10">
@@ -128,15 +130,12 @@ function ContactMessagesPage() {
       )}
 
       {loadError ? (
-        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4">
-          <p className="text-sm font-medium">The contact messages could not be loaded.</p>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {loadError} This is not the same as having no messages.
-          </p>
-          <Button className="mt-3" size="sm" variant="outline" onClick={() => void load()}>
-            Try again
-          </Button>
-        </div>
+        <LoadFailure
+          what="The contact messages"
+          message={loadError}
+          hint="This is not the same as having no messages."
+          onRetry={() => void load()}
+        />
       ) : messages.length === 0 ? (
         <p className="text-sm text-muted-foreground">No messages yet.</p>
       ) : (

--- a/src/routes/_authenticated/manager.kb.tsx
+++ b/src/routes/_authenticated/manager.kb.tsx
@@ -7,7 +7,7 @@
 // feature actually has: several articles rather than one, a visibility setting,
 // and a feedback panel.
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import ReactMarkdown from "react-markdown";
@@ -40,6 +40,9 @@ import {
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { CSS } from "@dnd-kit/utilities";
 import { Button } from "@/components/ui/button";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -243,6 +246,9 @@ function KnowledgeBaseManager() {
    * confident wrong answer on the panel a manager uses to decide whether members'
    * feedback has been dealt with.
    */
+  // The article and section lists themselves, as opposed to `failed` below,
+  // which is about one opened article's version and comment panels.
+  const [listError, setListError] = useState<string | null>(null);
   const [failed, setFailed] = useState<{ article: boolean; versions: boolean; feedback: boolean }>({
     article: false,
     versions: false,
@@ -388,8 +394,9 @@ function KnowledgeBaseManager() {
   }, [rolesLoading, isManager, user, navigate]);
 
   /** Load the lists, and open the first article so the screen is never empty. */
-  useEffect(() => {
-    Promise.all([fetchArticles(), fetchSections()])
+  const loadLists = useCallback(() => {
+    setLoading(true);
+    return Promise.all([fetchArticles(), fetchSections()])
       .then(([rows, sectionRows]) => {
         setArticles(rows);
         setSections(sectionRows);
@@ -404,16 +411,24 @@ function KnowledgeBaseManager() {
         // this article was next saved.
         if (firstArticle) void openDocument(firstArticle.slug, { articles: rows });
       })
+      .then(() => setListError(null))
       .catch((e) => {
-        // A non-manager is redirected by the effect above; anything else is
-        // worth saying out loud rather than leaving a blank screen.
+        // A non-manager is redirected by the effect above; anything else stays
+        // on screen. "Nothing here yet. Create the first article." over a
+        // failed read invites a manager to write one that already exists.
         if (!(e instanceof Error) || !e.message.includes("Forbidden")) {
-          toast.error(e instanceof Error ? e.message : "Could not load articles");
+          const message = describeLoadError(e, "Could not load articles");
+          setListError(message);
+          toast.error(message);
         }
       })
       .finally(() => setLoading(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetchArticles, fetchSections]);
+
+  useEffect(() => {
+    void loadLists();
+  }, [loadLists]);
 
   /** Put the placement fields on screen from a list row. */
   function applyPlacement(summary: ArticleSummary | undefined) {
@@ -1214,7 +1229,7 @@ function KnowledgeBaseManager() {
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
-  if (loading) return <div className="p-8">Loading...</div>;
+  if (loading) return <Loading className="p-8" />;
 
   // The same `isSectionDirty` the discard prompt consults, so "there is nothing
   // to save" and "there is nothing to lose" can never disagree.
@@ -1283,10 +1298,20 @@ function KnowledgeBaseManager() {
                 tells members it was updated.
               </p>
 
-              {articles.length === 0 && sections.length === 0 && (
-                <p className="text-xs text-muted-foreground">
-                  Nothing here yet. Create the first article.
-                </p>
+              {listError ? (
+                <LoadFailure
+                  what="The knowledge base"
+                  message={listError}
+                  hint="This is not the same as it being empty, so do not write an article from here: it may already exist."
+                  onRetry={() => void loadLists()}
+                />
+              ) : (
+                articles.length === 0 &&
+                sections.length === 0 && (
+                  <p className="text-xs text-muted-foreground">
+                    Nothing here yet. Create the first article.
+                  </p>
+                )
               )}
 
               <DndContext
@@ -1667,7 +1692,7 @@ function KnowledgeBaseManager() {
                         ? "Create and publish"
                         : "Save as new version"}
                 </Button>
-                {busy && <span className="text-xs text-muted-foreground">Loading...</span>}
+                {busy && <Loading className="text-xs" />}
                 {dirty && <span className="text-xs text-muted-foreground">Unsaved changes</span>}
               </div>
             </>

--- a/src/routes/_authenticated/manager.membership-plans.tsx
+++ b/src/routes/_authenticated/manager.membership-plans.tsx
@@ -1,8 +1,11 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -404,6 +407,7 @@ function PlansPage() {
    * it still matches the database and grey its Save button out when it does. */
   const [baseline, setBaseline] = useState<Record<string, MembershipPlanRow>>({});
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [savingId, setSavingId] = useState<string | null>(null);
   const [newPlan, setNewPlan] = useState<NewPlanForm>(emptyNewPlan);
   const [copiedFrom, setCopiedFrom] = useState<string | null>(null);
@@ -413,16 +417,29 @@ function PlansPage() {
     if (!rolesLoading && user && !isManager) navigate({ to: "/account" });
   }, [rolesLoading, isManager, user, navigate]);
 
+  const load = useMemo(
+    () => () => {
+      setLoading(true);
+      return fetchAll()
+        .then((data) => {
+          setPlans(data as MembershipPlanRow[]);
+          setBaseline(baselineOf(data as MembershipPlanRow[]));
+          setLoadError(null);
+        })
+        .catch((e) => {
+          const message = describeLoadError(e, "Could not load the plans");
+          setLoadError(message);
+          toast.error(message);
+        })
+        .finally(() => setLoading(false));
+    },
+    [fetchAll],
+  );
+
   useEffect(() => {
     if (!isManager) return;
-    fetchAll()
-      .then((data) => {
-        setPlans(data as MembershipPlanRow[]);
-        setBaseline(baselineOf(data as MembershipPlanRow[]));
-      })
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load plans"))
-      .finally(() => setLoading(false));
-  }, [isManager, fetchAll]);
+    void load();
+  }, [isManager, load]);
 
   function patch(id: string, p: Partial<MembershipPlanRow>) {
     setPlans((prev) => prev.map((pl) => (pl.id === id ? { ...pl, ...p } : pl)));
@@ -544,13 +561,24 @@ function PlansPage() {
     }
   }
 
-  if (loading) {
+  if (loading) return <Loading className="p-8" />;
+
+  // In place of the plan list AND the add form. A failed load leaves both plan
+  // sections empty, which reads as a club that sells nothing, and the obvious
+  // response to that is to add a plan that already exists.
+  if (loadError)
     return (
-      <>
-        <div className="p-8">Loading...</div>
-      </>
+      <section className="mx-auto max-w-2xl px-4 py-10">
+        <h1 className="text-3xl font-black">Membership plans</h1>
+        <LoadFailure
+          className="mt-6"
+          what="The plans"
+          message={loadError}
+          hint="This is not the same as the club selling nothing, so do not add a plan from here: you would be adding one that already exists."
+          onRetry={() => void load()}
+        />
+      </section>
     );
-  }
 
   // Club-local, not UTC: the member purchase screen's `sellablePlans` decides
   // a dated plan has ended by the same club-local calendar day, so the two

--- a/src/routes/_authenticated/manager.memberships.tsx
+++ b/src/routes/_authenticated/manager.memberships.tsx
@@ -1,9 +1,12 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Pill } from "@/components/site/StatusPill";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import { MembershipRowActions } from "@/components/site/MembershipRowActions";
 import { membershipClass } from "@/lib/status-colours";
 import { membershipStatusLabel } from "@/lib/status-labels";
@@ -28,23 +31,34 @@ function ManagerMembershipsPage() {
 
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!rolesLoading && user && !isManager) navigate({ to: "/account" });
   }, [rolesLoading, isManager, user, navigate]);
 
+  const load = useMemo(
+    () => () => {
+      setLoading(true);
+      return fetchList()
+        .then((data) => {
+          setRows(data as Row[]);
+          setLoadError(null);
+        })
+        .catch((e) => {
+          const message = describeLoadError(e, "Could not load the memberships");
+          setLoadError(message);
+          toast.error(message);
+        })
+        .finally(() => setLoading(false));
+    },
+    [fetchList],
+  );
+
   useEffect(() => {
     if (!isManager) return;
-    fetchList()
-      .then((data) => {
-        setRows(data as Row[]);
-        setLoading(false);
-      })
-      .catch((e) => {
-        toast.error(e instanceof Error ? e.message : "Failed to load memberships");
-        setLoading(false);
-      });
-  }, [isManager, fetchList]);
+    void load();
+  }, [isManager, load]);
 
   async function refresh() {
     setRows((await fetchList()) as Row[]);
@@ -80,7 +94,14 @@ function ManagerMembershipsPage() {
         </div>
 
         {loading ? (
-          <p>Loading...</p>
+          <Loading />
+        ) : loadError ? (
+          <LoadFailure
+            what="The memberships"
+            message={loadError}
+            hint="This is not the same as nobody being on a plan, so do not raise one from here until it loads."
+            onRetry={() => void load()}
+          />
         ) : rows.length === 0 ? (
           <p className="text-sm text-muted-foreground">No memberships yet.</p>
         ) : (

--- a/src/routes/_authenticated/manager.reconciliation.test.tsx
+++ b/src/routes/_authenticated/manager.reconciliation.test.tsx
@@ -1,0 +1,66 @@
+// The worst version of the missing-load-error bug: this screen told a manager
+// "Everything imported has been matched." when the transactions had not
+// arrived at all. It is a money screen, so an all-clear it cannot back up is
+// worse than no answer.
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const listBankTransactions = vi.fn();
+const listMemberships = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => opts,
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+  useNavigate: () => vi.fn(),
+}));
+vi.mock("@tanstack/react-start", () => ({ useServerFn: (fn: unknown) => fn }));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock("@/lib/membership.functions", () => ({
+  importBankStatement: vi.fn(),
+  listBankTransactions: (...args: unknown[]) => listBankTransactions(...args),
+  listMemberships: (...args: unknown[]) => listMemberships(...args),
+  matchTransaction: vi.fn(),
+}));
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "manager-1" }, session: null, loading: false }),
+  useRoles: () => ({ roles: ["manager"], loading: false, isManager: true }),
+}));
+
+const { Route } = await import("./manager.reconciliation");
+const ReconciliationPage = (Route as unknown as { component: () => ReactNode }).component;
+
+// Every test sets both mocks itself, so there is nothing to reset between
+// them. Clearing a mock whose rejected promise vitest is still tracking makes
+// that rejection surface as an unhandled error and fails the run.
+describe("manager reconciliation", () => {
+  it("never reports the all-clear when the transactions could not be loaded", async () => {
+    listBankTransactions.mockRejectedValue(new Error("Failed to fetch"));
+    listMemberships.mockResolvedValue([]);
+    render(<ReconciliationPage />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("The imported transactions could not be loaded.");
+    expect(alert).toHaveTextContent("Failed to fetch");
+    expect(screen.queryByText(/everything imported has been matched/i)).not.toBeInTheDocument();
+  });
+
+  it("retries the same fetch from the panel", async () => {
+    listBankTransactions.mockRejectedValueOnce(new Error("Failed to fetch")).mockResolvedValue([]);
+    listMemberships.mockResolvedValue([]);
+    render(<ReconciliationPage />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /try again/i }));
+    expect(await screen.findByText(/everything imported has been matched/i)).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("still says everything is matched when the load worked and there is nothing left", async () => {
+    listBankTransactions.mockResolvedValue([]);
+    listMemberships.mockResolvedValue([]);
+    render(<ReconciliationPage />);
+
+    expect(await screen.findByText(/everything imported has been matched/i)).toBeInTheDocument();
+  });
+});

--- a/src/routes/_authenticated/manager.reconciliation.tsx
+++ b/src/routes/_authenticated/manager.reconciliation.tsx
@@ -4,6 +4,9 @@ import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import { formatCents, isUnpaid, parseMoneyToCents, type BankTxnRow } from "@/lib/validation";
 import {
   importBankStatement,
@@ -108,6 +111,10 @@ function ReconciliationPage() {
   const [memberships, setMemberships] = useState<Membership[]>([]);
   const [busy, setBusy] = useState(false);
   const [loading, setLoading] = useState(true);
+  // Without this the card below reports "Everything imported has been matched."
+  // to a manager whose transactions never arrived. On a screen about money that
+  // is not an ambiguous empty state, it is the wrong answer stated confidently.
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   // What a statement line can settle is an UNPAID invoice, which is what this
   // screen is for. Filtering on `status === "pending"` used to mean the same
@@ -128,12 +135,28 @@ function ReconciliationPage() {
     [fetchTxns, fetchMemberships],
   );
 
+  // Wrapped so the "Try again" button runs the same fetch the mount effect does,
+  // error state and all. `reload()` on its own is also called after an import
+  // and after a manual match, where a failure is reported by those handlers.
+  const load = useMemo(
+    () => () => {
+      setLoading(true);
+      return reload()
+        .then(() => setLoadError(null))
+        .catch((e) => {
+          const message = describeLoadError(e, "Could not load the transactions");
+          setLoadError(message);
+          toast.error(message);
+        })
+        .finally(() => setLoading(false));
+    },
+    [reload],
+  );
+
   useEffect(() => {
     if (!isManager) return;
-    reload()
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load"))
-      .finally(() => setLoading(false));
-  }, [isManager, reload]);
+    void load();
+  }, [isManager, load]);
 
   async function onFile(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -217,7 +240,14 @@ function ReconciliationPage() {
         </Card>
 
         {loading ? (
-          <p>Loading...</p>
+          <Loading />
+        ) : loadError ? (
+          <LoadFailure
+            what="The imported transactions"
+            message={loadError}
+            hint="Nothing here is reconciled or unreconciled until this loads, so do not treat the missing list as an all-clear."
+            onRetry={() => void load()}
+          />
         ) : (
           <Card>
             <CardHeader>

--- a/src/routes/_authenticated/manager.settings.tsx
+++ b/src/routes/_authenticated/manager.settings.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import ReactMarkdown from "react-markdown";
 import { AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Loading } from "@/components/site/Loading";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -148,13 +149,7 @@ function SettingsPage() {
     }
   }
 
-  if (loading) {
-    return (
-      <>
-        <div className="p-8">Loading...</div>
-      </>
-    );
-  }
+  if (loading) return <Loading className="p-8" />;
 
   /**
    * The read failed, so we do not know what the club's account currently says.

--- a/src/routes/_authenticated/manager.users.tsx
+++ b/src/routes/_authenticated/manager.users.tsx
@@ -5,6 +5,9 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Pill } from "@/components/site/StatusPill";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import { formatDate } from "@/lib/dates";
 import {
   ROLE_CLASS,
@@ -45,6 +48,7 @@ function ManagerUsersPage() {
 
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   // Who registered interest since a manager last opened this screen, captured
   // before the watermark moved. Normalized addresses: a lead is keyed by the
   // address they typed, a person by their auth email.
@@ -61,18 +65,28 @@ function ManagerUsersPage() {
     if (!rolesLoading && user && !isManager) navigate({ to: "/account" });
   }, [rolesLoading, isManager, user, navigate]);
 
+  const load = useMemo(
+    () => () => {
+      setLoading(true);
+      return fetchList()
+        .then((data) => {
+          setRows(data as Row[]);
+          setLoadError(null);
+        })
+        .catch((e) => {
+          const message = describeLoadError(e, "Could not load the members");
+          setLoadError(message);
+          toast.error(message);
+        })
+        .finally(() => setLoading(false));
+    },
+    [fetchList],
+  );
+
   useEffect(() => {
     if (!isManager) return;
-    fetchList()
-      .then((data) => {
-        setRows(data as Row[]);
-        setLoading(false);
-      })
-      .catch((e) => {
-        toast.error(e instanceof Error ? e.message : "Failed to load users");
-        setLoading(false);
-      });
-  }, [isManager, fetchList]);
+    void load();
+  }, [isManager, load]);
 
   // This screen is where new interest registrations are read, so opening it is
   // what clears them off the "needs attention" list. Club-wide, like the contact
@@ -239,7 +253,14 @@ function ManagerUsersPage() {
         </div>
 
         {loading ? (
-          <p>Loading...</p>
+          <Loading />
+        ) : loadError ? (
+          <LoadFailure
+            what="The member list"
+            message={loadError}
+            hint="This is not the same as the club having no members."
+            onRetry={() => void load()}
+          />
         ) : rows.length === 0 ? (
           <p className="text-sm text-muted-foreground">No users yet.</p>
         ) : (

--- a/src/routes/_authenticated/manager.users_.$userId.tsx
+++ b/src/routes/_authenticated/manager.users_.$userId.tsx
@@ -4,6 +4,9 @@ import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { ChevronDown, Download } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -485,22 +488,31 @@ function ManagerUserPage() {
     [fetchDetail, userId],
   );
 
+  // Returns its own cancel flag so the mount effect can drop a late response,
+  // while "Try again" calls it with nothing to cancel.
+  const retry = useCallback(
+    (isCancelled: () => boolean = () => false) => {
+      setLoading(true);
+      setError(null);
+      return load(true)
+        .catch((e) => {
+          if (!isCancelled()) setError(describeLoadError(e, "Could not load this member"));
+        })
+        .finally(() => {
+          if (!isCancelled()) setLoading(false);
+        });
+    },
+    [load],
+  );
+
   useEffect(() => {
     if (!isManager) return;
-    let active = true;
-    setLoading(true);
-    setError(null);
-    load(true)
-      .catch((e) => {
-        if (active) setError(e instanceof Error ? e.message : "Failed to load user");
-      })
-      .finally(() => {
-        if (active) setLoading(false);
-      });
+    let cancelled = false;
+    void retry(() => cancelled);
     return () => {
-      active = false;
+      cancelled = true;
     };
-  }, [isManager, load]);
+  }, [isManager, retry]);
 
   // Sign a PDF URL only for panels actually open, and re-sign a stale one:
   // Radix unmounts collapsed content, so re-expanding an old panel remounts the
@@ -648,15 +660,34 @@ function ManagerUserPage() {
   if (loading) {
     return (
       <section className="mx-auto max-w-5xl px-4 py-10">
-        <p>Loading...</p>
+        <Loading />
       </section>
     );
   }
 
-  if (error || !detail) {
+  // Two different answers that used to share one line. "User not found" is a
+  // fact about the club; a failed read is a fact about the network, and only
+  // one of them is worth pressing a button about.
+  if (error) {
     return (
       <section className="mx-auto max-w-5xl space-y-4 px-4 py-10">
-        <p className="text-sm text-muted-foreground">{error ?? "User not found."}</p>
+        <LoadFailure
+          what="This member's record"
+          message={error}
+          hint="This is not the same as them having no waiver, membership or history."
+          onRetry={() => void retry()}
+        />
+        <Button asChild variant="outline">
+          <Link to="/manager/users">Back to users</Link>
+        </Button>
+      </section>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <section className="mx-auto max-w-5xl space-y-4 px-4 py-10">
+        <p className="text-sm text-muted-foreground">User not found.</p>
         <Button asChild variant="outline">
           <Link to="/manager/users">Back to users</Link>
         </Button>

--- a/src/routes/_authenticated/manager.waiver-template.test.tsx
+++ b/src/routes/_authenticated/manager.waiver-template.test.tsx
@@ -1,0 +1,76 @@
+// The editor writes a new live version out of whatever is in its fields, so an
+// editor rendered over a failed load is dangerous rather than merely
+// unhelpful: the body would be empty, and saving would publish that as the
+// document people sign.
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const listWaiverTemplates = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => opts,
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+  useNavigate: () => vi.fn(),
+}));
+vi.mock("@tanstack/react-start", () => ({ useServerFn: (fn: unknown) => fn }));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() } }));
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children: string }) => <>{children}</>,
+}));
+vi.mock("@/lib/waiver.functions", () => ({
+  listWaiverTemplates: (...args: unknown[]) => listWaiverTemplates(...args),
+  saveWaiverTemplate: vi.fn(),
+  setCurrentWaiverTemplate: vi.fn(),
+}));
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "manager-1" }, session: null, loading: false }),
+  useRoles: () => ({ roles: ["manager"], loading: false, isManager: true }),
+}));
+
+const { Route } = await import("./manager.waiver-template");
+const EditorPage = (Route as unknown as { component: () => ReactNode }).component;
+
+const template = {
+  id: "t1",
+  version: 3,
+  title: "Training waiver",
+  body_md: "The live waiver text.",
+  acknowledgements: [],
+  is_current: true,
+  created_at: "2026-08-01T00:00:00.000Z",
+};
+
+describe("manager waiver template editor", () => {
+  it("refuses to open a blank editor over the live waiver when the load fails", async () => {
+    listWaiverTemplates.mockRejectedValue(new Error("Failed to fetch"));
+    render(<EditorPage />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("The waiver template could not be loaded.");
+    expect(alert).toHaveTextContent("saving would publish an empty waiver over it");
+    expect(screen.queryByLabelText(/^title$/i)).not.toBeInTheDocument();
+  });
+
+  it("opens the editor once a retry lands", async () => {
+    listWaiverTemplates
+      .mockRejectedValueOnce(new Error("Failed to fetch"))
+      .mockResolvedValue([template]);
+    render(<EditorPage />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /try again/i }));
+    expect(await screen.findByDisplayValue("The live waiver text.")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  // A non-manager is redirected rather than shown a failure, which is what the
+  // Forbidden branch was always for. Keep it out of the new panel.
+  it("leaves a Forbidden refusal to the redirect", async () => {
+    listWaiverTemplates.mockRejectedValue(new Error("Forbidden"));
+    render(<EditorPage />);
+
+    await screen.findByRole("heading", { name: /waiver template/i });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/src/routes/_authenticated/manager.waiver-template.tsx
+++ b/src/routes/_authenticated/manager.waiver-template.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import ReactMarkdown from "react-markdown";
@@ -10,6 +10,9 @@ import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import { Trash2 } from "lucide-react";
 import {
   listWaiverTemplates,
@@ -109,6 +112,10 @@ function EditorPage() {
   const [body, setBody] = useState("");
   const [acks, setAcks] = useState<AcknowledgementDef[]>([]);
   const [loading, setLoading] = useState(true);
+  // The editor must never open blank over a live legal document. An empty body
+  // here looks like a template nobody has written yet, and saving from that
+  // state publishes an empty waiver as the thing people sign.
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [promoting, setPromoting] = useState(false);
 
@@ -121,9 +128,12 @@ function EditorPage() {
     setAcks(template.acknowledgements ?? []);
   }
 
-  useEffect(() => {
-    fetchTemplates()
+  // Named so the failure panel's "Try again" repeats exactly what mount does.
+  const loadTemplates = useCallback(() => {
+    setLoading(true);
+    return fetchTemplates()
       .then((rows) => {
+        setLoadError(null);
         setTemplates(rows);
         // Open on the live version when there is one, otherwise the newest
         // draft, so a template seeded outside the editor is never invisible.
@@ -131,14 +141,21 @@ function EditorPage() {
         if (opening) load(opening);
       })
       .catch((e) => {
-        // A non-manager is redirected by the effect below; anything else is
-        // worth saying out loud rather than leaving a blank editor.
+        // A non-manager is redirected by the effect below; anything else stops
+        // the editor rendering at all, rather than leaving a blank body that
+        // saves over the live waiver.
         if (!(e instanceof Error) || !e.message.includes("Forbidden")) {
-          toast.error(e instanceof Error ? e.message : "Could not load waiver versions");
+          const message = describeLoadError(e, "Could not load waiver versions");
+          setLoadError(message);
+          toast.error(message);
         }
       })
       .finally(() => setLoading(false));
   }, [fetchTemplates]);
+
+  useEffect(() => {
+    void loadTemplates();
+  }, [loadTemplates]);
 
   // Editing a version and saving writes a NEW version, so an unsaved edit is
   // lost by switching away from it. Warn rather than discard silently.
@@ -250,11 +267,22 @@ function EditorPage() {
     setBody((b) => `${b}${b.endsWith(" ") || b === "" ? "" : " "}{{${name}}}`);
   }
 
-  if (loading)
+  if (loading) return <Loading className="p-8" />;
+
+  // Deliberately in place of the whole editor, not beside it. Saving writes a
+  // new live version out of whatever is in these fields, so an editor rendered
+  // over a failed load is a loaded gun: the body would be empty and the save
+  // would publish that.
+  if (loadError)
     return (
-      <>
-        <div className="p-8">Loading...</div>
-      </>
+      <section className="mx-auto max-w-2xl px-4 py-10">
+        <LoadFailure
+          what="The waiver template"
+          message={loadError}
+          hint="Nothing has changed, and the version people sign is still live. Do not edit from here until it loads: saving would publish an empty waiver over it."
+          onRetry={() => void loadTemplates()}
+        />
+      </section>
     );
 
   return (

--- a/src/routes/_authenticated/manager.waivers.test.tsx
+++ b/src/routes/_authenticated/manager.waivers.test.tsx
@@ -1,0 +1,63 @@
+// The list pages all had the same shape: catch the load into a toast, then
+// render the ordinary empty state underneath it. Four seconds later a manager
+// is reading "No waivers signed yet." with no way to tell and nothing to
+// press. This pins the fixed shape on one of them.
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const listWaivers = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => opts,
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+  useNavigate: () => vi.fn(),
+}));
+vi.mock("@tanstack/react-start", () => ({ useServerFn: (fn: unknown) => fn }));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock("@/lib/waiver.functions", () => ({
+  listWaivers: (...args: unknown[]) => listWaivers(...args),
+  getWaiverPdfUrl: vi.fn(),
+  setWaiverApproval: vi.fn(),
+}));
+vi.mock("@/lib/google-drive.functions", () => ({
+  getGoogleDriveStatus: () => Promise.resolve({ connected: false, folderId: null }),
+  listMyDriveUploads: () => Promise.resolve([]),
+  uploadWaiverToDrive: vi.fn(),
+}));
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "manager-1" }, session: null, loading: false }),
+  useRoles: () => ({ roles: ["manager"], loading: false, isManager: true }),
+}));
+
+const { Route } = await import("./manager.waivers");
+const WaiversPage = (Route as unknown as { component: () => ReactNode }).component;
+
+describe("manager waivers list", () => {
+  it("keeps a failed load on screen instead of showing the empty state", async () => {
+    listWaivers.mockRejectedValue(new Error("Failed to fetch"));
+    render(<WaiversPage />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("The signed waivers could not be loaded.");
+    expect(alert).toHaveTextContent("This is not the same as nobody having signed one");
+    expect(screen.queryByText(/no waivers signed yet/i)).not.toBeInTheDocument();
+  });
+
+  it("loads the list on a retry", async () => {
+    listWaivers.mockRejectedValueOnce(new Error("Failed to fetch")).mockResolvedValue([]);
+    render(<WaiversPage />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /try again/i }));
+    expect(await screen.findByText(/no waivers signed yet/i)).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("announces the wait politely while it loads", () => {
+    listWaivers.mockReturnValue(new Promise(() => {}));
+    render(<WaiversPage />);
+
+    expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+  });
+});

--- a/src/routes/_authenticated/manager.waivers.tsx
+++ b/src/routes/_authenticated/manager.waivers.tsx
@@ -1,9 +1,12 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Pill } from "@/components/site/StatusPill";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import { waiverClass } from "@/lib/status-colours";
 import { formatDateTime } from "@/lib/dates";
 import { listWaivers, getWaiverPdfUrl, setWaiverApproval } from "@/lib/waiver.functions";
@@ -59,6 +62,7 @@ function WaiversPage() {
 
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [approvingId, setApprovingId] = useState<string | null>(null);
   const [driveConnected, setDriveConnected] = useState(false);
   const [driveFolderReady, setDriveFolderReady] = useState(false);
@@ -69,17 +73,27 @@ function WaiversPage() {
     if (!rolesLoading && user && !isManager) navigate({ to: "/account" });
   }, [rolesLoading, isManager, user, navigate]);
 
+  const load = useMemo(
+    () => () => {
+      setLoading(true);
+      return fetchList()
+        .then((data) => {
+          setRows(data as Row[]);
+          setLoadError(null);
+        })
+        .catch((e) => {
+          const message = describeLoadError(e, "Could not load the waivers");
+          setLoadError(message);
+          toast.error(message);
+        })
+        .finally(() => setLoading(false));
+    },
+    [fetchList],
+  );
+
   useEffect(() => {
     if (!isManager) return;
-    fetchList()
-      .then((data) => {
-        setRows(data as Row[]);
-        setLoading(false);
-      })
-      .catch((e) => {
-        toast.error(e.message);
-        setLoading(false);
-      });
+    void load();
     fetchDriveStatus()
       .then((s) => {
         setDriveConnected(s.connected);
@@ -96,7 +110,7 @@ function WaiversPage() {
         setUploads(map);
       })
       .catch(() => {});
-  }, [isManager, fetchList, fetchDriveStatus, fetchDriveUploads]);
+  }, [isManager, load, fetchDriveStatus, fetchDriveUploads]);
 
   async function download(id: string) {
     try {
@@ -185,7 +199,14 @@ function WaiversPage() {
         ) : null}
 
         {loading ? (
-          <p>Loading...</p>
+          <Loading />
+        ) : loadError ? (
+          <LoadFailure
+            what="The signed waivers"
+            message={loadError}
+            hint="This is not the same as nobody having signed one, so nothing here is waiting on you until it loads."
+            onRetry={() => void load()}
+          />
         ) : rows.length === 0 ? (
           <p className="text-sm text-muted-foreground">No waivers signed yet.</p>
         ) : (

--- a/src/routes/_authenticated/membership.tsx
+++ b/src/routes/_authenticated/membership.tsx
@@ -4,6 +4,9 @@ import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
+import { describeLoadError } from "@/lib/load-error";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -237,6 +240,7 @@ function MembershipPage() {
     unreadable: boolean;
   }>({ details: null, unreadable: false });
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [studentNumber, setStudentNumber] = useState("");
   const [sessionDate, setSessionDate] = useState(() => new Date().toISOString().slice(0, 10));
   // The insurance checkbox is not raw state: it starts from the rules in
@@ -299,11 +303,26 @@ function MembershipPage() {
     [fetchPlans, fetchMine, fetchInstructions],
   );
 
+  // `reload()` on its own runs after choosing a plan, where that handler
+  // reports its own failure; this is the one the page loads through.
+  const load = useMemo(
+    () => () => {
+      setLoading(true);
+      return reload()
+        .then(() => setLoadError(null))
+        .catch((e) => {
+          const message = describeLoadError(e, "Could not load your membership");
+          setLoadError(message);
+          toast.error(message);
+        })
+        .finally(() => setLoading(false));
+    },
+    [reload],
+  );
+
   useEffect(() => {
-    reload()
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load memberships"))
-      .finally(() => setLoading(false));
-  }, [reload]);
+    void load();
+  }, [load]);
 
   // Runs after the panel has rendered, so the ref is attached by the time we
   // reach for it. A member who ends up with nothing to pay just clears the flag.
@@ -351,13 +370,27 @@ function MembershipPage() {
     }
   }
 
-  if (loading) {
+  if (loading) return <Loading className="p-8" />;
+
+  // In place of the page, not beside it. With nothing loaded the status card
+  // falls back to "lead" and greets a paid-up member as somebody new, and the
+  // plan list would be empty, which reads as a club with nothing to sell.
+  if (loadError)
     return (
-      <>
-        <div className="p-8">Loading...</div>
-      </>
+      <section className="mx-auto max-w-2xl px-4 py-12">
+        <h1 className="text-3xl font-black">Membership</h1>
+        <LoadFailure
+          className="mt-6"
+          what="Your membership"
+          message={loadError}
+          hint="Nothing has changed, and anything you have already paid for is still yours."
+          onRetry={() => void load()}
+        />
+        <Button asChild variant="outline" className="mt-4">
+          <Link to="/account">Back to account</Link>
+        </Button>
+      </section>
     );
-  }
 
   const lifecycle = mine?.lifecycle ?? "lead";
   const status = lifecycleCopy(lifecycle, mine?.memberships ?? []);

--- a/src/routes/_authenticated/notifications.tsx
+++ b/src/routes/_authenticated/notifications.tsx
@@ -7,6 +7,7 @@ import { AlertTriangle, Bell } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { NotificationSwitches } from "@/components/site/NotificationSwitches";
+import { Loading } from "@/components/site/Loading";
 import { useNotifications } from "@/hooks/useNotifications";
 import type { EmailPreferenceKey } from "@/lib/notifications";
 import {
@@ -163,7 +164,7 @@ function NotificationsPage() {
           )}
         </CardHeader>
         <CardContent>
-          {loading && <p className="text-sm text-muted-foreground">Loading...</p>}
+          {loading && <Loading />}
           {data && data.items.length === 0 && (
             <p className="text-sm text-muted-foreground">
               Nothing yet. Replies to your comments will show up here.
@@ -211,8 +212,15 @@ function NotificationsPage() {
               disabled={savingPrefs}
               isManager={data?.isManager}
             />
+          ) : failed ? (
+            // Without this the switches sat on "Loading..." for good after a
+            // failed read, which reads as a page still working rather than one
+            // that has already given up. The retry is in the panel above.
+            <p className="text-sm text-muted-foreground" role="status">
+              Your email choices could not be loaded, so they are not shown. Nothing has changed.
+            </p>
           ) : (
-            <p className="text-sm text-muted-foreground">Loading...</p>
+            <Loading />
           )}
         </CardContent>
       </Card>

--- a/src/routes/calendar.tsx
+++ b/src/routes/calendar.tsx
@@ -4,6 +4,7 @@ import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { CalendarPlus, Clock, MapPin, User } from "lucide-react";
 import { SiteLayout } from "@/components/site/SiteLayout";
+import { Loading } from "@/components/site/Loading";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { getCalendar, getMyCalendarFeedUrl, getMyRsvps, setRsvp } from "@/lib/calendar.functions";
@@ -211,7 +212,7 @@ function CalendarPage() {
 
       <section className="mx-auto max-w-4xl px-4 pb-20">
         {loading ? (
-          <p className="text-muted-foreground">Loading...</p>
+          <Loading />
         ) : groups.length === 0 ? (
           <p className="text-muted-foreground">Nothing scheduled right now. Check back soon.</p>
         ) : (

--- a/src/routes/code-of-conduct.tsx
+++ b/src/routes/code-of-conduct.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { CheckCircle2 } from "lucide-react";
 import { SiteLayout } from "@/components/site/SiteLayout";
+import { Loading } from "@/components/site/Loading";
 import { CodeOfConductDocument } from "@/components/site/CodeOfConductDocument";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -128,7 +129,7 @@ function CodeOfConduct() {
 
         <div className="mt-8">
           {signerQ.isPending ? (
-            <p className="text-sm text-muted-foreground">Loading...</p>
+            <Loading />
           ) : justSigned ? (
             <SignedPanel
               name={signer?.name ?? ""}

--- a/src/routes/email-settings/$token.tsx
+++ b/src/routes/email-settings/$token.tsx
@@ -24,6 +24,7 @@ import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 
 import { SiteLayout } from "@/components/site/SiteLayout";
+import { Loading } from "@/components/site/Loading";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { NotificationSwitches } from "@/components/site/NotificationSwitches";
@@ -104,7 +105,7 @@ function EmailSettingsPage() {
           </p>
         </div>
 
-        {state === "loading" && <p className="text-sm text-muted-foreground">Loading...</p>}
+        {state === "loading" && <Loading />}
 
         {state === "unavailable" && (
           <Card>

--- a/src/routes/kb/$slug.tsx
+++ b/src/routes/kb/$slug.tsx
@@ -16,11 +16,20 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { ArrowLeft, ArrowRight, Check, ChevronRight, ExternalLink, List } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  ChevronRight,
+  ExternalLink,
+  List,
+  RefreshCw,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { KbArticleReader } from "@/components/site/KbArticleReader";
+import { Loading } from "@/components/site/Loading";
 import type { NewAnnotation } from "@/components/site/KbArticleReader";
 import { useKbNav } from "@/hooks/useKbNav";
 import {
@@ -179,7 +188,7 @@ function ArticlePage() {
   }
 
   if (authLoading || articleQ.isPending || redirectTo) {
-    return <p className="text-muted-foreground">Loading...</p>;
+    return <Loading />;
   }
 
   if (articleQ.isError || !article || !viewer) {
@@ -192,6 +201,14 @@ function ArticlePage() {
             : "That article does not exist, or is not available to you."}
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
+          {/* A rejected fetch and an article that is not yours look the same
+              from here, so offer the retry that only helps the first: a reader
+              whose connection dropped otherwise has nothing to press. */}
+          {articleQ.isError && (
+            <Button variant="outline" onClick={() => void articleQ.refetch()}>
+              <RefreshCw className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" /> Try again
+            </Button>
+          )}
           <Button asChild variant="outline">
             <Link to="/kb">Back to the knowledge base</Link>
           </Button>

--- a/src/routes/kb/index.test.tsx
+++ b/src/routes/kb/index.test.tsx
@@ -1,0 +1,50 @@
+// A member whose nav fetch fails used to be told the club has written nothing
+// for them to read. That is a claim about the club, and it is the one message
+// most likely to stop somebody coming back to the page.
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const mockUseKbNav = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => opts,
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+}));
+vi.mock("@/hooks/useKbNav", () => ({ useKbNav: () => mockUseKbNav() }));
+
+const { Route } = await import("./index");
+const KnowledgeBaseIndex = (Route as unknown as { component: () => ReactNode }).component;
+
+describe("/kb index", () => {
+  afterEach(() => mockUseKbNav.mockReset());
+
+  it("keeps a failed load on screen with a retry, instead of the empty state", async () => {
+    const refetch = vi.fn();
+    mockUseKbNav.mockReturnValue({ nav: [], loading: false, error: "Failed to fetch", refetch });
+    render(<KnowledgeBaseIndex />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("The knowledge base could not be loaded.");
+    expect(screen.queryByText(/nothing here for you to read yet/i)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it("still says the knowledge base is empty when it genuinely is", () => {
+    mockUseKbNav.mockReturnValue({ nav: [], loading: false, error: null, refetch: vi.fn() });
+    render(<KnowledgeBaseIndex />);
+
+    expect(screen.getByText(/nothing here for you to read yet/i)).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("announces the wait rather than rendering bare text", () => {
+    mockUseKbNav.mockReturnValue({ nav: [], loading: true, error: null, refetch: vi.fn() });
+    render(<KnowledgeBaseIndex />);
+
+    expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+  });
+});

--- a/src/routes/kb/index.tsx
+++ b/src/routes/kb/index.tsx
@@ -7,6 +7,8 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowRight, Check, ExternalLink, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { LoadFailure } from "@/components/site/LoadFailure";
+import { Loading } from "@/components/site/Loading";
 import { useKbNav } from "@/hooks/useKbNav";
 import { flattenKbNav, kbProgress, readState } from "@/lib/kb-nav";
 
@@ -18,7 +20,7 @@ export const Route = createFileRoute("/kb/")({
 });
 
 function KnowledgeBaseIndex() {
-  const { nav, loading } = useKbNav();
+  const { nav, loading, error, refetch } = useKbNav();
   const progress = kbProgress(nav);
   const started = progress.read > 0 || progress.updated > 0;
   // Where to send them: the next thing they have not read, or the very first
@@ -104,9 +106,22 @@ function KnowledgeBaseIndex() {
         </div>
       )}
 
-      {loading && <p className="mt-10 text-sm text-muted-foreground">Loading...</p>}
+      {loading && <Loading className="mt-10" />}
 
-      {!loading && !nav.length && (
+      {/* Before the empty state, and instead of it. "There is nothing here for
+          you to read yet" is a claim about the club, and a member who is told
+          it because a fetch failed has no reason to ever come back. */}
+      {!loading && error && (
+        <LoadFailure
+          className="mt-10"
+          what="The knowledge base"
+          message={error}
+          hint="It is still there. This is a problem reaching it, not an empty knowledge base."
+          onRetry={refetch}
+        />
+      )}
+
+      {!loading && !error && !nav.length && (
         <p className="mt-10 text-sm text-muted-foreground">
           There is nothing here for you to read yet. If you think there should be, tell a coach.
         </p>


### PR DESCRIPTION
Closes #54. Also addresses items **1** and **3** of #33 (it does not close #33: item 2, the confirmation dialogs, is owned by #53 and is deliberately untouched here).

## What the user will feel

**Managers.** When something fails to load, the screen now says so and stays saying so, with a "Try again" button under it. Before, a toast appeared for four seconds and then the page underneath told you there were no members, no waivers, no comments, nothing to reconcile. The three that mattered most:

- **Reconciliation** told you "Everything imported has been matched." when the transactions had not arrived at all. On a money screen that is an all-clear it cannot back up.
- **The waiver template editor** opened blank over the live document. Saving from there would have published an empty waiver as the thing people sign. It now refuses to render the editor at all until the template loads, and says why.
- **Membership plans** and **the blog post editor** did the same in a smaller way: an empty list invites you to add a plan or write a post that already exists, and the post editor rendered a completely blank page. Both now hold the failure instead.

**Members.** `/kb` used to sit on "Loading..." forever if the contents failed to fetch, with no error and no exit. It now shows the failure and a retry, in the sidebar and on the index page. On `/account`, three cards used to state something untrue after a failed read: "No waivers on file yet." (sending someone to re-sign a waiver they already signed), the code-of-conduct prompt (asking again for an agreement already given), and the Drive card (offering to connect an account already linked). `/membership` greeted a paid-up member as "New here" when nothing had loaded; it now says the load failed rather than guessing.

**Screen-reader users, everywhere.** Every bare `Loading...` on the site now announces itself (`role="status"` / `aria-live="polite"`), the same way `AuthPending` and `SubmitStatus` already did. Before, the text simply appeared and vanished with nothing said.

Nothing is slower, nothing new is asked for, and no email or write behaviour changes.

## How it is built

Three commits, grouped so review stays tractable.

1. **Preparatory refactor, no behaviour change.** `manager.contact-messages.tsx` was the only screen doing this right, so the pattern is lifted out of it into `components/site/LoadFailure` (the panel, the "this is not the same as having none" line, `role="alert"`, the retry), `components/site/Loading` (the live-region loading line) and `lib/load-error.ts`'s `describeLoadError`, which falls back to a real sentence when the thrown Error carries an empty message. Contact messages then renders through all three, unchanged on screen.
2. **The three misleading screens** from the issue: reconciliation, the waiver template editor, and `useKbNav` / `/kb`. `useKbNav` only ever reported `query.isLoading`, which is **false** once a query has rejected, which is why the page loaded forever; it now returns `error` and `refetch`.
3. **The rollout** across the rest: users, memberships, waivers, blog posts, blog comments, api tokens, calendar (and one event's replies), check-in, knowledge base admin, membership plans, blog editor, member detail, `/membership`, `/notifications`, and the three `/account` cards.

Where an empty screen invites a destructive action, the panel replaces the **whole** screen rather than sitting beside it, and the copy says why not to work around it. Where it is merely ambiguous, it replaces the list.

## Verified

`bun run deps`, then `bun run lint`, `bun run typecheck`, `bun run test` (2050 passing, 116 files) and `bun run build`, all green. `bun.lock` is untouched.

New tests: `LoadFailure`, `Loading`, `describeLoadError`, `useKbNav`'s error, the KB sidebar and `/kb` index, reconciliation's all-clear, the waiver-template blank-editor guard (including its `Forbidden` carve-out), the waivers list, and the `/account` waivers card.

## Decisions a reviewer may want to correct

- **The wording of each "this is not the same as..." line** is written per screen, since what the empty state would have claimed differs every time. They are all one sentence and all in the failure panel. Change any of them freely.
- **Three public pages** (`/calendar`, `/code-of-conduct`, `/email-settings/<token>`) got the `Loading` component too. #33 item 3 does not restrict itself to manager pages and it is markup only, but it is outside #54's stated scope, so it is called out here. No load-error work was done on public pages.
- **`manager.settings.tsx` keeps its own bespoke failure card** rather than moving to `LoadFailure`. It already says more than the generic panel does (and links back to memberships), so only its loading line changed.
- **`manager.waivers_.upload.tsx` was left alone.** Its only load pre-fills a template version, and a blank field there is something the manager just types; there is no empty state making a false claim.
- **Retries refetch, they do not reset any other state.** On check-in the class list and the roster retry independently, because a failed roster and a failed class list are different problems.

## Note on the mock-reset trap

Two of the new route tests initially failed with an unhandled rejection that turned out to be `mockReset()` / `mockClear()` in a `beforeEach` on a mock whose rejected promise Vitest was still tracking. Those tests set their implementation per test instead, with a comment saying why, so nobody re-adds the reset.

---
_Generated by [Claude Code](https://claude.ai/code/session_018LiAvZDwQ89v5WNQUHVRcR)_