### PR TITLE
Declare the four font weights the site was built against

### DIFF
--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -31,6 +31,16 @@ Both are **variable** fonts with a `wght` axis running 200 to 1000, so one file
 per subset covers every weight the site uses. Google's own CSS gives the game
 away here: it returns the same URL for 400, 600, 700 and 900.
 
+Each subset is declared **four times**, once per weight, rather than once with
+`font-weight: 200 1000`. That looks like duplication and is not. Google served
+those four weights and no others, so `font-weight: 500` has always matched the
+400 face, CSS picking the nearest declared weight. Declare the axis as a range
+and the browser renders a real 500 instead, which is heavier, and `font-medium`
+is used on hundreds of elements around the site. The public pages come out
+pixel-identical to the Google-hosted build with four declarations and visibly
+different with a range, so the four stay until somebody decides, on purpose,
+that the site wants more weights. `src/lib/fonts.test.ts` pins this.
+
 The `@font-face` rules are at the top of `src/styles.css`, with the
 `unicode-range` for each subset. The ranges matter: the browser fetches
 `latin-ext` only for a page that actually contains an accented character, which
@@ -70,7 +80,8 @@ otherwise, so this is not routine maintenance.
    `@font-face` rules in `src/styles.css`. They change between font versions,
    and a stale range means a character silently renders in the fallback font.
 
-5. Check the weight axis still covers what the site asks for:
+5. Check the weight axis still covers the four weights declared above (a
+   narrower axis would silently snap them together):
 
    ```
    python3 -c "from fontTools.ttLib import TTFont; f=TTFont('public/fonts/nunito-sans-latin.woff2'); print([(a.axisTag, a.minValue, a.maxValue) for a in f['fvar'].axes])"

--- a/src/lib/fonts.test.ts
+++ b/src/lib/fonts.test.ts
@@ -59,10 +59,22 @@ describe("the typeface is self-hosted", () => {
     // design change wearing the clothes of a hosting change.
     const css = readFileSync(join(root, "src/styles.css"), "utf8");
     const faces = [...css.matchAll(/@font-face\s*\{([^}]*)\}/g)].map((m) => m[1]);
-    const weights = faces.map((face) => face.match(/font-weight:\s*([^;]+);/)?.[1].trim());
 
-    expect(faces.length).toBeGreaterThan(0);
-    expect(new Set(weights)).toEqual(new Set(["400", "600", "700", "900"]));
+    // Per subset, not across all of them: dropping 900 from latin while
+    // latin-ext still declares it would leave the overall set looking right,
+    // and headings would quietly render at 700 for anyone reading English.
+    const byFile: Record<string, string[]> = {};
+    for (const face of faces) {
+      const src = face.match(/url\("([^"]+)"\)/)?.[1];
+      const weight = face.match(/font-weight:\s*([^;]+);/)?.[1].trim();
+      expect(src, "a @font-face with no src").toBeTruthy();
+      (byFile[src!] ??= []).push(weight!);
+    }
+
+    expect(Object.keys(byFile).length).toBeGreaterThan(0);
+    for (const [file, weights] of Object.entries(byFile)) {
+      expect(weights.slice().sort(), file).toEqual(["400", "600", "700", "900"]);
+    }
   });
 
   it("keeps a real fallback stack, so a failed fetch is not invisible text", () => {

--- a/src/lib/fonts.test.ts
+++ b/src/lib/fonts.test.ts
@@ -51,6 +51,20 @@ describe("the typeface is self-hosted", () => {
     }
   });
 
+  it("declares the four weights Google served, not the file's whole axis", () => {
+    // The files are variable and would happily render a 500. Google's
+    // stylesheet declared 400/600/700/900 only, so `font-weight: 500` has
+    // always matched the 400 face, and `font-medium` is used on hundreds of
+    // elements. Widening these to a range re-weights all of them, which is a
+    // design change wearing the clothes of a hosting change.
+    const css = readFileSync(join(root, "src/styles.css"), "utf8");
+    const faces = [...css.matchAll(/@font-face\s*\{([^}]*)\}/g)].map((m) => m[1]);
+    const weights = faces.map((face) => face.match(/font-weight:\s*([^;]+);/)?.[1].trim());
+
+    expect(faces.length).toBeGreaterThan(0);
+    expect(new Set(weights)).toEqual(new Set(["400", "600", "700", "900"]));
+  });
+
   it("keeps a real fallback stack, so a failed fetch is not invisible text", () => {
     const css = readFileSync(join(root, "src/styles.css"), "utf8");
     for (const token of ["--font-sans:", "--font-display:"]) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -15,8 +15,17 @@
  *
  * One variable file per subset covers every weight the site uses (Google's own
  * CSS returns the same URL for 400, 600, 700 and 900, which is the giveaway).
- * The `wght` axis runs 200-1000; declaring the real range lets the browser
- * render any weight from the one file rather than snapping to four.
+ *
+ * The four weights are declared separately, rather than as one face spanning
+ * the whole `wght` axis, because the axis is not what the site was built
+ * against. Google served exactly these four, so `font-weight: 500` has always
+ * matched the 400 face: CSS picks the nearest declared weight, and there was
+ * no 500 to pick. Declaring a range instead gives it a real 500, which is
+ * heavier, and `font-medium` is used on hundreds of elements across the site
+ * (28 on /pricing alone). Screenshots of the public pages are pixel-identical
+ * to the Google-hosted build with these four declarations, and differ with a
+ * range. Adding a weight is a design decision, not a side effect of where the
+ * file is hosted, so it belongs in a change that intends it.
  *
  * `font-display: swap` keeps text readable while the file loads, and the
  * fallback stack below it is a real one, so a failed fetch degrades to the
@@ -29,7 +38,40 @@
 @font-face {
   font-family: "Nunito Sans";
   font-style: normal;
-  font-weight: 200 1000;
+  font-weight: 400;
+  font-display: swap;
+  src: url("/fonts/nunito-sans-latin.woff2") format("woff2");
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "Nunito Sans";
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url("/fonts/nunito-sans-latin.woff2") format("woff2");
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "Nunito Sans";
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url("/fonts/nunito-sans-latin.woff2") format("woff2");
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "Nunito Sans";
+  font-style: normal;
+  font-weight: 900;
   font-display: swap;
   src: url("/fonts/nunito-sans-latin.woff2") format("woff2");
   unicode-range:
@@ -45,7 +87,43 @@
 @font-face {
   font-family: "Nunito Sans";
   font-style: normal;
-  font-weight: 200 1000;
+  font-weight: 400;
+  font-display: swap;
+  src: url("/fonts/nunito-sans-latin-ext.woff2") format("woff2");
+  unicode-range:
+    U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329,
+    U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
+    U+A720-A7FF;
+}
+
+@font-face {
+  font-family: "Nunito Sans";
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url("/fonts/nunito-sans-latin-ext.woff2") format("woff2");
+  unicode-range:
+    U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329,
+    U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
+    U+A720-A7FF;
+}
+
+@font-face {
+  font-family: "Nunito Sans";
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url("/fonts/nunito-sans-latin-ext.woff2") format("woff2");
+  unicode-range:
+    U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329,
+    U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
+    U+A720-A7FF;
+}
+
+@font-face {
+  font-family: "Nunito Sans";
+  font-style: normal;
+  font-weight: 900;
   font-display: swap;
   src: url("/fonts/nunito-sans-latin-ext.woff2") format("woff2");
   unicode-range:


### PR DESCRIPTION
Follow-up to #92 (which closed #59). That change was right to make and the privacy problem is fixed. This corrects one side effect it carried with it.

## What the user will feel

Text on every page goes back to the weight it was before the font moved, which for most people means going back to what they were looking at last week. The difference is small but it is not nothing: it is on the promo banner, the nav, form labels, card subheadings, everything using `font-medium`. Nothing else changes. No copy, no new step, no email, no layout shift, and the fonts still come from this origin, so no visitor's browser contacts Google.

## What went wrong

Google served four discrete weights: 400, 600, 700 and 900. CSS picks the *nearest declared* weight, so `font-weight: 500` has always matched the 400 face, because there was no 500 to pick.

The self-hosted files are variable fonts carrying the whole 200–1000 axis. #92 declared that axis as a range (`font-weight: 200 1000`), which gives the browser a real 500 to render instead. `font-medium` is used on hundreds of elements: 38 on the home page, 29 on `/about`, 28 on `/pricing`.

The comment in `styles.css` says this was intentional ("lets the browser render any weight from the one file rather than snapping to four"). More weights may well be an improvement. This is not the change to decide that in, and whoever decides it should be able to see it happen.

## Before / after

Three builds of identical page content, differing only in how the font is loaded, screenshotted across `/`, `/about`, `/pricing`, `/classes` and `/contact` at 1280 and 390 wide:

| Comparison | Result |
| --- | --- |
| reference (font from Google, as before #59) vs **this PR** | **0 differing pixels**, all 10 screenshots byte-identical |
| reference vs **main today** | **83,036 differing pixels**, all 10 screenshots differ |

The reference build is current `main` with `src/styles.css` and `src/routes/__root.tsx` reverted to their pre-#92 state, served Google's exact bytes locally so the sandbox could reach them. Same page content in all three, so the only variable is the font declaration.

Per-screenshot, reference vs `main` today:

```
desktop-home      16,334 px      mobile-home      6,547 px
desktop-contact   15,557 px      mobile-contact   6,324 px
desktop-classes   11,898 px      mobile-about     2,814 px
desktop-pricing    9,744 px      mobile-classes   2,814 px
desktop-about      8,190 px      mobile-pricing   2,814 px
```

Against this PR, every one of those is 0.

The clearest place to see it by eye is the `/pricing` promo banner ("Your first 2 classes are free"), which is weight 500: on `main` today the line is visibly heavier and sits differently within the band than it does on the deployed site. The e2e gallery on this PR shows it against the one on #92.

## The diff

`src/styles.css`: each subset is declared four times, once per weight, instead of once with a range. It looks like duplication and is not, which is why the comment above it and `docs/fonts.md` both say so.

`src/lib/fonts.test.ts` gains a case that fails if the declarations widen back to a range. It would have failed on `main` before this change.

## Not changed here

Two things I measured while checking this, both worth a decision rather than a quiet edit:

- **The preload costs first paint on a slow connection.** Over a throttled 1.5 Mbps / 40 ms link, preloading the latin file takes bandwidth from the render-blocking stylesheet and moves first contentful paint from 2.39s to 2.54s. Dropping it puts the font ~340ms behind the text instead, which is what `font-display: swap` is for. Happy to follow up if you want it either way.
- **Vietnamese is not carried.** Google served a `vietnamese` subset (10KB) that #92 left out along with Cyrillic. A Vietnamese name currently falls back per character. Adding it is one file and one `@font-face`.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (2310 passing, 133 files) and `bun run build` all pass. `bun.lock` untouched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeEZiqbq1kDKKjUPuzfSr4