### PR TITLE
Let a member replace their calendar link

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -143,10 +143,12 @@ top-up, so a repeat offers "Stop repeating" instead. Cancel keeps the record.
 3. **Get a calendar link** — a private URL (`/api/calendar/<token>`) to add to a
    phone or laptop calendar. New dates, changes and cancellations then sync on
    their own. It includes members-only entries only while that person is a paid
-   member. It is minted on the first visit to `/calendar` and shown in full on
-   both `/calendar` and `/account` every visit after that: one link per person,
-   with nothing to press to get it. Losing the link is not a failure state,
-   since it is always on the page.
+   member. It is minted the first time they open `/calendar` or `/account`,
+   whichever comes first, and shown in full on both every visit after that: one
+   link per person, with nothing to press to get it. Losing the link is not a
+   failure state, since it is always on the page. That does mean every signed-in
+   person ends up with one, managers and people who will never subscribe
+   included, which is the price of it always being there when they ask.
 4. **Replace the calendar link** — "Replace link", on the same panel in both
    places. It exists because the token can never leave the URL path (a calendar
    app subscribes to an address and has nowhere else to put a credential), so

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -173,9 +173,13 @@ top-up, so a repeat offers "Stop repeating" instead. Cancel keeps the record.
    links, so a subscriber can never silently miss a members-only entry. A link
    is a secret, but a durable one: like any calendar app's private ICS address
    it is stored and shown to its owner whenever they ask, not shown once and
-   then unrecoverable. It lasts until **its owner replaces it**, and nothing
-   else ever retires one. Replacing mints a new link and revokes the old row
-   rather than deleting it, so the old address can say what happened. Because the
+   then unrecoverable. It lasts until it is **replaced**, which happens for
+   exactly two reasons: its owner asked, or it is one of the pre-`20260728180000`
+   links the server only ever stored the hash of, which it cannot show and so
+   swaps for a fresh one the first time its owner opens the page. Nothing else
+   retires a link, and nothing expires one on age. Both paths revoke the old row
+   rather than deleting it, and mint a new one alongside, so the old address can
+   say what happened instead of reading as a typo. Because the
    secret is in the URL, the feed is served with `Referrer-Policy: no-referrer`
    (see "Security headers" in `CLAUDE.md`). It keeps its own
    `Cache-Control: private, max-age=300`, which is what a polling calendar client
@@ -208,4 +212,5 @@ top-up, so a repeat offers "Stop repeating" instead. Cancel keeps the record.
   "you changed your password so your calendar stopped". The only thing a member
   notices when a calendar link quietly stops working is that they stopped
   hearing about training, which is a worse outcome than the risk it would
-  reduce. A link ends because somebody asked it to.
+  reduce. A link ends because somebody asked it to, bar the one legacy case in
+  rule 4.

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -14,7 +14,8 @@ settings, including members-only and invite-only. A **manager** owns the calenda
 they add entries, edit them, cancel a single date or a whole run, and choose **who
 can see** each one. The public `/calendar` page shows the schedule, and **anyone
 signed in can RSVP** going / maybe / can't make it. Each signed-in person can also
-get a **private calendar link** so it stays in sync in their own calendar app.
+get a **private calendar link** so it stays in sync in their own calendar app,
+and replace that link if it ends up somewhere it should not be.
 
 ### Fields
 
@@ -61,7 +62,7 @@ date actually has, so an entry with no location keeps having none.
   `has_role(..., 'manager')`; the client is never trusted. Managers can see who
   has responded to each date.
 - **Signed-in person** (any account, trial visitors included): sees the public
-  schedule, **can RSVP**, and can get a private calendar link.
+  schedule, **can RSVP**, and can get a private calendar link, and replace it.
 - **Paid member** (an active, non-trial, paid-for membership): everything above,
   **plus members-only entries**, on the site and in their calendar link.
 - **Public** (not signed in): sees the public schedule only. No members-only
@@ -142,10 +143,23 @@ top-up, so a repeat offers "Stop repeating" instead. Cancel keeps the record.
 3. **Get a calendar link** — a private URL (`/api/calendar/<token>`) to add to a
    phone or laptop calendar. New dates, changes and cancellations then sync on
    their own. It includes members-only entries only while that person is a paid
-   member. It is minted on the first visit to `/calendar` and shown there every
-   visit after that: one permanent link per person, with nothing to press and no
-   replace or turn-off buttons. Losing the link is not a failure state, since it
-   is always on the page.
+   member. It is minted on the first visit to `/calendar` and shown in full on
+   both `/calendar` and `/account` every visit after that: one link per person,
+   with nothing to press to get it. Losing the link is not a failure state,
+   since it is always on the page.
+4. **Replace the calendar link** — "Replace link", on the same panel in both
+   places. It exists because the token can never leave the URL path (a calendar
+   app subscribes to an address and has nowhere else to put a credential), so
+   minting a new one is the only way a link that ended up somewhere public is
+   ever made harmless.
+
+   It **breaks their existing subscription on purpose**, so it asks first, in an
+   `AlertDialog` that says the current link stops working straight away and that
+   every calendar app holding it stops updating until the new one goes in. The
+   new link then replaces the old one on the same panel, still on screen, with
+   the copy button and a line saying the old one has stopped. Anyone who opens
+   the retired address gets **410 Gone** and a sentence telling them it was
+   replaced and where the new one is, rather than a 404 that reads like a typo.
 
 ## Rules
 
@@ -155,10 +169,13 @@ top-up, so a repeat offers "Stop repeating" instead. Cancel keeps the record.
 2. **Cancel, don't delete.** Cancelling keeps the row so subscribers and RSVPs
    survive. Deletion is for mistakes only.
 3. **One RSVP per person per date**, owned by that person.
-4. **No public calendar feed.** Only per-person links, so a subscriber can never
-   silently miss a members-only entry. A link is a secret, but a durable one:
-   like any calendar app's private ICS address it is stored and shown to its
-   owner whenever they ask, not shown once and then unrecoverable. Because the
+4. **No public calendar feed, and one live link per person.** Only per-person
+   links, so a subscriber can never silently miss a members-only entry. A link
+   is a secret, but a durable one: like any calendar app's private ICS address
+   it is stored and shown to its owner whenever they ask, not shown once and
+   then unrecoverable. It lasts until **its owner replaces it**, and nothing
+   else ever retires one. Replacing mints a new link and revokes the old row
+   rather than deleting it, so the old address can say what happened. Because the
    secret is in the URL, the feed is served with `Referrer-Policy: no-referrer`
    (see "Security headers" in `CLAUDE.md`). It keeps its own
    `Cache-Control: private, max-age=300`, which is what a polling calendar client
@@ -179,3 +196,16 @@ top-up, so a repeat offers "Stop repeating" instead. Cancel keeps the record.
 - **Moving a repeat's day or time.** Dates already on the calendar would become
   wrong, and people may have already replied to them. Stop the repeat and add a
   new one.
+- **A manager replacing somebody else's calendar link.** Replacing one stops
+  that person's calendar updating with no warning, and they are the one who has
+  to re-subscribe, so the club asks them to do it rather than doing it to them.
+  The case this was weighed against, a member reporting that they pasted their
+  link somewhere public, is answered by the member pressing the button
+  themselves. If a manager ever genuinely needs to force it (an account the
+  person can no longer sign in to), that is a deliberate feature to add, with
+  the email that has to go with it.
+- **Anything that expires or invalidates a link on its own.** No age limit, no
+  "you changed your password so your calendar stopped". The only thing a member
+  notices when a calendar link quietly stops working is that they stopped
+  hearing about training, which is a worse outcome than the risk it would
+  reduce. A link ends because somebody asked it to.

--- a/docs/database.md
+++ b/docs/database.md
@@ -753,17 +753,30 @@ can't send an auth header. There is **no public/anon feed** — a personal feed
 carries members-only events only while that person is a paid member, so a
 subscriber never silently misses one.
 
-`token` exists because `/calendar` shows the member their link on every visit
-rather than once at creation (`20260728180000`), and a hash cannot be reversed.
-The hash column stays and is still what the feed route looks up. Rows minted
-before that migration have `token IS NULL`; the server re-mints those in place
-the next time their owner opens the page, which retires the old URL.
+`token` exists because `/calendar` and `/account` show the member their link on
+every visit rather than once at creation (`20260728180000`), and a hash cannot be
+reversed. The hash column stays and is still what the feed route looks up. Rows
+minted before that migration have `token IS NULL`; the server re-mints those in
+place the next time their owner opens the page, which retires the old URL.
 
-**RLS:** a person reads their own token row; minting and feed lookup run through
-the service role; `authenticated` gets SELECT only, so a client cannot clear its
-own `revoked_at`. The owner's row now carries the live token, which is what the
-page shows them anyway. There is no member-facing rotate or revoke: the link is
-permanent, the way a private ICS address is in any calendar app.
+`revoked_at` is what **replacing a link** writes. A member pressing "Replace
+link" retires their live row (`revoked_at = now()`, and `token` set back to
+NULL, since a row that is nobody's live link has no reason to keep the raw
+secret) and inserts a fresh one, which is why the one-live-per-person partial
+index is on `revoked_at IS NULL`. The old row is kept rather than deleted so its
+`token_hash` still resolves: the feed route looks a token up **without** filtering
+on `revoked_at` and answers a revoked one with **410 Gone** and a sentence saying
+it was replaced, instead of the 404 that would read as a typo. That branch is
+`feedTokenVerdict` in `src/lib/calendar-feed-token.ts`. No schema change was
+needed for any of this, and nothing else in the app ever sets `revoked_at`:
+nothing expires a link, and a manager cannot replace somebody else's. See
+`docs/calendar.md`.
+
+**RLS:** a person reads their own token row; minting, replacing and feed lookup
+all run through the service role; `authenticated` gets SELECT only, so a client
+cannot clear its own `revoked_at` and resurrect a link it just replaced. The
+owner's live row carries the raw token, which is what the page shows them
+anyway.
 
 ---
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -756,21 +756,26 @@ subscriber never silently misses one.
 `token` exists because `/calendar` and `/account` show the member their link on
 every visit rather than once at creation (`20260728180000`), and a hash cannot be
 reversed. The hash column stays and is still what the feed route looks up. Rows
-minted before that migration have `token IS NULL`; the server re-mints those in
-place the next time their owner opens the page, which retires the old URL.
+minted before that migration have `token IS NULL`; there is nothing to show, so
+the next time their owner opens the page the server revokes that row and inserts
+a fresh one, retiring the old URL. It used to overwrite the hash in place, which
+retired the address too but left it answering 404 rather than the 410 below.
 
 `revoked_at` is what **replacing a link** writes. A member pressing "Replace
 link" retires their live row (`revoked_at = now()`, and `token` set back to
 NULL, since a row that is nobody's live link has no reason to keep the raw
 secret) and inserts a fresh one, which is why the one-live-per-person partial
-index is on `revoked_at IS NULL`. The old row is kept rather than deleted so its
+index is on `revoked_at IS NULL`. The legacy re-mint above takes the same shape,
+so a revoked row is the only way a link ever ends. The old row is kept rather than deleted so its
 `token_hash` still resolves: the feed route looks a token up **without** filtering
 on `revoked_at` and answers a revoked one with **410 Gone** and a sentence saying
 it was replaced, instead of the 404 that would read as a typo. That branch is
 `feedTokenVerdict` in `src/lib/calendar-feed-token.ts`. No schema change was
-needed for any of this, and nothing else in the app ever sets `revoked_at`:
-nothing expires a link, and a manager cannot replace somebody else's. See
-`docs/calendar.md`.
+needed for any of this. Nothing expires a link on age, and a manager cannot
+replace somebody else's: `replaceMyCalendarFeedUrl` and the legacy re-mint are
+the only two writers of `revoked_at`. Retired rows are never pruned, so they
+accumulate one per replace; that is deliberate, since a cap would have to decide
+how long a retired address may keep explaining itself. See `docs/calendar.md`.
 
 **RLS:** a person reads their own token row; minting, replacing and feed lookup
 all run through the service role; `authenticated` gets SELECT only, so a client

--- a/docs/database.md
+++ b/docs/database.md
@@ -766,16 +766,20 @@ link" retires their live row (`revoked_at = now()`, and `token` set back to
 NULL, since a row that is nobody's live link has no reason to keep the raw
 secret) and inserts a fresh one, which is why the one-live-per-person partial
 index is on `revoked_at IS NULL`. The legacy re-mint above takes the same shape,
-so a revoked row is the only way a link ever ends. The old row is kept rather than deleted so its
-`token_hash` still resolves: the feed route looks a token up **without** filtering
-on `revoked_at` and answers a revoked one with **410 Gone** and a sentence saying
-it was replaced, instead of the 404 that would read as a typo. That branch is
-`feedTokenVerdict` in `src/lib/calendar-feed-token.ts`. No schema change was
-needed for any of this. Nothing expires a link on age, and a manager cannot
-replace somebody else's: `replaceMyCalendarFeedUrl` and the legacy re-mint are
-the only two writers of `revoked_at`. Retired rows are never pruned, so they
-accumulate one per replace; that is deliberate, since a cap would have to decide
-how long a retired address may keep explaining itself. See `docs/calendar.md`.
+so a revoked row is the only way a link ever ends.
+
+The old row is kept rather than deleted so its `token_hash` still resolves: the
+feed route looks a token up **without** filtering on `revoked_at` and answers a
+revoked one with **410 Gone** and a sentence saying it was replaced, instead of
+the 404 that would read as a typo. That branch is `feedTokenVerdict` in
+`src/lib/calendar-feed-token.ts`.
+
+Replacing needed no schema change; the columns and indexes above were already
+here. Nothing expires a link on age, and a manager cannot replace somebody
+else's: `replaceMyCalendarFeedUrl` and the legacy re-mint are the only two
+writers of `revoked_at`. Retired rows are never pruned, so they accumulate one
+per replace; that is deliberate, since a cap would have to decide how long a
+retired address may keep explaining itself. See `docs/calendar.md`.
 
 **RLS:** a person reads their own token row; minting, replacing and feed lookup
 all run through the service role; `authenticated` gets SELECT only, so a client

--- a/docs/database.md
+++ b/docs/database.md
@@ -780,8 +780,12 @@ how long a retired address may keep explaining itself. See `docs/calendar.md`.
 **RLS:** a person reads their own token row; minting, replacing and feed lookup
 all run through the service role; `authenticated` gets SELECT only, so a client
 cannot clear its own `revoked_at` and resurrect a link it just replaced. The
-owner's live row carries the raw token, which is what the page shows them
-anyway.
+original migration also carried owner-scoped INSERT and UPDATE policies, kept as
+defence in depth when the write grants went; `20260822093000` drops them, because
+`revoked_at` is now what makes a leaked link stop working and a policy saying "a
+person may write their own row" would undo exactly that the moment a write grant
+came back. The owner's live row carries the raw token, which is what the page
+shows them anyway.
 
 ---
 

--- a/e2e/member/calendar-link.spec.ts
+++ b/e2e/member/calendar-link.spec.ts
@@ -4,7 +4,8 @@
 // URLs do afterwards: the token lives in the path of a feed that a calendar app
 // fetches with no session at all, so only a real request against the real route
 // can show that the old address has stopped carrying events and the new one has
-// started.
+// started. The route reads no session, only the token in the path, which is why
+// fetching the URL is a complete test of it.
 //
 // It cleans up after itself by construction: the member ends the test holding
 // one live link, the same as they started with.
@@ -56,8 +57,10 @@ test("a member replaces their calendar link and the old one stops working", asyn
   );
 
   await step(page, "the old link has stopped, and the new one works", async () => {
-    // The whole point of the feature. `page.request` carries no session, which
-    // is how a calendar app asks.
+    // The whole point of the feature. `page.request` does send the context's
+    // cookies, so this is not proof that an anonymous caller is refused; it does
+    // not need to be, because the feed route reads no session at all and
+    // resolves everything from the token in the path.
     const retired = await page.request.get(oldUrl);
     expect(retired.status()).toBe(410);
     expect(await retired.text()).toContain("replaced");

--- a/e2e/member/calendar-link.spec.ts
+++ b/e2e/member/calendar-link.spec.ts
@@ -1,0 +1,69 @@
+// A member replaces the private calendar link they subscribe to.
+//
+// This is here rather than in a unit test because the proof is what the two
+// URLs do afterwards: the token lives in the path of a feed that a calendar app
+// fetches with no session at all, so only a real request against the real route
+// can show that the old address has stopped carrying events and the new one has
+// started.
+//
+// It cleans up after itself by construction: the member ends the test holding
+// one live link, the same as they started with.
+
+import { expect, step, test } from "../support/test";
+import { expectPageRendered } from "../support/page";
+
+test("a member replaces their calendar link and the old one stops working", async ({ page }) => {
+  // Lazy, so the same locator reads the new link after it has been replaced.
+  const linkText = page.locator("code", { hasText: "/api/calendar/" }).first();
+
+  const oldUrl = await step(
+    page,
+    "a member finds their calendar link on their account",
+    async () => {
+      await page.goto("/account");
+      await expect(page.getByRole("heading", { name: "Your account", level: 1 })).toBeVisible();
+      await expectPageRendered(page);
+      const url = await linkText.innerText();
+      expect(url).toContain("/api/calendar/");
+
+      // Proves the starting state is real: a working subscription, not just a
+      // string on a page.
+      const before = await page.request.get(url);
+      expect(before.status()).toBe(200);
+      expect(await before.text()).toContain("BEGIN:VCALENDAR");
+      return url;
+    },
+  );
+
+  await step(page, "the confirm says what replacing it will break", async () => {
+    await page.getByRole("button", { name: "Replace link" }).click();
+    // Irreversible, and it stops a subscription they already have, so the
+    // dialog says that in words before the click. This step's photograph is it.
+    await expect(page.getByRole("alertdialog")).toContainText(
+      "Your current link stops working straight away",
+    );
+  });
+
+  const newUrl = await step(
+    page,
+    "the new link is on screen, ready to subscribe with",
+    async () => {
+      await page.getByRole("alertdialog").getByRole("button", { name: "Replace link" }).click();
+      await expect(page.getByText("This is your new link.")).toBeVisible();
+      await expect(linkText).not.toHaveText(oldUrl);
+      return await linkText.innerText();
+    },
+  );
+
+  await step(page, "the old link has stopped, and the new one works", async () => {
+    // The whole point of the feature. `page.request` carries no session, which
+    // is how a calendar app asks.
+    const retired = await page.request.get(oldUrl);
+    expect(retired.status()).toBe(410);
+    expect(await retired.text()).toContain("replaced");
+
+    const fresh = await page.request.get(newUrl);
+    expect(fresh.status()).toBe(200);
+    expect(await fresh.text()).toContain("BEGIN:VCALENDAR");
+  });
+});

--- a/src/components/site/CalendarLinkPanel.test.tsx
+++ b/src/components/site/CalendarLinkPanel.test.tsx
@@ -113,8 +113,27 @@ describe("CalendarLinkPanel", () => {
     expect(screen.getByRole("button", { name: /copy your calendar link/i })).toBeEnabled();
   });
 
-  // A failed replace may or may not have retired the old link, so it stays in
-  // the dialog with the message and the button, never a toast.
+  // The server retires the old link before it mints the new one, so a failure
+  // can still have left the address on screen dead. Handing that back with a
+  // Copy button beside it is the worst outcome available, so the panel asks
+  // what the live link is now instead of assuming nothing happened.
+  it("recovers a replace that failed after the old link was already retired", async () => {
+    replaceMyCalendarFeedUrl.mockRejectedValueOnce(new Error("lost the response"));
+    await renderPanel();
+    getMyCalendarFeedUrl.mockResolvedValue({ url: NEW_URL });
+
+    await userEvent.click(screen.getByRole("button", { name: /replace link/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /replace link/i }));
+
+    // It did land, so this is not an error to make them press through.
+    expect(await screen.findByText(NEW_URL)).toBeInTheDocument();
+    expect(screen.queryByText(OLD_URL)).not.toBeInTheDocument();
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  // A failed replace that really did nothing stays in the dialog with the
+  // message and the button, never a toast.
   it("keeps a failed replace in the dialog with something to press", async () => {
     replaceMyCalendarFeedUrl.mockRejectedValueOnce(new Error("nope"));
     await renderPanel();
@@ -123,7 +142,9 @@ describe("CalendarLinkPanel", () => {
     const dialog = await screen.findByRole("alertdialog");
     await userEvent.click(within(dialog).getByRole("button", { name: /replace link/i }));
 
-    expect(await screen.findByRole("alert")).toHaveTextContent(/didn't go through/i);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /didn't go through, and your link has not changed/i,
+    );
     expect(screen.getByRole("alertdialog")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /try again/i })).toBeEnabled();
   });

--- a/src/components/site/CalendarLinkPanel.test.tsx
+++ b/src/components/site/CalendarLinkPanel.test.tsx
@@ -1,0 +1,130 @@
+// Replacing a calendar link breaks whatever the person has already subscribed,
+// on purpose and immediately, so what is pinned here is the guard rather than
+// the layout: nothing happens on the first click, the warning says what will
+// stop working, and the new link stays on screen afterwards where they can act
+// on it. The failure path is pinned too, because a toast there would fade while
+// someone was still working out which link they now hold.
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMyCalendarFeedUrl = vi.fn();
+const replaceMyCalendarFeedUrl = vi.fn();
+
+vi.mock("@tanstack/react-start", () => ({
+  useServerFn: (fn: unknown) => fn,
+}));
+
+vi.mock("@/lib/calendar.functions", () => ({
+  getMyCalendarFeedUrl: () => getMyCalendarFeedUrl(),
+  replaceMyCalendarFeedUrl: () => replaceMyCalendarFeedUrl(),
+}));
+
+const { CalendarLinkPanel } = await import("./CalendarLinkPanel");
+
+const OLD_URL = "https://jitsu.au/api/calendar/utsj_oldoldoldold";
+const NEW_URL = "https://jitsu.au/api/calendar/utsj_newnewnewnew";
+
+beforeEach(() => {
+  getMyCalendarFeedUrl.mockReset().mockResolvedValue({ url: OLD_URL });
+  replaceMyCalendarFeedUrl.mockReset().mockResolvedValue({ url: NEW_URL });
+});
+
+async function renderPanel() {
+  render(<CalendarLinkPanel />);
+  expect(await screen.findByText(OLD_URL)).toBeInTheDocument();
+}
+
+describe("CalendarLinkPanel", () => {
+  it("shows the link with a way to copy it, and something to press to replace it", async () => {
+    await renderPanel();
+    expect(screen.getByRole("button", { name: /copy your calendar link/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /replace link/i })).toBeEnabled();
+  });
+
+  // A blank panel while the link is fetched tells a screen reader nothing.
+  it("announces that it is loading", () => {
+    getMyCalendarFeedUrl.mockReturnValue(new Promise(() => {}));
+    render(<CalendarLinkPanel />);
+    expect(screen.getByRole("status")).toHaveTextContent(/loading your link/i);
+  });
+
+  // A failed load is not "you have no link". It has to stay on screen with
+  // something to press, and say that nothing has changed.
+  it("keeps a failed load on screen with a retry", async () => {
+    getMyCalendarFeedUrl.mockRejectedValueOnce(new Error("network"));
+    render(<CalendarLinkPanel />);
+
+    // By text, not by role: the loading line is a live region too, and it is
+    // the one already on screen when this starts polling.
+    const failure = await screen.findByText(/couldn't load your calendar link/i);
+    expect(failure).toHaveAttribute("role", "status");
+    await userEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(await screen.findByText(OLD_URL)).toBeInTheDocument();
+  });
+
+  // The guard. One click opens the confirm and nothing else; the link is still
+  // the old one until the second, deliberate press.
+  it("does not replace anything until the confirm is accepted", async () => {
+    await renderPanel();
+    await userEvent.click(screen.getByRole("button", { name: /replace link/i }));
+
+    expect(await screen.findByRole("alertdialog")).toBeInTheDocument();
+    expect(replaceMyCalendarFeedUrl).not.toHaveBeenCalled();
+    expect(screen.getByText(OLD_URL)).toBeInTheDocument();
+  });
+
+  // Said in words, before the click: this breaks the subscription they already
+  // have. That sentence is the reason the dialog exists at all.
+  it("says the current link stops working before anything is pressed", async () => {
+    await renderPanel();
+    await userEvent.click(screen.getByRole("button", { name: /replace link/i }));
+
+    const dialog = await screen.findByRole("alertdialog");
+    expect(dialog).toHaveTextContent(/current link stops working straight away/i);
+    expect(dialog).toHaveTextContent(/stops updating until you put the new link in/i);
+    expect(screen.getByRole("button", { name: /keep my link/i })).toBeEnabled();
+  });
+
+  // Backing out is a click, and it changes nothing.
+  it("leaves the link alone when the confirm is declined", async () => {
+    await renderPanel();
+    await userEvent.click(screen.getByRole("button", { name: /replace link/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /keep my link/i }));
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
+    expect(replaceMyCalendarFeedUrl).not.toHaveBeenCalled();
+    expect(screen.getByText(OLD_URL)).toBeInTheDocument();
+  });
+
+  // The other half of the UX bar: after the break they need the new link in
+  // front of them, still there, with a copy button, and told plainly that the
+  // old one is dead.
+  it("puts the new link on screen and says the old one has stopped", async () => {
+    await renderPanel();
+    await userEvent.click(screen.getByRole("button", { name: /replace link/i }));
+    // Scoped to the dialog: the button that opened it carries the same words.
+    const dialog = await screen.findByRole("alertdialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /replace link/i }));
+
+    expect(await screen.findByText(NEW_URL)).toBeInTheDocument();
+    expect(screen.queryByText(OLD_URL)).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(/old one has stopped working/i);
+    expect(screen.getByRole("button", { name: /copy your calendar link/i })).toBeEnabled();
+  });
+
+  // A failed replace may or may not have retired the old link, so it stays in
+  // the dialog with the message and the button, never a toast.
+  it("keeps a failed replace in the dialog with something to press", async () => {
+    replaceMyCalendarFeedUrl.mockRejectedValueOnce(new Error("nope"));
+    await renderPanel();
+    await userEvent.click(screen.getByRole("button", { name: /replace link/i }));
+    // Scoped to the dialog: the button that opened it carries the same words.
+    const dialog = await screen.findByRole("alertdialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /replace link/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/didn't go through/i);
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeEnabled();
+  });
+});

--- a/src/components/site/CalendarLinkPanel.tsx
+++ b/src/components/site/CalendarLinkPanel.tsx
@@ -28,6 +28,29 @@ import {
 } from "@/components/ui/alert-dialog";
 import { getMyCalendarFeedUrl, replaceMyCalendarFeedUrl } from "@/lib/calendar.functions";
 
+/**
+ * How long to wait for either call before giving up on the answer.
+ *
+ * Not a retry, and not an abort of the work: as `submit-resilience.ts` puts it,
+ * giving up on a reply never tells you the work did not happen. It is here
+ * because the confirm below cannot be dismissed while a request is in flight,
+ * so without a ceiling a stalled connection (this club's traffic is phones, in
+ * transit) leaves someone in a modal with a spinner and no way out. The panel
+ * answers a timeout the same way it answers a failure: by asking what the live
+ * link is now, which is the only thing that actually settles it.
+ */
+const REQUEST_TIMEOUT_MS = 20_000;
+
+function withTimeout<T>(work: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    work,
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error("Timed out.")), REQUEST_TIMEOUT_MS);
+    }),
+  ]).finally(() => clearTimeout(timer)) as Promise<T>;
+}
+
 /** Open confirm, mid-flight, or failed with something to press again. */
 type Pending = { busy: boolean; error: string | null };
 
@@ -44,7 +67,7 @@ export function CalendarLinkPanel() {
 
   const load = useCallback(() => {
     setLoadFailed(false);
-    loadFeedUrl()
+    withTimeout(loadFeedUrl())
       .then(({ url: fresh }) => setUrl(fresh))
       .catch(() => setLoadFailed(true));
   }, [loadFeedUrl]);
@@ -62,7 +85,7 @@ export function CalendarLinkPanel() {
     const previous = url;
     setPending({ busy: true, error: null });
     try {
-      settle((await replaceFeedUrl()).url);
+      settle((await withTimeout(replaceFeedUrl())).url);
       return;
     } catch {
       // Not a clean "nothing happened". The server retires the old link before
@@ -73,7 +96,7 @@ export function CalendarLinkPanel() {
       // question, since the server mints one for anyone left without one.
     }
     try {
-      const { url: current } = await loadFeedUrl();
+      const { url: current } = await withTimeout(loadFeedUrl());
       // A different link means the replace effectively landed, whatever the
       // first call reported. Nothing is gained by making them press again.
       if (current !== previous) return settle(current);

--- a/src/components/site/CalendarLinkPanel.tsx
+++ b/src/components/site/CalendarLinkPanel.tsx
@@ -1,0 +1,62 @@
+// A member's private calendar link: fetched, shown in full, and copyable.
+//
+// Lifted out of /calendar unchanged. It is here because /account is about to
+// show the same link, and the panel is not styling: it is a live-region loading
+// state, a failure that stays on screen with a retry, and a URL that is the
+// most sensitive string this app ever prints. Two copies of that would be two
+// places for one of them to drift.
+import { useCallback, useEffect, useState } from "react";
+import { useServerFn } from "@tanstack/react-start";
+import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/site/CopyButton";
+import { getMyCalendarFeedUrl } from "@/lib/calendar.functions";
+
+export function CalendarLinkPanel() {
+  const loadFeedUrl = useServerFn(getMyCalendarFeedUrl);
+
+  const [url, setUrl] = useState<string | null>(null);
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  const load = useCallback(() => {
+    setLoadFailed(false);
+    loadFeedUrl()
+      .then(({ url: fresh }) => setUrl(fresh))
+      .catch(() => setLoadFailed(true));
+  }, [loadFeedUrl]);
+
+  useEffect(load, [load]);
+
+  if (loadFailed) {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-muted-foreground" role="status">
+          We couldn't load your calendar link just now. Nothing has changed.
+        </p>
+        <Button size="sm" variant="outline" onClick={load}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  if (!url) {
+    return (
+      <p className="text-sm text-muted-foreground" role="status">
+        Loading your link...
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <code className="min-w-0 flex-1 overflow-x-auto rounded bg-background px-3 py-2 text-xs">
+          {url}
+        </code>
+        <CopyButton text={url} label="Copy" ariaLabel="Copy your calendar link" />
+      </div>
+    </div>
+  );
+}
+
+export default CalendarLinkPanel;

--- a/src/components/site/CalendarLinkPanel.tsx
+++ b/src/components/site/CalendarLinkPanel.tsx
@@ -1,21 +1,46 @@
-// A member's private calendar link: fetched, shown in full, and copyable.
+// A member's private calendar link, and the one thing they can do to it.
 //
-// Lifted out of /calendar unchanged. It is here because /account is about to
-// show the same link, and the panel is not styling: it is a live-region loading
-// state, a failure that stays on screen with a retry, and a URL that is the
-// most sensitive string this app ever prints. Two copies of that would be two
-// places for one of them to drift.
+// Shared by /calendar, where the link has always lived, and /account, where you
+// go when something needs doing. Both show the same link and offer the same
+// replace, so they are one component: two copies would be two places for the
+// warning to drift, and the warning is the whole point of the button.
+//
+// Replacing is irreversible and it breaks something on purpose, so it goes
+// through a real confirm that says in words what will stop working. The new
+// link then stays on screen with a copy button, because this is the only moment
+// it exists in front of the person and their calendar app is out of date until
+// they paste it somewhere. A toast would take it away again while they were
+// still unlocking their phone.
 import { useCallback, useEffect, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
+import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/site/CopyButton";
-import { getMyCalendarFeedUrl } from "@/lib/calendar.functions";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { getMyCalendarFeedUrl, replaceMyCalendarFeedUrl } from "@/lib/calendar.functions";
+
+/** Open confirm, mid-flight, or failed with something to press again. */
+type Pending = { busy: boolean; error: string | null };
 
 export function CalendarLinkPanel() {
   const loadFeedUrl = useServerFn(getMyCalendarFeedUrl);
+  const replaceFeedUrl = useServerFn(replaceMyCalendarFeedUrl);
 
   const [url, setUrl] = useState<string | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
+  // Sticks around after the dialog closes: the person has to notice that the
+  // link in front of them is not the one their calendar app is subscribed to.
+  const [justReplaced, setJustReplaced] = useState(false);
+  const [pending, setPending] = useState<Pending | null>(null);
 
   const load = useCallback(() => {
     setLoadFailed(false);
@@ -25,6 +50,26 @@ export function CalendarLinkPanel() {
   }, [loadFeedUrl]);
 
   useEffect(load, [load]);
+
+  async function replace() {
+    setPending({ busy: true, error: null });
+    try {
+      const { url: fresh } = await replaceFeedUrl();
+      setUrl(fresh);
+      setJustReplaced(true);
+      setPending(null);
+    } catch {
+      // Stays in the dialog with the button still there. The message has to
+      // cover both halves of a half-finished replace: it may have retired the
+      // old link before it failed, and a reload is what settles which link they
+      // actually hold now.
+      setPending({
+        busy: false,
+        error:
+          "That didn't go through. Reload this page to see which link you have now, and try again if it hasn't changed.",
+      });
+    }
+  }
 
   if (loadFailed) {
     return (
@@ -55,6 +100,70 @@ export function CalendarLinkPanel() {
         </code>
         <CopyButton text={url} label="Copy" ariaLabel="Copy your calendar link" />
       </div>
+
+      {justReplaced && (
+        <p
+          role="status"
+          className="rounded-md border border-primary/40 bg-primary/5 px-3 py-2 text-sm"
+        >
+          This is your new link. The old one has stopped working, so add this one to your calendar
+          app now.
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => setPending({ busy: false, error: null })}
+        >
+          Replace link
+        </Button>
+        <span className="text-xs text-muted-foreground">
+          Use this if your link has ended up somewhere it shouldn't.
+        </span>
+      </div>
+
+      <AlertDialog
+        open={Boolean(pending)}
+        onOpenChange={(open) => {
+          if (!open && !pending?.busy) setPending(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Replace your calendar link?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Your current link stops working straight away. Every calendar app you added it to
+              stops updating until you put the new link in, and anyone you gave the old one to loses
+              it. We'll show you the new link here as soon as it's ready.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {pending?.error && (
+            <p
+              role="alert"
+              className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            >
+              {pending.error}
+            </p>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={pending?.busy}>Keep my link</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={pending?.busy}
+              // Not the default form-submitting close: the dialog has to stay
+              // open to show a failure.
+              onClick={(e) => {
+                e.preventDefault();
+                void replace();
+              }}
+            >
+              {pending?.busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {pending?.error ? "Try again" : "Replace link"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/components/site/CalendarLinkPanel.tsx
+++ b/src/components/site/CalendarLinkPanel.tsx
@@ -51,18 +51,39 @@ export function CalendarLinkPanel() {
 
   useEffect(load, [load]);
 
+  /** Show `fresh` as the live link and close the confirm on a done replace. */
+  function settle(fresh: string) {
+    setUrl(fresh);
+    setJustReplaced(true);
+    setPending(null);
+  }
+
   async function replace() {
+    const previous = url;
     setPending({ busy: true, error: null });
     try {
-      const { url: fresh } = await replaceFeedUrl();
-      setUrl(fresh);
-      setJustReplaced(true);
-      setPending(null);
+      settle((await replaceFeedUrl()).url);
+      return;
     } catch {
-      // Stays in the dialog with the button still there. The message has to
-      // cover both halves of a half-finished replace: it may have retired the
-      // old link before it failed, and a reload is what settles which link they
-      // actually hold now.
+      // Not a clean "nothing happened". The server retires the old link before
+      // it mints the new one, so a failure here can still have left the address
+      // on screen dead, and leaving it there next to a Copy button would hand
+      // someone a URL that no longer works. So ask what the live link is now
+      // rather than guessing: that both repairs the screen and answers the
+      // question, since the server mints one for anyone left without one.
+    }
+    try {
+      const { url: current } = await loadFeedUrl();
+      // A different link means the replace effectively landed, whatever the
+      // first call reported. Nothing is gained by making them press again.
+      if (current !== previous) return settle(current);
+      setUrl(current);
+      setPending({
+        busy: false,
+        error: "That didn't go through, and your link has not changed. Try again.",
+      });
+    } catch {
+      // Could not even ask. Say exactly that, rather than claiming either way.
       setPending({
         busy: false,
         error:

--- a/src/lib/calendar-feed-token.test.ts
+++ b/src/lib/calendar-feed-token.test.ts
@@ -1,0 +1,52 @@
+// The calendar link is the site's longest-lived secret and it can never leave
+// the URL path, so replacing it is the only way one ever stops working. These
+// pin the half of that which lives in the feed: a replaced link must serve
+// nothing, and must not be indistinguishable from a typo.
+import { describe, expect, it } from "vitest";
+import {
+  REPLACED_LINK_MESSAGE,
+  UNKNOWN_LINK_MESSAGE,
+  feedTokenVerdict,
+} from "./calendar-feed-token";
+
+describe("feedTokenVerdict", () => {
+  it("serves a live link, and hands the row back", () => {
+    const row = { id: "tok-1", user_id: "usr-1", revoked_at: null };
+    const verdict = feedTokenVerdict(row);
+    expect(verdict.serve).toBe(true);
+    // The caller needs the row to know whose calendar this is; a verdict that
+    // only said "yes" would leave it re-checking for null.
+    expect(verdict.serve && verdict.row).toBe(row);
+  });
+
+  // The whole point of the feature: the old address stops carrying events the
+  // moment its owner replaces it.
+  it("refuses a replaced link", () => {
+    const verdict = feedTokenVerdict({
+      id: "tok-1",
+      user_id: "usr-1",
+      revoked_at: "2026-08-22T01:00:00Z",
+    });
+    expect(verdict.serve).toBe(false);
+    expect(verdict).toMatchObject({ status: 410, message: REPLACED_LINK_MESSAGE });
+  });
+
+  // 410, not 404. "This address was real and is now gone" is a different answer
+  // from "no such address", and it is what lets the message be honest.
+  it("tells a replaced link apart from one that never existed", () => {
+    const replaced = feedTokenVerdict({ revoked_at: "2026-08-22T01:00:00Z" });
+    const unknown = feedTokenVerdict(null);
+    expect(replaced).not.toEqual(unknown);
+    expect(unknown).toEqual({ serve: false, status: 404, message: UNKNOWN_LINK_MESSAGE });
+  });
+
+  // Someone holding a replaced link is its owner, or the person they leaked it
+  // to. Either way they need to know it was replaced rather than broken, and
+  // where the new one is.
+  it("tells the holder of a replaced link what to do next", () => {
+    expect(REPLACED_LINK_MESSAGE).toContain("replaced");
+    expect(REPLACED_LINK_MESSAGE).toContain("/account");
+    // Copy voice: no em dashes (AGENTS.md).
+    expect(REPLACED_LINK_MESSAGE).not.toContain("—");
+  });
+});

--- a/src/lib/calendar-feed-token.ts
+++ b/src/lib/calendar-feed-token.ts
@@ -1,0 +1,47 @@
+// What the ICS feed route does with the token it was handed.
+//
+// Pulled out of the route so the rule that matters can be tested without a
+// request: a link its owner has REPLACED must never serve events again, and it
+// must say why rather than answering like a typo.
+//
+// Why replacing exists at all: the token rides in the URL path because a
+// calendar app subscribes to an address and has nowhere else to put a
+// credential. It can never move to a header, so it is the longest-lived secret
+// on the site, and minting a fresh one is the only lever a member has if theirs
+// ends up somewhere it should not be. See docs/calendar.md.
+
+/** All the verdict reads off the row the feed route looked up by hash. */
+export type FeedTokenRow = { revoked_at: string | null };
+
+export type FeedTokenVerdict<T> =
+  | { serve: true; row: T }
+  | { serve: false; status: number; message: string };
+
+/**
+ * What someone gets from a link that has been replaced. Most calendar apps
+ * swallow the body and simply stop syncing, but the person who pastes the old
+ * URL into a browser to find out what happened gets a straight answer, and so
+ * does the manager they ask about it.
+ */
+export const REPLACED_LINK_MESSAGE =
+  "This calendar link was replaced, so it has stopped updating. Sign in at jitsu.au/account, copy your new calendar link, and add that one to your calendar app.";
+
+/** Deliberately the same words for "never existed" and "mistyped". */
+export const UNKNOWN_LINK_MESSAGE = "Calendar not found.";
+
+/**
+ * Decide whether a token may still be served a calendar.
+ *
+ * A replaced link answers 410 rather than 404: the address was real and is now
+ * permanently gone, which is a different thing from never having existed, and
+ * it is what lets the message above be honest. Saying "replaced" to whoever
+ * holds the old token gives nothing away, since holding it was the only way to
+ * ask in the first place.
+ */
+export function feedTokenVerdict<T extends FeedTokenRow>(row: T | null): FeedTokenVerdict<T> {
+  if (!row) return { serve: false, status: 404, message: UNKNOWN_LINK_MESSAGE };
+  if (row.revoked_at) return { serve: false, status: 410, message: REPLACED_LINK_MESSAGE };
+  // Carries the row through so the caller keeps it non-null without a second
+  // check that could only ever be dead code.
+  return { serve: true, row };
+}

--- a/src/lib/calendar.functions.ts
+++ b/src/lib/calendar.functions.ts
@@ -207,11 +207,15 @@ export const setRsvp = createServerFn({ method: "POST" })
 // the raw token is stored (see 20260728180000). The hash is still written and is
 // what the feed route looks up.
 //
-// The link is permanent until its owner asks for a new one. Nothing expires it
-// and nothing else retires it, because the only thing a member notices when a
-// calendar link stops working is that they stopped hearing about training. The
-// one exception is replaceMyCalendarFeedUrl below, which exists precisely so
-// that breaking the old link is something a person chose.
+// A link lasts until somebody replaces it. Nothing expires one on age or on a
+// password change, because the only thing a member notices when a calendar link
+// quietly stops working is that they stopped hearing about training.
+//
+// TWO things retire one, and both go through the same retire-and-mint shape so
+// the retired address always answers "this was replaced" rather than reading as
+// a typo: replaceMyCalendarFeedUrl below, which is a person choosing to break
+// their own link, and the legacy branch in getMyCalendarFeedUrl, which has to
+// because it cannot show a link it only ever stored the hash of.
 //
 // POST rather than GET because the first call for a person writes their row.
 export const getMyCalendarFeedUrl = createServerFn({ method: "POST" })
@@ -230,25 +234,27 @@ export const getMyCalendarFeedUrl = createServerFn({ method: "POST" })
     if (error) throw new Error(error.message);
     if (existing?.token) return feedUrl(existing.token);
 
-    const raw = generateRawToken();
-    const token_hash = await hashToken(raw);
-    const token_prefix = tokenPreview(raw);
-
     if (existing) {
-      // A link minted while only the hash was stored: the original is not
-      // recoverable, so it is re-minted in place. Anything still subscribed to
-      // that old URL stops updating.
-      const { error: updateError } = await admin
+      // A link minted while only the hash was stored (before 20260728180000):
+      // the raw token is not recoverable, so there is nothing to show and it has
+      // to be replaced. Retired the same way a member-initiated replace retires
+      // one, rather than overwritten in place, so its address answers "this link
+      // was replaced" instead of the 404 that reads as a typo. Anything still
+      // subscribed to it stops updating either way.
+      const { error: retireError } = await admin
         .from("calendar_feed_tokens")
-        .update({ token: raw, token_hash, token_prefix })
+        .update({ revoked_at: new Date().toISOString() })
         .eq("id", existing.id);
-      if (updateError) throw new Error(updateError.message);
-      return feedUrl(raw);
+      if (retireError) throw new Error(retireError.message);
     }
 
-    const { error: insertError } = await admin
-      .from("calendar_feed_tokens")
-      .insert({ user_id: context.userId, token: raw, token_hash, token_prefix });
+    const raw = generateRawToken();
+    const { error: insertError } = await admin.from("calendar_feed_tokens").insert({
+      user_id: context.userId,
+      token: raw,
+      token_hash: await hashToken(raw),
+      token_prefix: tokenPreview(raw),
+    });
     if (insertError) {
       // Two first-ever loads racing (two tabs): the one-live-token-per-person
       // index rejects the loser, so use the row the winner just wrote.
@@ -279,6 +285,12 @@ export const getMyCalendarFeedUrl = createServerFn({ method: "POST" })
  * token is cleared on the way past: the column only exists so the page can show
  * a member their live link, and a row that is no longer anyone's live link has
  * no reason to keep the secret. The hash stays, and is what the feed matches on.
+ *
+ * Retired rows are never pruned, so a member pressing this repeatedly writes
+ * rows nothing removes. Left alone rather than capped: every row costs a
+ * deliberate press by a signed-in person, a club this size will not notice, and
+ * a cap would have to decide how old a retired address may be before it goes
+ * back to answering like a typo. Worth revisiting if the table ever grows.
  */
 export const replaceMyCalendarFeedUrl = createServerFn({ method: "POST" })
   .middleware([requireSupabaseAuth])
@@ -303,11 +315,14 @@ export const replaceMyCalendarFeedUrl = createServerFn({ method: "POST" })
       token_prefix: tokenPreview(raw),
     });
     // Deliberately not swallowed the way the mint path's race is. There, losing
-    // the race means someone else already made you a link; here it would mean
-    // the old link is revoked and no new one exists, and the member has to be
-    // told so they reload rather than walking off with a dead address. That
-    // state heals itself: getMyCalendarFeedUrl mints a link for anyone with no
-    // live row, so the next page load hands them a working one.
+    // the race means someone else already made you a link; here it means the old
+    // link is retired and no new one exists, which is the one state a member
+    // must not be left in believing nothing happened. There is no transaction
+    // around the two statements, so a getMyCalendarFeedUrl landing in the gap
+    // (the panel is mounted on two pages, so a second tab is enough) mints a row
+    // and makes this insert collide. Either way the caller reacts by asking what
+    // its live link is now, and getMyCalendarFeedUrl mints one for anyone left
+    // without one, so the state heals rather than persisting.
     if (insertError) throw new Error(insertError.message);
 
     return { url: `${origin}/api/calendar/${raw}` };

--- a/src/lib/calendar.functions.ts
+++ b/src/lib/calendar.functions.ts
@@ -204,9 +204,14 @@ export const setRsvp = createServerFn({ method: "POST" })
 
 // ---- Member: personal ICS feed link ----
 // One link per person, minted on first ask and shown every time afterwards, so
-// the raw token is stored (see 20260728180000). There is no rotate or turn-off:
-// the link is a permanent, private subscription address like any other calendar
-// app's. The hash is still written and is what the feed route looks up.
+// the raw token is stored (see 20260728180000). The hash is still written and is
+// what the feed route looks up.
+//
+// The link is permanent until its owner asks for a new one. Nothing expires it
+// and nothing else retires it, because the only thing a member notices when a
+// calendar link stops working is that they stopped hearing about training. The
+// one exception is replaceMyCalendarFeedUrl below, which exists precisely so
+// that breaking the old link is something a person chose.
 //
 // POST rather than GET because the first call for a person writes their row.
 export const getMyCalendarFeedUrl = createServerFn({ method: "POST" })
@@ -257,6 +262,55 @@ export const getMyCalendarFeedUrl = createServerFn({ method: "POST" })
       throw new Error(insertError.message);
     }
     return feedUrl(raw);
+  });
+
+/**
+ * Replace the caller's calendar link: retire the one they have and mint a new
+ * one, returning the new URL.
+ *
+ * The token cannot leave the URL path, so this is the only way a leaked link is
+ * ever made harmless, and it is deliberately the member's own call to make.
+ * A manager cannot do it for somebody: it silently stops that person's calendar
+ * updating, and they are the one who has to re-subscribe, so the club asks them
+ * instead. See docs/calendar.md.
+ *
+ * The old row is kept, revoked rather than deleted, so the old address can tell
+ * whoever opens it that it was replaced instead of reading as a typo. Its raw
+ * token is cleared on the way past: the column only exists so the page can show
+ * a member their live link, and a row that is no longer anyone's live link has
+ * no reason to keep the secret. The hash stays, and is what the feed matches on.
+ */
+export const replaceMyCalendarFeedUrl = createServerFn({ method: "POST" })
+  .middleware([requireSupabaseAuth])
+  .handler(async ({ context }) => {
+    const admin = await adminClient();
+    const origin = await requestOrigin();
+
+    // Retire first: calendar_feed_tokens_one_live_idx allows one live row per
+    // person, so inserting before revoking would just collide.
+    const { error: revokeError } = await admin
+      .from("calendar_feed_tokens")
+      .update({ revoked_at: new Date().toISOString(), token: null })
+      .eq("user_id", context.userId)
+      .is("revoked_at", null);
+    if (revokeError) throw new Error(revokeError.message);
+
+    const raw = generateRawToken();
+    const { error: insertError } = await admin.from("calendar_feed_tokens").insert({
+      user_id: context.userId,
+      token: raw,
+      token_hash: await hashToken(raw),
+      token_prefix: tokenPreview(raw),
+    });
+    // Deliberately not swallowed the way the mint path's race is. There, losing
+    // the race means someone else already made you a link; here it would mean
+    // the old link is revoked and no new one exists, and the member has to be
+    // told so they reload rather than walking off with a dead address. That
+    // state heals itself: getMyCalendarFeedUrl mints a link for anyone with no
+    // live row, so the next page load hands them a working one.
+    if (insertError) throw new Error(insertError.message);
+
+    return { url: `${origin}/api/calendar/${raw}` };
   });
 
 // ================= Manager =================

--- a/src/lib/calendar.functions.ts
+++ b/src/lib/calendar.functions.ts
@@ -265,6 +265,15 @@ export const getMyCalendarFeedUrl = createServerFn({ method: "POST" })
         .is("revoked_at", null)
         .maybeSingle();
       if (raced?.token) return feedUrl(raced.token);
+      // Nothing to fall back on, and the retire above already happened, so this
+      // person would be left with NO live link and a dead address, from a page
+      // load that was only meant to show them something. There is no
+      // transaction around the two statements, so put the old row back by hand
+      // before reporting the failure: the next load then finds it and takes the
+      // same branch again, rather than the member's calendar silently stopping.
+      if (existing) {
+        await admin.from("calendar_feed_tokens").update({ revoked_at: null }).eq("id", existing.id);
+      }
       throw new Error(insertError.message);
     }
     return feedUrl(raw);
@@ -286,11 +295,12 @@ export const getMyCalendarFeedUrl = createServerFn({ method: "POST" })
  * a member their live link, and a row that is no longer anyone's live link has
  * no reason to keep the secret. The hash stays, and is what the feed matches on.
  *
- * Retired rows are never pruned, so a member pressing this repeatedly writes
- * rows nothing removes. Left alone rather than capped: every row costs a
- * deliberate press by a signed-in person, a club this size will not notice, and
- * a cap would have to decide how old a retired address may be before it goes
- * back to answering like a typo. Worth revisiting if the table ever grows.
+ * Retired rows are never pruned, so every call writes a row nothing removes, and
+ * nothing rate-limits the call: a signed-in account, or a stolen session, can
+ * loop it. Left uncapped for now because a club this size will not notice, and
+ * because a cap has to decide how long a retired address may keep explaining
+ * itself before it goes back to answering like a typo. That is a judgement, not
+ * a guarantee, so revisit it if the table ever grows.
  */
 export const replaceMyCalendarFeedUrl = createServerFn({ method: "POST" })
   .middleware([requireSupabaseAuth])

--- a/src/routes/_authenticated/account.test.tsx
+++ b/src/routes/_authenticated/account.test.tsx
@@ -54,6 +54,13 @@ vi.mock("@/lib/waiver.functions", () => ({
   getWaiverPdfUrl: vi.fn(),
 }));
 
+vi.mock("@/lib/calendar.functions", () => ({
+  getMyCalendarFeedUrl: vi.fn().mockResolvedValue({
+    url: "https://jitsu.au/api/calendar/utsj_000000000000",
+  }),
+  replaceMyCalendarFeedUrl: vi.fn(),
+}));
+
 vi.mock("@/lib/code-of-conduct.functions", () => ({
   getCodeOfConductSigner: vi.fn().mockResolvedValue({ status: null }),
 }));

--- a/src/routes/_authenticated/account.tsx
+++ b/src/routes/_authenticated/account.tsx
@@ -14,6 +14,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Pill } from "@/components/site/StatusPill";
 import { NewPasswordField } from "@/components/site/NewPasswordField";
+import { CalendarLinkPanel } from "@/components/site/CalendarLinkPanel";
 import { describePasswordError, passwordProblem, type BreachStatus } from "@/lib/password-policy";
 import {
   BELT_SIZE_HINT,
@@ -235,6 +236,22 @@ function AccountPage() {
       <WaiversCard />
 
       <CodeOfConductCard />
+
+      <SectionHeading>Calendar</SectionHeading>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Your calendar link</CardTitle>
+          <CardDescription>
+            The private link that keeps the club calendar in your own calendar app. Anyone who has
+            it can see what's on, so keep it to yourself. If it has ended up somewhere it shouldn't,
+            replace it and the old one stops working.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <CalendarLinkPanel />
+        </CardContent>
+      </Card>
 
       <SectionHeading>Sign-in</SectionHeading>
 

--- a/src/routes/api/calendar/$token.ts
+++ b/src/routes/api/calendar/$token.ts
@@ -71,11 +71,16 @@ export const Route = createFileRoute("/api/calendar/$token")({
         // No `.is("revoked_at", null)` filter: token_hash is unique across the
         // whole table, so this still matches at most one row, and a replaced
         // one has to come back so the verdict can tell the two cases apart.
-        const { data: lookup } = await admin
+        const { data: lookup, error: lookupError } = await admin
           .from("calendar_feed_tokens")
           .select("id, user_id, revoked_at")
           .eq("token_hash", token_hash)
           .maybeSingle();
+        // Surfaced rather than folded into `lookup === null`. This route's whole
+        // job is telling a live link, a replaced one and a made-up one apart, and
+        // a database blip answering "no such calendar" to a subscriber holding a
+        // perfectly good token is the one wrong answer of the three.
+        if (lookupError) return textResponse("Could not build calendar.", 500);
         const verdict = feedTokenVerdict(lookup);
         if (!verdict.serve) return textResponse(verdict.message, verdict.status);
         const tokenRow = verdict.row;

--- a/src/routes/api/calendar/$token.ts
+++ b/src/routes/api/calendar/$token.ts
@@ -1,15 +1,20 @@
 // Per-person ICS calendar feed: GET /api/calendar/<token>
 //
 // The token rides in the URL path (calendar apps can't send an auth header). We
-// hash it and look up a live calendar_feed_tokens row; the feed then carries that
+// hash it and look up the calendar_feed_tokens row; the feed then carries that
 // person's events — public always, plus members-only ones if they are a PAID
 // member (or a manager). There is deliberately no public/anon feed, so a
 // subscriber never silently misses a members-only event.
+//
+// A row whose owner has REPLACED their link is looked up too, rather than
+// filtered out, so the old address can say what happened instead of reading as
+// a typo. feedTokenVerdict owns that call.
 //
 // All DB access uses the service-role client, lazy-imported (route files ship to
 // the client bundle, so it must never be a top-level import).
 import { createFileRoute } from "@tanstack/react-router";
 import { hashToken } from "@/lib/manager-api-tokens";
+import { feedTokenVerdict, UNKNOWN_LINK_MESSAGE } from "@/lib/calendar-feed-token";
 import { buildCalendar, type IcsEvent } from "@/lib/ics";
 import { CLUB_TIME_ZONE } from "@/lib/calendar";
 import type { CalendarClient, CalendarFeedSelection } from "@/lib/calendar-types";
@@ -57,19 +62,23 @@ export const Route = createFileRoute("/api/calendar/$token")({
     handlers: {
       GET: async ({ params }) => {
         const raw = params.token;
-        if (!raw) return textResponse("Calendar not found.", 404);
+        if (!raw) return textResponse(UNKNOWN_LINK_MESSAGE, 404);
 
         const { supabaseAdmin } = await import("@/integrations/supabase/client.server");
         const admin = supabaseAdmin as unknown as CalendarClient;
 
         const token_hash = await hashToken(raw);
-        const { data: tokenRow } = await admin
+        // No `.is("revoked_at", null)` filter: token_hash is unique across the
+        // whole table, so this still matches at most one row, and a replaced
+        // one has to come back so the verdict can tell the two cases apart.
+        const { data: lookup } = await admin
           .from("calendar_feed_tokens")
-          .select("id, user_id")
+          .select("id, user_id, revoked_at")
           .eq("token_hash", token_hash)
-          .is("revoked_at", null)
           .maybeSingle();
-        if (!tokenRow) return textResponse("Calendar not found.", 404);
+        const verdict = feedTokenVerdict(lookup);
+        if (!verdict.serve) return textResponse(verdict.message, verdict.status);
+        const tokenRow = verdict.row;
 
         // Best-effort usage stamp — never blocks the feed. A PostgrestBuilder is
         // a lazy thenable: `void builder` would never issue the request, so the

--- a/src/routes/calendar.tsx
+++ b/src/routes/calendar.tsx
@@ -7,7 +7,8 @@ import { SiteLayout } from "@/components/site/SiteLayout";
 import { Loading } from "@/components/site/Loading";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { getCalendar, getMyCalendarFeedUrl, getMyRsvps, setRsvp } from "@/lib/calendar.functions";
+import { getCalendar, getMyRsvps, setRsvp } from "@/lib/calendar.functions";
+import { CalendarLinkPanel } from "@/components/site/CalendarLinkPanel";
 import type { RsvpResponse } from "@/lib/validation";
 import { buildPageMeta } from "@/lib/seo";
 
@@ -67,7 +68,6 @@ function CalendarPage() {
   const loadCalendar = useServerFn(getCalendar);
   const loadRsvps = useServerFn(getMyRsvps);
   const saveRsvp = useServerFn(setRsvp);
-  const loadFeedUrl = useServerFn(getMyCalendarFeedUrl);
 
   const [events, setEvents] = useState<CalendarEvent[]>([]);
   const [signedIn, setSignedIn] = useState(false);
@@ -75,8 +75,6 @@ function CalendarPage() {
   const [loading, setLoading] = useState(true);
   const [rsvps, setRsvps] = useState<Record<string, RsvpResponse | undefined>>({});
   const [savingRsvp, setSavingRsvp] = useState<Set<string>>(new Set());
-  const [feedUrl, setFeedUrl] = useState<string | null>(null);
-  const [feedFailed, setFeedFailed] = useState(false);
 
   const refreshRsvps = useCallback(() => {
     loadRsvps()
@@ -95,20 +93,13 @@ function CalendarPage() {
         setSignedIn(data.signed_in);
         setSeesMembersOnly(data.sees_members_only);
         setLoading(false);
-        if (data.signed_in) {
-          refreshRsvps();
-          // The link is minted on first ask and shown on every visit after that,
-          // so there is nothing for the member to press to get one.
-          loadFeedUrl()
-            .then(({ url }) => setFeedUrl(url))
-            .catch(() => setFeedFailed(true));
-        }
+        if (data.signed_in) refreshRsvps();
       })
       .catch((e) => {
         toast.error(e instanceof Error ? e.message : "Could not load the calendar");
         setLoading(false);
       });
-  }, [loadCalendar, loadFeedUrl, refreshRsvps]);
+  }, [loadCalendar, refreshRsvps]);
 
   async function respond(eventId: string, response: RsvpResponse) {
     // Per-event, so replying to one event doesn't re-enable another's buttons.
@@ -127,18 +118,6 @@ function CalendarPage() {
         next.delete(eventId);
         return next;
       });
-    }
-  }
-
-  async function copyFeedUrl() {
-    if (!feedUrl) return;
-    try {
-      await navigator.clipboard.writeText(feedUrl);
-      toast.success("Calendar link copied.");
-    } catch {
-      // Clipboard access can be blocked (older browsers, no secure context).
-      // The link is on screen either way, so this is only a convenience.
-      toast.error("Could not copy it. Select the link and copy it by hand.");
     }
   }
 
@@ -175,22 +154,7 @@ function CalendarPage() {
                   ? " Your link includes members-only events."
                   : " Members-only events are included once you have a paid membership."}
               </p>
-              {feedUrl ? (
-                <div className="flex flex-wrap items-center gap-2">
-                  <code className="min-w-0 flex-1 overflow-x-auto rounded bg-background px-3 py-2 text-xs">
-                    {feedUrl}
-                  </code>
-                  <Button size="sm" variant="outline" onClick={copyFeedUrl}>
-                    Copy
-                  </Button>
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">
-                  {feedFailed
-                    ? "We could not load your link just now. Refresh the page to try again."
-                    : "Loading your link..."}
-                </p>
-              )}
+              <CalendarLinkPanel />
             </div>
           ) : (
             <p className="text-sm text-muted-foreground">

--- a/supabase/migrations/20260822093000_calendar_feed_token_client_write_policies.sql
+++ b/supabase/migrations/20260822093000_calendar_feed_token_client_write_policies.sql
@@ -1,0 +1,33 @@
+-- Drop the two client write policies on calendar_feed_tokens.
+--
+-- They came from 20260726000000_calendar.sql and have been dead since
+-- 20260728120000_calendar_revoke_client_grants.sql took INSERT and UPDATE away
+-- from `anon` and `authenticated`: a policy without a grant is unreachable. That
+-- migration kept them on purpose, reasoning they cost nothing and would "stay
+-- correct if a grant is ever added back".
+--
+-- That reasoning no longer holds for the UPDATE one. `revoked_at` is now the
+-- mechanism by which a member makes a leaked calendar link stop working: the
+-- feed route (src/routes/api/calendar/$token.ts) serves a token unless its row
+-- carries a revoked_at, and replaceMyCalendarFeedUrl is what writes it. An
+-- owner-scoped UPDATE policy is therefore no longer defence in depth pointing
+-- the same way as the app; it says "a person may write their own row", which,
+-- the moment any future migration or dashboard change hands `authenticated` an
+-- UPDATE grant, means a member can PATCH revoked_at back to NULL and resurrect
+-- the exact link they had just reported as leaked. The original migration's own
+-- comment names that attack, then leaves the policy that would allow it.
+--
+-- The INSERT policy goes with it for the same reason in a milder form: minting
+-- runs through the service role only, and a client that could insert its own row
+-- could hand itself a token the server never issued. Neither policy has a
+-- caller, in this repo or anywhere else, so dropping them removes no code path.
+--
+-- SELECT is untouched. `authenticated` really does hold that grant (see
+-- supabase/lint/client-grants-expected.txt), the owner-only policy narrows it to
+-- their own row, and that row is what /calendar and /account show them. This
+-- migration changes no grants, so client-grants-expected.txt is unchanged.
+
+DROP POLICY IF EXISTS "Users can revoke their own feed token" ON public.calendar_feed_tokens;
+DROP POLICY IF EXISTS "Users can create their own feed token" ON public.calendar_feed_tokens;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Closes #91.

> [!IMPORTANT]
> **This PR carries a migration that has NOT been applied.**
> `supabase/migrations/20260822093000_calendar_feed_token_client_write_policies.sql`
> drops two dead RLS policies (details under "The one migration" below). Per
> `docs/database-changes.md`'s apply gate, a human applies it after approving
> this PR, records it in the ledger, verifies, reloads PostgREST, and only then
> merges. **Nothing in this change needs it to ship** and no code path depends
> on it, so it can also be dropped from the PR if you'd rather not run it now.

## Decisions I made that you may want to change

The issue named three open questions. I picked the smallest version of each and built it. All three are easy to move.

**1. Only the member can replace their own link. A manager cannot do it for them.**
A manager replacing somebody's link stops that person's calendar updating with no warning, and the member is the one who has to go and re-subscribe. The case this was weighed against, "I pasted my link somewhere public", is answered by that member pressing the button themselves, which is what they'd have to be told to do anyway. If you'd rather managers could force it (say, for an account somebody can no longer sign in to), that is a separate screen plus an email telling the person what just happened to their calendar, and it should be decided together with that email.

**2. Nothing replaces a link automatically. Only a person asking.**
No age limit, no "you changed your password so your calendar stopped". The only thing a member notices when a calendar link quietly stops working is that they stopped hearing about training, which is a worse outcome than the risk an expiry would reduce. The alternative, if you want it, is a "last used" age cutoff, and it would need warning emails before it fired.

**3. At the moment of the break, the person is told on the page, not by email.**
Pressing Replace opens a confirm that says, before the click, that their current link stops working straight away and that every calendar app holding it stops updating until the new one goes in. Once they confirm, the new link takes the old one's place on the same panel and **stays on screen**, with a copy button and a line saying the old one has stopped. Anyone who opens the old address (them, or whoever they gave it to) gets a plain-text answer saying it was replaced and where to get the new one.
No email goes out. They are on the page holding the new link, and an email carrying a calendar link is one more place for it to leak. If you'd prefer a confirmation email, say so and I'll add it.

## What changes for people

**A member**, on `/account` under a new "Calendar" heading, and on `/calendar` where the link has always been:

- Their calendar link is shown in full with a Copy button, same as before.
- New: a **Replace link** button, with "Use this if your link has ended up somewhere it shouldn't." next to it.
- Pressing it opens a confirm. Nothing has happened yet. It says: *"Your current link stops working straight away. Every calendar app you added it to stops updating until you put the new link in, and anyone you gave the old one to loses it. We'll show you the new link here as soon as it's ready."* The way out is "Keep my link".
- Confirming swaps the link on the panel and leaves a note above the button: *"This is your new link. The old one has stopped working, so add this one to your calendar app now."* It does not fade.
- If it fails or stalls, the panel goes and asks what the live link is now rather than guessing, because the server retires the old one before it mints the new one. A different link back means the replace landed and they are simply shown it. The same link back gets "That didn't go through, and your link has not changed. Try again." in the dialog, with the button still there. Both calls give up waiting after 20 seconds, so a bad connection can never leave someone stuck in the dialog with a spinner.

**Anyone who opens a replaced link**, including a calendar app still subscribed to it, now gets `410 Gone` and: *"This calendar link was replaced, so it has stopped updating. Sign in at jitsu.au/account, copy your new calendar link, and add that one to your calendar app."* Previously a retired link would have been indistinguishable from a mistyped one.

**A manager** sees nothing new.

**Nobody's existing link changes** when this ships. Replacing only ever happens because somebody pressed the button, with one pre-existing exception: a member whose link predates the change that started storing the raw token has a link the server cannot show them, so it swaps that one for a fresh link the first time they open the page. That was already true before this PR (it re-minted in place); the difference now is that their old address answers "this link was replaced" instead of "not found".

One thing worth naming: because the panel is on `/account` too, **every signed-in person now ends up with a calendar link minted**, managers and people who will never subscribe included. That is the price of the link always being there when they ask, which is the rule the calendar already worked to.

## The one migration (unapplied)

`20260822093000_calendar_feed_token_client_write_policies.sql` drops the owner-scoped **INSERT** and **UPDATE** policies on `calendar_feed_tokens`. They have had no grant behind them since `20260728120000` took client writes away, and were deliberately kept then as defence in depth. That was fair while they pointed the same way as the app. They no longer do: `revoked_at` is now the thing that makes a leaked link stop working, and a policy that says "a person may write their own row" is exactly what would undo that the moment any future migration or dashboard change handed `authenticated` an UPDATE grant. The original migration's own comment names that attack and then leaves the policy that would allow it.

No grants change, so `supabase/lint/client-grants-expected.txt` is untouched, and `SELECT` (which is real and is what shows a member their link) is left alone. Nothing in the app calls either policy, so applying it changes no behaviour.

**Everything else needed no schema change.** `calendar_feed_tokens` already has `revoked_at`, the raw `token` column, and the one-live-token-per-person partial index on `revoked_at IS NULL`. Replacing revokes the live row (and clears its raw token, since a row that is nobody's live link has no reason to keep the secret) and inserts a fresh one.

Retired rows are never pruned, and nothing rate-limits the call. Left uncapped: a club this size will not notice, and a cap has to decide how long a retired address may keep explaining itself before it goes back to answering like a typo. It is a judgement rather than a guarantee, and it is written down as one in the code and in `docs/database.md`.

## How it holds up

- `src/lib/calendar-feed-token.ts` is a pure module deciding serve / 410 / 404, unit-tested including that a replaced link is not answered the same way as one that never existed.
- `src/components/site/CalendarLinkPanel.test.tsx` pins the guard (the first click replaces nothing), the warning copy, that backing out changes nothing, that the new link lands on screen and is announced, that a failure which actually landed is recovered rather than reported as an error, and that a real failure stays in the dialog rather than becoming a toast.
- `e2e/member/calendar-link.spec.ts` does it for real against the seeded club: reads the link off `/account`, fetches it and gets a calendar, replaces it through the dialog, then fetches both URLs. Old one 410, new one 200. It leaves the member holding exactly one live link, so it cleans up by construction.
- Every new test was checked against the old behaviour rather than assumed: reverting the 410 branch fails the feed test, removing the confirm fails five panel tests, and dropping the "old one has stopped" note, the in-dialog error, or the failure recovery fails the rest.
- `bun run lint`, `bun run typecheck`, `bun run test` and `bun run build` all pass locally, as does `bunx tsc -p e2e/tsconfig.json`.

## Reading it

Four commits, on purpose:

1. **Preparatory refactor** — the calendar link block moves out of `/calendar` into a component, behaviour unchanged, so `/account` can show the same thing.
2. **The change itself** — the replace button, the server function, the 410, the docs.
3. **First review pass** — the failed-replace recovery, making the legacy re-mint retire-and-insert like a replace so its old address 410s too, surfacing the feed route's lookup error instead of answering a live subscriber "not found", and writing down the un-pruned rows.
4. **Second review pass** — request timeouts so a stalled connection cannot trap someone in the dialog, putting the old row back if the legacy re-mint's insert fails, the migration above, and two doc/comment corrections.

`docs/calendar.md` rule 4 said there was deliberately no way to replace a link; it now says a link lasts until it is replaced, names the two things that replace one, and the "not built, on purpose" entries record decisions 1 and 2 with their reasoning. `docs/database.md` records what `revoked_at` now means and why the two policies go.
