### PR TITLE
Knowledge base: follow links without reloading, and load faster

### DIFF
--- a/docs/knowledge-base.md
+++ b/docs/knowledge-base.md
@@ -568,6 +568,11 @@ security property rather than a nicety: managers-only drafts are readable data
 under these keys, and a five-minute cache under a reader-agnostic key would keep
 one on screen after a sign-out in another tab.
 
+**Publishing clears all of it.** The manager screen keeps its own state and
+never goes through these queries, so it drops them by hand after every write
+(`useInvalidateKbReader`). Without that, a manager who publishes a correction
+and opens `/kb/<slug>` to check it reads the version they have just replaced.
+
 ## SEO
 
 `/kb` is in `robots.txt`'s disallow list, and every page under it is `noindex`

--- a/docs/knowledge-base.md
+++ b/docs/knowledge-base.md
@@ -114,7 +114,9 @@ Three consequences worth knowing:
 
 `/kb/<slug>` for a link entry bounces to the destination. The sidebar already
 points straight at it, so that path only fires for a URL somebody saved before
-the entry became a link.
+the entry became a link. The bounce, and the sidebar entry itself, are handled
+by the router: `link_path` is site-relative by validation, so leaving for
+`/first-class` swaps the shell rather than reloading the application.
 
 ## Reading an article
 
@@ -144,6 +146,15 @@ reader to the fees part of the grading article without them having to find it.
 - **Link to one with an ordinary Markdown link.** `[the fees](/kb/belts#fees)`
   from another article, `[the fees](#fees)` inside the same one. There is no
   special syntax, because there does not need to be.
+- **Following one does not reload the page.** A link to a path on this site is
+  rendered as a router link, so a cross-reference costs a fetch of the next
+  article and nothing else. It used to be a plain anchor, which made every
+  cross-reference a full page load: blank screen, the whole bundle again, the
+  session resolved again, the sidebar fetched again, to move one page. A `#`
+  fragment stays a plain anchor, because it names a heading in the article
+  already on screen. Anything that is not a same-site path (including
+  `//another-host`, which is not one however much it looks like a path) opens in
+  a new tab with `rel="noopener noreferrer"`.
 - **Pin an anchor by ending the heading with `{#your-anchor}`**, the attribute
   syntax Pandoc and Docusaurus use: `## How grading works {#grading}` answers to
   `#grading` for as long as that suffix is there, whatever the heading is
@@ -521,6 +532,42 @@ agent API; nothing in the code depends on those slugs existing. The articles
 themselves (your first belt, how to train off the mat, our belt system, the full
 syllabus, our history, how to contribute) are content, written through the skill.
 
+## How fast it feels, and why
+
+Every page under `/kb` renders client-side, so there is a real cost to opening
+one: the session has to resolve in the browser before anything can be asked for,
+and each answer is a round trip through the site's own server to Supabase. Four
+things keep that off the reader's path.
+
+- **The contents is fetched once and held.** The sidebar is on every page here
+  and its structure changes when a manager publishes, which is a few times a
+  year, so it is cached for five minutes rather than refetched on every mount
+  and every window focus. Finishing an article still ticks it off immediately:
+  recording a read invalidates the contents on purpose.
+- **Articles are prefetched on intent.** The sidebar, the index list, the search
+  results and the previous/next links all know the slug a reader is about to
+  open, so the fetch starts on hover, on keyboard focus, or on the touch that
+  precedes a tap. On a warm cache the click lands on an article that is already
+  there. An article is held for five minutes too, so moving back and forth
+  through a section costs nothing.
+- **Nothing waits for anything it does not need.** The article, its comments and
+  the reader's identity are three independent lookups, and they now run at the
+  same time. The comments used to wait for the article to arrive even though all
+  they need is the slug the router already has; on the server, working out who
+  is asking (two round trips of its own) used to sit in front of the first query
+  rather than beside it. The article page also read the same database row twice
+  on every load: once to tell a link entry from a real page, once again inside
+  the loader it then called.
+- **The page keeps its frame while the text is fetched.** The contents already
+  knows this article's section and title, so moving between two articles shows
+  the breadcrumb and the heading straight away rather than replacing the whole
+  page with a spinner.
+
+Everything a reader is cached for is keyed by **who they are**. That is a
+security property rather than a nicety: managers-only drafts are readable data
+under these keys, and a five-minute cache under a reader-agnostic key would keep
+one on screen after a sign-out in another tab.
+
 ## SEO
 
 `/kb` is in `robots.txt`'s disallow list, and every page under it is `noindex`
@@ -551,6 +598,8 @@ it as a marketing page or a blog post instead.
 | Shell (top bar, sidebar, search, progress)  | `src/components/site/KbLayout.tsx`                  |
 | Reader UI                                   | `src/components/site/KbArticleReader.tsx`           |
 | Sign-in gate + reader routes                | `src/routes/kb/route.tsx`, `index.tsx`, `$slug.tsx` |
+| Contents fetch and its cache                | `src/hooks/useKbNav.ts`                             |
+| Article fetch, its cache, prefetching       | `src/hooks/useKbArticle.ts`                         |
 | Manager screen                              | `src/routes/_authenticated/manager.kb.tsx`          |
 | Manager API actions                         | `src/routes/api/manager/agent.ts`                   |
 

--- a/src/components/site/KbLayout.test.tsx
+++ b/src/components/site/KbLayout.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@tanstack/react-router", () => ({
 }));
 
 vi.mock("@/hooks/useKbNav", () => ({ useKbNav: () => mockUseKbNav() }));
+vi.mock("@/hooks/useKbArticle", () => ({ useKbArticlePrefetch: () => vi.fn() }));
 vi.mock("@/hooks/useAuth", () => ({ useAuth: () => ({ user: { id: "u1" }, loading: false }) }));
 vi.mock("@tanstack/react-query", () => ({ useQuery: () => ({ data: [], isLoading: false }) }));
 vi.mock("@tanstack/react-start", () => ({ useServerFn: () => vi.fn() }));

--- a/src/components/site/KbLayout.tsx
+++ b/src/components/site/KbLayout.tsx
@@ -37,6 +37,7 @@ import { cn } from "@/lib/utils";
 import logoAsset from "@/assets/UTS_JITSU_CMYK.png.asset.json";
 import { useAuth } from "@/hooks/useAuth";
 import { useKbNav } from "@/hooks/useKbNav";
+import { useKbArticlePrefetch } from "@/hooks/useKbArticle";
 import { readState } from "@/lib/kb-nav";
 import type { KbNavEntry, KbNavSection } from "@/lib/kb-nav";
 import { searchKnowledgeBase } from "@/lib/kb.functions";
@@ -134,6 +135,10 @@ function KbNavList({
   onRetry: () => void;
 }) {
   const location = useLocation();
+  // The sidebar knows what a reader is about to open before they click it, so
+  // the fetch starts on hover, on keyboard focus, or on the touch that precedes
+  // the tap. On a warm cache the article is simply there when the click lands.
+  const prefetchArticle = useKbArticlePrefetch();
 
   // Above everything, including the loading and empty states: the way out is
   // the one control that must never depend on a fetch landing. The top bar has
@@ -200,9 +205,10 @@ function KbNavList({
             {section.entries.map((entry) => {
               const active = location.pathname === `/kb/${entry.slug}`;
               // A link entry leaves the knowledge base for the marketing site,
-              // which is a different shell entirely — a plain anchor is the
-              // honest thing to render, and it saves a client-side route that
-              // would only bounce.
+              // which is a different shell entirely — but it is still this
+              // application, and `link_path` is validated site-relative
+              // (`kbLinkPathSchema`), so the router swaps the shell without the
+              // browser reloading everything to do it.
               const className = cn(
                 "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm transition-colors",
                 active
@@ -212,16 +218,19 @@ function KbNavList({
               return (
                 <li key={entry.slug}>
                   {entry.link_path ? (
-                    <a href={entry.link_path} className={className}>
+                    <Link to={entry.link_path} className={className}>
                       {entry.title}
                       <ExternalLink className="h-3 w-3 shrink-0 opacity-60" />
-                    </a>
+                    </Link>
                   ) : (
                     <Link
                       to="/kb/$slug"
                       params={{ slug: entry.slug }}
                       className={className}
                       aria-current={active ? "page" : undefined}
+                      onMouseEnter={() => prefetchArticle(entry.slug)}
+                      onFocus={() => prefetchArticle(entry.slug)}
+                      onTouchStart={() => prefetchArticle(entry.slug)}
                     >
                       {entry.title}
                       {/* Only a manager ever sees a managers-only entry, so
@@ -283,6 +292,7 @@ function KbSearch() {
   const [debounced, setDebounced] = useState("");
   const containerRef = useRef<HTMLDivElement>(null);
   const runSearch = useServerFn(searchKnowledgeBase);
+  const prefetchResult = useKbArticlePrefetch();
 
   useEffect(() => {
     const timer = setTimeout(() => setDebounced(term.trim()), 200);
@@ -369,14 +379,20 @@ function KbSearch() {
                 return (
                   <li key={result.slug}>
                     {result.link_path ? (
-                      <a href={result.link_path} className="block px-3 py-2 hover:bg-muted">
+                      <Link
+                        to={result.link_path}
+                        onClick={() => setOpen(false)}
+                        className="block px-3 py-2 hover:bg-muted"
+                      >
                         {body}
-                      </a>
+                      </Link>
                     ) : (
                       <Link
                         to="/kb/$slug"
                         params={{ slug: result.slug }}
                         onClick={() => setOpen(false)}
+                        onMouseEnter={() => prefetchResult(result.slug)}
+                        onFocus={() => prefetchResult(result.slug)}
                         className="block px-3 py-2 hover:bg-muted"
                       >
                         {body}

--- a/src/hooks/useKbArticle.test.tsx
+++ b/src/hooks/useKbArticle.test.tsx
@@ -18,7 +18,8 @@ vi.mock("@tanstack/react-start", () => ({ useServerFn: () => fetchArticle }));
 vi.mock("@/hooks/useAuth", () => ({ useAuth: () => auth }));
 vi.mock("@/lib/kb.functions", () => ({ getKbArticle: vi.fn() }));
 
-const { useKbArticle, useKbArticlePrefetch } = await import("./useKbArticle");
+const { useInvalidateKbReader, useKbArticle, useKbArticlePrefetch } =
+  await import("./useKbArticle");
 
 function harness() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -101,5 +102,30 @@ describe("useKbArticlePrefetch", () => {
 
     result.current("belts");
     await waitFor(() => expect(fetchArticle).not.toHaveBeenCalled());
+  });
+});
+
+describe("useInvalidateKbReader", () => {
+  // Nothing else connects the manager editor to the reader's cache: the editor
+  // keeps its own state and never goes through these queries. Without this, a
+  // manager who publishes a correction reads the version they just replaced
+  // for as long as the article stays fresh.
+  it("makes a cached article refetch", async () => {
+    const { client, wrapper } = harness();
+    const { result } = renderHook(
+      () => ({ article: useKbArticle("belts"), invalidate: useInvalidateKbReader() }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.article.data).toEqual(ARTICLE));
+    expect(fetchArticle).toHaveBeenCalledTimes(1);
+
+    const REWRITTEN = { ...ARTICLE, article: { slug: "belts", title: "Belts, rewritten" } };
+    fetchArticle.mockResolvedValue(REWRITTEN);
+    result.current.invalidate();
+
+    await waitFor(() => expect(result.current.article.data).toEqual(REWRITTEN));
+    // Invalidated, not removed: the reader refetches rather than blanking.
+    expect(client.getQueryData(["kb-article", "u1", "belts"])).toEqual(REWRITTEN);
   });
 });

--- a/src/hooks/useKbArticle.test.tsx
+++ b/src/hooks/useKbArticle.test.tsx
@@ -1,0 +1,105 @@
+// What the reader's copy of an article is cached under, and when it starts
+// being fetched.
+//
+// Both matter for a reason that is not obvious from the hook: articles are now
+// held for minutes rather than refetched on every mount, so the key is the only
+// thing keeping one reader's copy away from another's. A managers-only draft
+// cached under a bare `["kb-article", slug]` would still be on screen after a
+// sign-out in another tab.
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const fetchArticle = vi.fn();
+const auth = { user: { id: "u1" } as { id: string } | null, loading: false };
+
+vi.mock("@tanstack/react-start", () => ({ useServerFn: () => fetchArticle }));
+vi.mock("@/hooks/useAuth", () => ({ useAuth: () => auth }));
+vi.mock("@/lib/kb.functions", () => ({ getKbArticle: vi.fn() }));
+
+const { useKbArticle, useKbArticlePrefetch } = await import("./useKbArticle");
+
+function harness() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return { client, wrapper };
+}
+
+const ARTICLE = { article: { slug: "belts", title: "Belts" }, viewer: null, redirect_to: null };
+
+beforeEach(() => {
+  fetchArticle.mockReset();
+  fetchArticle.mockResolvedValue(ARTICLE);
+  auth.user = { id: "u1" };
+  auth.loading = false;
+});
+
+describe("useKbArticle", () => {
+  it("caches under a key scoped to the reader", async () => {
+    const { client, wrapper } = harness();
+    const { result } = renderHook(() => useKbArticle("belts"), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toEqual(ARTICLE));
+    expect(client.getQueryData(["kb-article", "u1", "belts"])).toEqual(ARTICLE);
+    // The unscoped key a second reader would have shared.
+    expect(client.getQueryData(["kb-article", "belts"])).toBeUndefined();
+  });
+
+  // The server resolves the reader from the request's bearer token, so asking
+  // before auth has settled reads a members-only article as a signed-out
+  // visitor and renders "not available to you" at somebody who is signed in.
+  it("waits for auth to settle before asking", async () => {
+    auth.loading = true;
+    const { wrapper } = harness();
+    renderHook(() => useKbArticle("belts"), { wrapper });
+
+    await waitFor(() => expect(fetchArticle).not.toHaveBeenCalled());
+  });
+});
+
+describe("useKbArticlePrefetch", () => {
+  // The point of the whole hook: the sidebar knows the slug before the click,
+  // so the click can land on an article that is already here.
+  it("fills the cache the article query then reads from", async () => {
+    const { client, wrapper } = harness();
+    const { result } = renderHook(() => useKbArticlePrefetch(), { wrapper });
+
+    result.current("belts");
+    await waitFor(() =>
+      expect(client.getQueryData(["kb-article", "u1", "belts"])).toEqual(ARTICLE),
+    );
+
+    // And the reader who now opens it does not pay for it a second time.
+    const { result: article } = renderHook(() => useKbArticle("belts"), { wrapper });
+    expect(article.current.data).toEqual(ARTICLE);
+    expect(fetchArticle).toHaveBeenCalledTimes(1);
+  });
+
+  // Safe to wire to `onMouseEnter`: a cursor running down the sidebar must not
+  // fire a request per pixel.
+  it("fetches an article at most once however often it is called", async () => {
+    const { client, wrapper } = harness();
+    const { result } = renderHook(() => useKbArticlePrefetch(), { wrapper });
+
+    result.current("belts");
+    result.current("belts");
+    await waitFor(() => expect(client.getQueryData(["kb-article", "u1", "belts"])).toBeDefined());
+    result.current("belts");
+
+    expect(fetchArticle).toHaveBeenCalledTimes(1);
+  });
+
+  // Caching the signed-out answer under the signed-in reader's key is the one
+  // failure this is not allowed to have.
+  it("does nothing until auth has settled", async () => {
+    auth.loading = true;
+    const { wrapper } = harness();
+    const { result } = renderHook(() => useKbArticlePrefetch(), { wrapper });
+
+    result.current("belts");
+    await waitFor(() => expect(fetchArticle).not.toHaveBeenCalled());
+  });
+});

--- a/src/hooks/useKbArticle.ts
+++ b/src/hooks/useKbArticle.ts
@@ -1,0 +1,92 @@
+// The knowledge base article query, in one place, so the page that reads an
+// article and the links that point at it agree about it.
+//
+// Two things live here that used to be inline in `routes/kb/$slug.tsx`:
+//
+//  * The QUERY KEY, which is scoped to the reader. The nav query has been keyed
+//    that way since it shipped (see `useKbNav` for the reasoning: a manager
+//    whose session ends with a tab open must not keep seeing managers-only
+//    drafts). Article bodies and comment threads are the same data, only more
+//    of it, and holding them under a bare `["kb-article", slug]` while they are
+//    cached for minutes at a time would leave a draft on screen after a sign-out
+//    in another tab.
+//  * PREFETCHING. The sidebar, the index and the previous/next links all know
+//    the slug a reader is about to open long before they click it, so the fetch
+//    can start on hover or on focus instead of after the click. On a warm cache
+//    the article is simply there, which is the difference between the knowledge
+//    base feeling like a set of pages and feeling like an app.
+import { useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useServerFn } from "@tanstack/react-start";
+import { useAuth } from "@/hooks/useAuth";
+import { getKbArticle } from "@/lib/kb.functions";
+
+/**
+ * How long a fetched article counts as fresh.
+ *
+ * Long enough that moving back and forth through a section costs nothing, short
+ * enough that a manager who has just published a correction sees it on the next
+ * article they open rather than at the end of the session. An article is
+ * versioned prose that changes a few times a year, so this errs long.
+ */
+export const KB_ARTICLE_STALE_TIME = 5 * 60_000;
+
+/** Everything the reader's copy of an article is cached under. */
+function articleQueryOptions<T>(
+  fetchArticle: (opts: { data: { slug: string } }) => Promise<T>,
+  userId: string | null,
+  slug: string,
+) {
+  return {
+    queryKey: ["kb-article", userId, slug],
+    queryFn: () => fetchArticle({ data: { slug } }),
+    staleTime: KB_ARTICLE_STALE_TIME,
+  };
+}
+
+/** The comment threads on an article, keyed by reader for the same reason. */
+export function kbAnnotationsQueryKey(userId: string | null, slug: string) {
+  return ["kb-annotations", userId, slug];
+}
+
+/**
+ * One article, once auth has settled.
+ *
+ * `enabled: !authLoading` because the server resolves the reader from the
+ * request's bearer token: asking too early reads a members-only article as a
+ * signed-out visitor and renders "not available to you" at somebody who is, in
+ * fact, signed in.
+ */
+export function useKbArticle(slug: string) {
+  const { user, loading: authLoading } = useAuth();
+  const fetchArticle = useServerFn(getKbArticle);
+  return useQuery({
+    ...articleQueryOptions(fetchArticle, user?.id ?? null, slug),
+    enabled: !authLoading,
+    retry: false,
+  });
+}
+
+/**
+ * Start fetching an article the reader has not clicked yet.
+ *
+ * Safe to call on every pointer move over a list: `prefetchQuery` is a no-op
+ * while the same key is already fresh or already in flight, so a reader running
+ * their cursor down the sidebar fetches each article at most once.
+ */
+export function useKbArticlePrefetch(): (slug: string) => void {
+  const { user, loading: authLoading } = useAuth();
+  const fetchArticle = useServerFn(getKbArticle);
+  const queryClient = useQueryClient();
+  const userId = user?.id ?? null;
+  return useCallback(
+    (slug: string) => {
+      // Prefetching before auth has settled would cache the signed-out answer
+      // under the signed-in reader's key, which is the one failure this is not
+      // allowed to have.
+      if (authLoading) return;
+      void queryClient.prefetchQuery(articleQueryOptions(fetchArticle, userId, slug));
+    },
+    [authLoading, fetchArticle, queryClient, userId],
+  );
+}

--- a/src/hooks/useKbArticle.ts
+++ b/src/hooks/useKbArticle.ts
@@ -41,6 +41,12 @@ function articleQueryOptions<T>(
     queryKey: ["kb-article", userId, slug],
     queryFn: () => fetchArticle({ data: { slug } }),
     staleTime: KB_ARTICLE_STALE_TIME,
+    // No retries, and here rather than on the observer so a PREFETCH obeys it
+    // too. The common failure is a refusal ("that article does not exist, or is
+    // not available to you"), which no amount of asking again will change, and
+    // a prefetch left retrying on the default backoff would hold a click in the
+    // loading state for seconds waiting for an answer that is already known.
+    retry: false,
   };
 }
 
@@ -63,7 +69,6 @@ export function useKbArticle(slug: string) {
   return useQuery({
     ...articleQueryOptions(fetchArticle, user?.id ?? null, slug),
     enabled: !authLoading,
-    retry: false,
   });
 }
 
@@ -89,4 +94,26 @@ export function useKbArticlePrefetch(): (slug: string) => void {
     },
     [authLoading, fetchArticle, queryClient, userId],
   );
+}
+
+/**
+ * Throw away everything the READER side has cached about the knowledge base.
+ *
+ * For the manager screen to call after it writes. Nothing else connects the
+ * two: the editor keeps its own state and never goes through these queries, so
+ * without this a manager who publishes a correction (or reorders the sidebar,
+ * or renames a section) would read the old version at `/kb/<slug>` until the
+ * five minutes above ran out. Cheap, and it is invalidation rather than
+ * removal, so a screen currently showing one of these refetches instead of
+ * blanking.
+ */
+export function useInvalidateKbReader(): () => void {
+  const queryClient = useQueryClient();
+  return useCallback(() => {
+    // Every reader's copy, not just this manager's: they are keyed by user id,
+    // and a manager holds at most one of them anyway.
+    for (const key of [["kb-article"], ["kb-nav"], ["kb-search"], ["kb-annotations"]]) {
+      void queryClient.invalidateQueries({ queryKey: key });
+    }
+  }, [queryClient]);
 }

--- a/src/hooks/useKbNav.ts
+++ b/src/hooks/useKbNav.ts
@@ -17,6 +17,11 @@ import { buildKbNav } from "@/lib/kb-nav";
 import type { KbNavSection } from "@/lib/kb-nav";
 import { listKnowledgeBase } from "@/lib/kb.functions";
 
+/**
+ * How long the fetched contents count as fresh. See the `staleTime` below.
+ */
+export const KB_NAV_STALE_TIME = 5 * 60_000;
+
 export function useKbNav(): {
   nav: KbNavSection[];
   loading: boolean;
@@ -42,6 +47,13 @@ export function useKbNav(): {
     // before auth has settled returns the signed-out view of the knowledge base
     // to a member who is signed in.
     enabled: !authLoading,
+    // The sidebar is on every page under /kb and its contents change when a
+    // manager publishes, which is a few times a year. Without this, React Query
+    // refetches the whole structure on every remount and every window focus, so
+    // a reader alt-tabbing back to an article they are part-way through paid for
+    // the nav again. `markKbArticleRead` invalidates this key when a tick needs
+    // to appear, so progress is still immediate.
+    staleTime: KB_NAV_STALE_TIME,
   });
 
   const nav = useMemo(

--- a/src/lib/kb-admin.test.ts
+++ b/src/lib/kb-admin.test.ts
@@ -11,6 +11,8 @@ import { describe, expect, it } from "vitest";
 import {
   deleteKbSection,
   listSharedAnnotations,
+  loadKbArticle,
+  loadKbArticleVersion,
   projectArticle,
   promoteArticleVersion,
   saveKbArticle,
@@ -696,5 +698,52 @@ describe("projectArticle", () => {
 
   it("reports an empty list for an article with no headings", () => {
     expect(projectArticle(loaded("Just prose.")).sections).toEqual([]);
+  });
+});
+
+describe("loadKbArticleVersion", () => {
+  const ARTICLE = { id: "a-1", slug: "belts", visibility: "members" } as unknown as KbArticleRow;
+  const VERSION = { article_id: "a-1", version: 3, is_current: true, body_md: "# Belts" };
+
+  /** Answer whichever table is being read, and record every read. */
+  const client = () => fakeClient((op) => (op.table === "kb_articles" ? ok(ARTICLE) : ok(VERSION)));
+
+  // The reader reads the article row first, to tell a link entry from a real
+  // page before it asks for any text. It then used to hand the SLUG to
+  // `loadKbArticle`, which read that same row a second time: a whole extra
+  // round trip to the database on the most-visited screen in the feature.
+  it("does not re-read the article row a caller already holds", async () => {
+    const { db, calls } = client();
+    const loaded = await loadKbArticleVersion(db, ARTICLE);
+
+    expect(loaded?.version).toEqual(VERSION);
+    expect(calls.filter((c) => c.table === "kb_articles")).toHaveLength(0);
+    expect(calls.filter((c) => c.table === "kb_article_versions")).toHaveLength(1);
+  });
+
+  it("asks for the live version by default and a named one when given it", async () => {
+    const live = client();
+    await loadKbArticleVersion(live.db, ARTICLE);
+    expect(live.calls[0].filters).toContainEqual(["is_current", true]);
+
+    const pinned = client();
+    await loadKbArticleVersion(pinned.db, ARTICLE, 2);
+    expect(pinned.calls[0].filters).toContainEqual(["version", 2]);
+    expect(pinned.calls[0].filters).not.toContainEqual(["is_current", true]);
+  });
+
+  // The by-slug path still reads both, and still reports "nothing to show" for
+  // an article with no live version (a half-failed save, or a link entry).
+  it("keeps loadKbArticle reading the row and then its version", async () => {
+    const { db, calls } = client();
+    const loaded = await loadKbArticle(db, "belts");
+
+    expect(loaded?.article).toEqual(ARTICLE);
+    expect(calls.map((c) => c.table)).toEqual(["kb_articles", "kb_article_versions"]);
+  });
+
+  it("returns null when the article has no version at all", async () => {
+    const { db } = fakeClient((op) => (op.table === "kb_articles" ? ok(ARTICLE) : ok(null)));
+    expect(await loadKbArticle(db, "belts")).toBeNull();
   });
 });

--- a/src/lib/kb-admin.ts
+++ b/src/lib/kb-admin.ts
@@ -469,7 +469,23 @@ export async function loadKbArticle(
 ): Promise<LoadedArticle | null> {
   const article = await loadKbArticleRow(db, slug);
   if (!article) return null;
+  return loadKbArticleVersion(db, article, version);
+}
 
+/**
+ * The version half of `loadKbArticle`, for a caller that already holds the row.
+ *
+ * The reader path reads the row first, to tell a link entry from an article
+ * before it asks for any text, and used to hand the slug to `loadKbArticle`
+ * afterwards — which fetched the same row a second time. That is a whole
+ * round trip to the database on the most-visited screen in the feature, for a
+ * row already in memory.
+ */
+export async function loadKbArticleVersion(
+  db: KbClient,
+  article: KbArticleRow,
+  version?: number,
+): Promise<LoadedArticle | null> {
   let query = db.from("kb_article_versions").select("*").eq("article_id", article.id);
   query = version === undefined ? query.eq("is_current", true) : query.eq("version", version);
   const { data: versionRow, error: verErr } = await query.maybeSingle();

--- a/src/lib/kb-markdown.test.tsx
+++ b/src/lib/kb-markdown.test.tsx
@@ -22,7 +22,12 @@ vi.mock("@tanstack/react-router", () => ({
   ),
 }));
 
-import { internalLinkTarget, kbMarkdownComponents, kbRemarkPlugins } from "./kb-markdown";
+import {
+  internalLinkTarget,
+  kbMarkdownComponents,
+  kbRemarkPlugins,
+  staysInThisTab,
+} from "./kb-markdown";
 
 function renderMarkdown(markdown: string) {
   return render(<ReactMarkdown components={kbMarkdownComponents}>{markdown}</ReactMarkdown>);
@@ -82,6 +87,29 @@ describe("kbMarkdownComponents", () => {
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
+
+  // `/\host` is the same off-site URL wearing a different hat, because a browser
+  // normalises the backslash to a slash before resolving it. It cannot arrive
+  // that way through an article: react-markdown percent-encodes the backslash
+  // first, and `%5C` is an ordinary path character no browser re-reads as an
+  // authority. Pinned because that is the only thing standing between the two,
+  // and `internalLinkTarget` refuses the raw form regardless.
+  it("cannot be handed a backslash-authority URL by markdown at all", () => {
+    renderMarkdown("[Also not us](/\\example.com/phish)");
+    expect(screen.getByRole("link", { name: "Also not us" })).toHaveAttribute(
+      "href",
+      "/%5Cexample.com/phish",
+    );
+  });
+
+  // The router will not take a query string as a bare `to`, but this is still
+  // a page on this site: opening it in a new tab would be wrong.
+  it("keeps a same-site path with a query string in the tab", () => {
+    renderMarkdown("[Tuesday](/classes?day=tue)");
+    const link = screen.getByRole("link", { name: "Tuesday" });
+    expect(link).not.toHaveAttribute("data-router-link");
+    expect(link).not.toHaveAttribute("target");
+  });
 });
 
 describe("internalLinkTarget", () => {
@@ -93,6 +121,7 @@ describe("internalLinkTarget", () => {
 
   it("refuses anything that is not a plain same-site path", () => {
     expect(internalLinkTarget("//example.com")).toBeNull();
+    expect(internalLinkTarget("/\\example.com")).toBeNull();
     expect(internalLinkTarget("https://example.com")).toBeNull();
     expect(internalLinkTarget("mailto:hello@example.com")).toBeNull();
     expect(internalLinkTarget("#fees")).toBeNull();
@@ -100,6 +129,22 @@ describe("internalLinkTarget", () => {
     // no article has ever needed one.
     expect(internalLinkTarget("/classes?day=tue")).toBeNull();
     expect(internalLinkTarget(undefined)).toBeNull();
+  });
+});
+
+describe("staysInThisTab", () => {
+  it("is true for this site, whether or not the router can take it", () => {
+    expect(staysInThisTab("/kb/belts")).toBe(true);
+    expect(staysInThisTab("/classes?day=tue")).toBe(true);
+    expect(staysInThisTab("#fees")).toBe(true);
+  });
+
+  it("is false for a destination that is not this site", () => {
+    expect(staysInThisTab("https://example.com")).toBe(false);
+    expect(staysInThisTab("//example.com")).toBe(false);
+    expect(staysInThisTab("/\\example.com")).toBe(false);
+    expect(staysInThisTab("mailto:hello@example.com")).toBe(false);
+    expect(staysInThisTab(undefined)).toBe(false);
   });
 
   // The table styling in this map is only reachable through `kbRemarkPlugins`,

--- a/src/lib/kb-markdown.test.tsx
+++ b/src/lib/kb-markdown.test.tsx
@@ -1,7 +1,28 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import ReactMarkdown from "react-markdown";
-import { kbMarkdownComponents, kbRemarkPlugins } from "./kb-markdown";
+
+// Article bodies link to other articles constantly, and those links go through
+// the ROUTER now rather than the browser. Stood in for here, marked so a test
+// can tell a router link from a plain anchor.
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    to,
+    hash,
+    children,
+    ...props
+  }: {
+    to: string;
+    hash?: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={hash ? `${to}#${hash}` : to} data-router-link="" {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { internalLinkTarget, kbMarkdownComponents, kbRemarkPlugins } from "./kb-markdown";
 
 function renderMarkdown(markdown: string) {
   return render(<ReactMarkdown components={kbMarkdownComponents}>{markdown}</ReactMarkdown>);
@@ -30,6 +51,55 @@ describe("kbMarkdownComponents", () => {
     renderMarkdown("[Belt system](/kb/belt-system) and [Activate](https://example.com)");
     expect(screen.getByRole("link", { name: "Belt system" })).not.toHaveAttribute("target");
     expect(screen.getByRole("link", { name: "Activate" })).toHaveAttribute("target", "_blank");
+  });
+
+  // The bug this fixes: every cross-reference between two articles was a full
+  // page load. The reader lost their place, the bundle and the sidebar were
+  // fetched again, and moving one page cost what opening the site costs.
+  it("follows a link to another article through the router, not the browser", () => {
+    renderMarkdown("See the [belt system](/kb/belt-system#grading).");
+    const link = screen.getByRole("link", { name: "belt system" });
+    expect(link).toHaveAttribute("data-router-link");
+    expect(link).toHaveAttribute("href", "/kb/belt-system#grading");
+  });
+
+  // A fragment names a heading in the article already on screen. The reader
+  // page listens for `hashchange` to jump to it, so it stays a plain anchor.
+  it("leaves a fragment as a plain anchor", () => {
+    renderMarkdown("Jump to [fees](#fees).");
+    const link = screen.getByRole("link", { name: "fees" });
+    expect(link).not.toHaveAttribute("data-router-link");
+    expect(link).not.toHaveAttribute("target");
+  });
+
+  // `//host` is a protocol-relative URL to somebody else's site. The old test
+  // for "internal" was `/^[/#]/`, which read it as a path and rendered it
+  // same-tab with no `rel="noopener"` on it.
+  it("treats a protocol-relative URL as leaving the site", () => {
+    renderMarkdown("[Not us](//example.com/phish)");
+    const link = screen.getByRole("link", { name: "Not us" });
+    expect(link).not.toHaveAttribute("data-router-link");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});
+
+describe("internalLinkTarget", () => {
+  it("splits a path from its fragment", () => {
+    expect(internalLinkTarget("/kb/belts")).toEqual({ to: "/kb/belts" });
+    expect(internalLinkTarget("/kb/belts#grading")).toEqual({ to: "/kb/belts", hash: "grading" });
+    expect(internalLinkTarget("/")).toEqual({ to: "/" });
+  });
+
+  it("refuses anything that is not a plain same-site path", () => {
+    expect(internalLinkTarget("//example.com")).toBeNull();
+    expect(internalLinkTarget("https://example.com")).toBeNull();
+    expect(internalLinkTarget("mailto:hello@example.com")).toBeNull();
+    expect(internalLinkTarget("#fees")).toBeNull();
+    // A typed `search` object is what the router wants for a query string, and
+    // no article has ever needed one.
+    expect(internalLinkTarget("/classes?day=tue")).toBeNull();
+    expect(internalLinkTarget(undefined)).toBeNull();
   });
 
   // The table styling in this map is only reachable through `kbRemarkPlugins`,

--- a/src/lib/kb-markdown.tsx
+++ b/src/lib/kb-markdown.tsx
@@ -35,16 +35,42 @@ import { remarkKbTables } from "@/lib/remark-kb-tables";
  * Returns null for anything that is not a plain same-site path, including a
  * fragment (which belongs to the page already on screen) and a path carrying a
  * query string (a typed `search` object is what the router wants there, and no
- * article has ever needed one).
+ * article has ever needed one). Those two still stay in the tab: see
+ * `staysInThisTab`.
  */
 export function internalLinkTarget(href: string | undefined): { to: string; hash?: string } | null {
-  if (typeof href !== "string") return null;
-  // One leading slash, and no `?`: `//host` and `/a?b=c` both fall through to
-  // the plain-anchor branch below.
-  const match = /^\/(?!\/)([^?#]*)(#(.*))?$/.exec(href);
+  if (!isSameSitePath(href)) return null;
+  // No `?`: a path carrying a query string falls through to a plain anchor.
+  const match = /^(\/[^?#]*)(#(.*))?$/.exec(href);
   if (!match) return null;
   const hash = match[3];
-  return { to: `/${match[1]}`, ...(hash ? { hash } : {}) };
+  return { to: match[1], ...(hash ? { hash } : {}) };
+}
+
+/**
+ * A path on this site, as opposed to a URL that only looks like one.
+ *
+ * The second character is what decides it, and both spellings matter. `//host`
+ * is a protocol-relative URL to somebody else's site; so is `/\host`, because a
+ * browser normalises the backslash to a slash before resolving it. Either one
+ * rendered as a same-tab link with no `rel="noopener"` is the hole this
+ * function exists to close.
+ */
+function isSameSitePath(href: string | undefined): href is string {
+  return typeof href === "string" && /^\/(?![/\\])/.test(href);
+}
+
+/**
+ * Whether following this link keeps the reader where they are.
+ *
+ * Wider than `internalLinkTarget`: a fragment names a heading on this page, and
+ * a same-site path with a query string is still this site even though the
+ * router will not take it as a bare string. Both are same-tab links; only a
+ * genuinely outside destination earns a new tab.
+ */
+export function staysInThisTab(href: string | undefined): boolean {
+  if (typeof href !== "string") return false;
+  return href.startsWith("#") || isSameSitePath(href);
 }
 
 /**
@@ -107,15 +133,15 @@ export const kbMarkdownComponents: Components = {
       );
     }
 
-    // A fragment stays in the tab and stays a plain anchor: it names a heading
-    // in the article already on screen, and the reader page listens for
-    // `hashchange` to jump to it. Anything else is leaving the site and gets
-    // the new-tab treatment.
-    const fragment = typeof href === "string" && href.startsWith("#");
+    // Everything the router cannot take as a bare string. A fragment names a
+    // heading in the article already on screen, and the reader page listens for
+    // `hashchange` to jump to it; a same-site path with a query string is still
+    // this site. Both stay in the tab. Anything else is leaving, and gets the
+    // new-tab treatment.
     return (
       <a
         href={href}
-        {...(fragment ? {} : { target: "_blank", rel: "noopener noreferrer" })}
+        {...(staysInThisTab(href) ? {} : { target: "_blank", rel: "noopener noreferrer" })}
         className={className}
       >
         {children}

--- a/src/lib/kb-markdown.tsx
+++ b/src/lib/kb-markdown.tsx
@@ -15,9 +15,37 @@
 // Heading levels are shifted down by one — a body `#` renders as an `<h2>` — so
 // a manager's markdown never produces a second `<h1>` competing with the page's
 // own title, keeping the heading outline correct for assistive tech.
+import { Link } from "@tanstack/react-router";
 import type { Components } from "react-markdown";
 import { remarkKbAnchors } from "@/lib/remark-kb-anchors";
 import { remarkKbTables } from "@/lib/remark-kb-tables";
+
+/**
+ * Where a link in an article body points, when it points somewhere on this site.
+ *
+ * Split out and exported because getting it wrong is expensive in both
+ * directions. Too narrow and a cross-reference between two articles reloads the
+ * whole application to move one page (the sidebar, the shell, the router and
+ * every bundle again, on a phone, mid-class) — which is exactly what club
+ * articles do most. Too wide and `//evil.example` reads as "a path", which is a
+ * protocol-relative URL to another host: the old test for an internal link was
+ * `/^[/#]/`, so that one was rendered as a same-tab link with no
+ * `rel="noopener"` on it.
+ *
+ * Returns null for anything that is not a plain same-site path, including a
+ * fragment (which belongs to the page already on screen) and a path carrying a
+ * query string (a typed `search` object is what the router wants there, and no
+ * article has ever needed one).
+ */
+export function internalLinkTarget(href: string | undefined): { to: string; hash?: string } | null {
+  if (typeof href !== "string") return null;
+  // One leading slash, and no `?`: `//host` and `/a?b=c` both fall through to
+  // the plain-anchor branch below.
+  const match = /^\/(?!\/)([^?#]*)(#(.*))?$/.exec(href);
+  if (!match) return null;
+  const hash = match[3];
+  return { to: `/${match[1]}`, ...(hash ? { hash } : {}) };
+}
 
 /**
  * The remark plugins every knowledge base rendering surface uses: the reader,
@@ -63,16 +91,32 @@ export const kbMarkdownComponents: Components = {
   ol: ({ children }) => <ol className="mb-4 ml-6 list-decimal space-y-1.5">{children}</ol>,
   li: ({ children }) => <li className="leading-relaxed text-foreground">{children}</li>,
   a: ({ children, href }) => {
-    // A path or a fragment stays in the tab; anything else is leaving the site
-    // and gets the new-tab treatment. Club articles cross-reference each other
-    // constantly, and opening a new tab for every one of those is how a reader
-    // ends up with fifteen.
-    const internal = typeof href === "string" && /^[/#]/.test(href);
+    const className = "break-words text-primary underline underline-offset-2 hover:no-underline";
+
+    // A same-site path goes through the ROUTER, not the browser. A club article
+    // links to another club article constantly, and rendering those as bare
+    // anchors made every one of them a full page load: blank screen, the whole
+    // bundle again, auth resolved again, the sidebar fetched again, and the
+    // reader's place in the knowledge base thrown away to move one page.
+    const target = internalLinkTarget(href);
+    if (target) {
+      return (
+        <Link {...target} className={className}>
+          {children}
+        </Link>
+      );
+    }
+
+    // A fragment stays in the tab and stays a plain anchor: it names a heading
+    // in the article already on screen, and the reader page listens for
+    // `hashchange` to jump to it. Anything else is leaving the site and gets
+    // the new-tab treatment.
+    const fragment = typeof href === "string" && href.startsWith("#");
     return (
       <a
         href={href}
-        {...(internal ? {} : { target: "_blank", rel: "noopener noreferrer" })}
-        className="break-words text-primary underline underline-offset-2 hover:no-underline"
+        {...(fragment ? {} : { target: "_blank", rel: "noopener noreferrer" })}
+        className={className}
       >
         {children}
       </a>

--- a/src/lib/kb.functions.ts
+++ b/src/lib/kb.functions.ts
@@ -28,6 +28,7 @@ import {
   listSharedAnnotations,
   loadKbArticle,
   loadKbArticleRow,
+  loadKbArticleVersion,
   projectArticle,
 } from "@/lib/kb-admin";
 import type { KbAnnotationRow, KbArticleRow, KbClient, KbSectionRow } from "@/lib/kb-types";
@@ -183,22 +184,28 @@ export const getKbArticle = createServerFn({ method: "POST" })
   .inputValidator((d: unknown) => readKbArticleSchema.parse(d))
   .handler(async ({ data }) => {
     const db = await adminClient();
-    const viewer = await resolveViewer(db);
+
+    // Both at once. Working out who is asking costs two round trips of its own
+    // (the token, then `has_role`) and the answer is not needed until the row
+    // is in hand, so waiting for it first put the whole identity lookup in
+    // front of every article read for nothing.
+    const [viewer, row] = await Promise.all([resolveViewer(db), loadKbArticleRow(db, data.slug)]);
+    if (!row) throw new Error(NOT_FOUND);
+    if (!canReadArticle(row.visibility, viewer)) throw new Error(NOT_FOUND);
 
     // A link entry has no text of its own, so `/kb/<slug>` for one is a
     // signpost rather than a page. The sidebar already points straight at the
     // destination; this path exists for a link somebody saved or shared before
     // the entry became a redirect, and it bounces them rather than showing a
     // "not available" page for something that plainly is.
-    const row = await loadKbArticleRow(db, data.slug);
-    if (row?.link_path) {
-      if (!canReadArticle(row.visibility, viewer)) throw new Error(NOT_FOUND);
+    if (row.link_path) {
       return { redirect_to: row.link_path, article: null, viewer: null };
     }
 
-    const loaded = await loadKbArticle(db, data.slug);
+    // `loadKbArticleVersion`, not `loadKbArticle`: the row is already here, and
+    // asking by slug again would re-read it.
+    const loaded = await loadKbArticleVersion(db, row);
     if (!loaded) throw new Error(NOT_FOUND);
-    if (!canReadArticle(loaded.article.visibility, viewer)) throw new Error(NOT_FOUND);
 
     return {
       redirect_to: null,
@@ -223,9 +230,13 @@ export const getKbArticle = createServerFn({ method: "POST" })
  */
 export const listKnowledgeBase = createServerFn({ method: "GET" }).handler(async () => {
   const db = await adminClient();
-  const viewer = await resolveViewer(db);
 
-  const [sectionsResult, articlesResult] = await Promise.all([
+  // Who is asking runs ALONGSIDE the two list queries rather than in front of
+  // them. It is two round trips of its own (the token, then `has_role`) and
+  // nothing below needs the answer until both lists are back, so making the
+  // sidebar wait for it added that latency to every page of the knowledge base.
+  const [viewer, sectionsResult, articlesResult] = await Promise.all([
+    resolveViewer(db),
     db.from("kb_sections").select("id, slug, title, position"),
     db
       .from("kb_articles")
@@ -255,39 +266,45 @@ export const listKnowledgeBase = createServerFn({ method: "GET" }).handler(async
   // version at all, so they are excluded from the lookup and take their label
   // from `nav_title`, which the schema requires them to have.
   const needVersions = readable.filter((a) => !a.link_path);
+  const versionIds = needVersions.map((a) => a.id);
+
+  // The titles and this reader's progress are two independent lookups over the
+  // same set of ids, so they go out together rather than one after the other.
+  // With the identity lookup moved alongside the lists above, building the
+  // sidebar is now two waits deep instead of five.
+  const [versionsResult, readsResult] = await Promise.all([
+    versionIds.length
+      ? db
+          .from("kb_article_versions")
+          .select("article_id, title, version, created_at")
+          .in("article_id", versionIds)
+          .eq("is_current", true)
+      : null,
+    // Nobody else's reads are ever fetched: the filter is `user_id`, so there
+    // is no shape of downstream bug that could show one member another member's
+    // progress.
+    viewer.userId && versionIds.length
+      ? db
+          .from("kb_article_reads")
+          .select("article_id, version")
+          .eq("user_id", viewer.userId)
+          .in("article_id", versionIds)
+      : null,
+  ]);
+
   let liveByArticle = new Map<string, { title: string; version: number; created_at: string }>();
-  if (needVersions.length) {
-    const { data: versions, error: vErr } = await db
-      .from("kb_article_versions")
-      .select("article_id, title, version, created_at")
-      .in(
-        "article_id",
-        needVersions.map((a) => a.id),
-      )
-      .eq("is_current", true);
-    if (vErr) throw new Error(vErr.message);
-    liveByArticle = new Map((versions ?? []).map((v) => [v.article_id, v]));
+  if (versionsResult) {
+    if (versionsResult.error) throw new Error(versionsResult.error.message);
+    liveByArticle = new Map((versionsResult.data ?? []).map((v) => [v.article_id, v]));
   }
 
-  // What this reader has already read. One query for the whole knowledge base,
-  // on the same call that builds the sidebar, so a tick costs no extra round
-  // trip. Nobody else's reads are ever fetched: the filter is `user_id`, so
-  // there is no shape of downstream bug that could show one member another
-  // member's progress.
   let readByArticle = new Map<string, number>();
-  if (viewer.userId && needVersions.length) {
-    const { data: reads, error: rErr } = await db
-      .from("kb_article_reads")
-      .select("article_id, version")
-      .eq("user_id", viewer.userId)
-      .in(
-        "article_id",
-        needVersions.map((a) => a.id),
-      );
+  if (readsResult) {
     // Progress is decoration on a page that works without it, so a failure here
     // shows everything as unread rather than taking the sidebar down with it.
-    if (rErr) console.warn("[kb] could not read this member's progress:", rErr.message);
-    else readByArticle = new Map((reads ?? []).map((r) => [r.article_id, r.version]));
+    if (readsResult.error)
+      console.warn("[kb] could not read this member's progress:", readsResult.error.message);
+    else readByArticle = new Map((readsResult.data ?? []).map((r) => [r.article_id, r.version]));
   }
 
   const entries = readable
@@ -534,6 +551,28 @@ async function requireReadableArticle(db: KbClient, slug: string, viewer: Viewer
 }
 
 /**
+ * The same check as `requireReadableArticle`, for a caller that needs the
+ * article ROW and nothing else.
+ *
+ * `requireReadableArticle` reads the live version too, which means the whole
+ * markdown body over the wire: fine when the body is what is being returned,
+ * pure waste when all that is wanted is `article.id` to filter comments by. A
+ * link entry is refused here explicitly, because it is only the missing version
+ * row that refuses it in the heavier check.
+ *
+ * The one case this is softer on: an article whose save half-failed, so it has
+ * no live version. `requireReadableArticle` calls that "not available"; this
+ * lists the comments on it, filtered by the same visibility rules as any other
+ * article's. Nothing reads them, because the page that would show them has
+ * already failed to load the text they hang off.
+ */
+function checkReadableArticleRow(article: KbArticleRow | null, viewer: Viewer) {
+  if (!article || article.link_path) throw new Error(NOT_FOUND);
+  if (!canReadArticle(article.visibility, viewer)) throw new Error(NOT_FOUND);
+  return article;
+}
+
+/**
  * Display names for a set of authors, so member-facing comments are not
  * signed with UUIDs.
  *
@@ -602,13 +641,17 @@ export const listAnnotations = createServerFn({ method: "POST" })
   .inputValidator((d: unknown) => z.object({ slug: kbSlugSchema }).parse(d))
   .handler(async ({ data }) => {
     const db = await adminClient();
-    const viewer = await resolveViewer(db);
-    const loaded = await requireReadableArticle(db, data.slug, viewer);
+    // The viewer lookup and the article row are independent, so they go out
+    // together: this call runs beside the article fetch on every page of the
+    // knowledge base, and it used to put its own identity round trips in front
+    // of the first query rather than beside it.
+    const [viewer, row] = await Promise.all([resolveViewer(db), loadKbArticleRow(db, data.slug)]);
+    const article = checkReadableArticleRow(row, viewer);
 
     let query = db
       .from("kb_annotations")
       .select("*")
-      .eq("article_id", loaded.article.id)
+      .eq("article_id", article.id)
       .order("created_at", { ascending: true })
       .limit(ANNOTATIONS_LIMIT);
     const filter = annotationReadFilter(viewer);

--- a/src/lib/remark-kb-tables.test.tsx
+++ b/src/lib/remark-kb-tables.test.tsx
@@ -1,6 +1,27 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import ReactMarkdown from "react-markdown";
+
+// Article bodies link to other articles constantly, and those links go through
+// the ROUTER now rather than the browser. Stood in for here, marked so a test
+// can tell a router link from a plain anchor.
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    to,
+    hash,
+    children,
+    ...props
+  }: {
+    to: string;
+    hash?: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={hash ? `${to}#${hash}` : to} data-router-link="" {...props}>
+      {children}
+    </a>
+  ),
+}));
+
 import { kbMarkdownComponents } from "./kb-markdown";
 import { remarkKbTables } from "./remark-kb-tables";
 

--- a/src/routes/_authenticated/manager.kb.test.tsx
+++ b/src/routes/_authenticated/manager.kb.test.tsx
@@ -91,6 +91,9 @@ const stray = {
   nav_title: null,
 };
 
+// Every write here drops the reader side's cached articles and sidebar. That
+// needs a query client, which this suite renders without.
+vi.mock("@/hooks/useKbArticle", () => ({ useInvalidateKbReader: () => vi.fn() }));
 vi.mock("@/lib/kb.functions", () => ({
   listManagerArticles: () => Promise.resolve([article, houseRules, syllabus, firstClass, stray]),
   listManagerSections: () =>

--- a/src/routes/_authenticated/manager.kb.tsx
+++ b/src/routes/_authenticated/manager.kb.tsx
@@ -69,6 +69,7 @@ import {
   setCurrentArticleVersion,
 } from "@/lib/kb.functions";
 import { kbMarkdownComponents, kbRemarkPlugins } from "@/lib/kb-markdown";
+import { useInvalidateKbReader } from "@/hooks/useKbArticle";
 import { articleVisibilities, visibilityAudience } from "@/lib/kb";
 import { discardUnsavedChanges, useConfirm } from "@/hooks/use-confirm";
 import type { ArticleVisibility } from "@/lib/kb";
@@ -262,6 +263,10 @@ function KnowledgeBaseManager() {
   const [promoting, setPromoting] = useState(false);
   const [busy, setBusy] = useState(false);
   const { confirm, confirmDialog } = useConfirm();
+  // Called after every write here. The reader side caches articles and the
+  // sidebar for minutes at a time, and this screen is the only thing that
+  // changes what they hold.
+  const invalidateKbReader = useInvalidateKbReader();
 
   /**
    * The arrangement a drag is producing, held while it is in flight and until
@@ -775,6 +780,12 @@ function KnowledgeBaseManager() {
             ? `Created "${targetSlug}" and published version ${res.version}`
             : `Saved version ${res.version}, now live`,
       );
+      // What members are reading has just changed, so drop the reader side's
+      // cached copies. This screen keeps its own state and never goes through
+      // those queries, so nothing else would: the manager who opens
+      // `/kb/<slug>` to check their correction would otherwise read the version
+      // they have just replaced.
+      invalidateKbReader();
       // The save landed either way, so it is reported. But if the manager has
       // since opened a different article, writing this one's text back into the
       // editor would put the screen out of step with itself.
@@ -842,6 +853,8 @@ function KnowledgeBaseManager() {
     try {
       await promote({ data: { id: version.id } });
       toast.success(`Version ${version.version} is now live`);
+      // A different version is what members read now. See `onSave`.
+      invalidateKbReader();
       // The publish has already committed. Reporting a failed REFRESH as a
       // failed publish would tell the manager the club's live article is
       // something it is not, so the refresh gets its own try. (`onSave` learned
@@ -895,6 +908,8 @@ function KnowledgeBaseManager() {
    * manager the MOVE failed would have them do it again and move it twice.
    */
   async function refreshStructure(token: number) {
+    // The reading order a member sees is what just moved. See `onSave`.
+    invalidateKbReader();
     try {
       const [rows, sectionRows] = await Promise.all([fetchArticles(), fetchSections()]);
       if (stale(token)) return;

--- a/src/routes/kb/$slug.test.tsx
+++ b/src/routes/kb/$slug.test.tsx
@@ -17,6 +17,13 @@ vi.mock("@tanstack/react-router", () => ({
     useParams: () => ({ slug: "belts" }),
   }),
   Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+  useNavigate: () => vi.fn(),
+  // The page reads the fragment from the router as well as from the browser,
+  // because a cross-reference between two articles is a router navigation now
+  // and those fire no `hashchange`. These tests set `window.location.hash`
+  // directly, so the router's view of it is empty throughout.
+  useRouterState: ({ select }: { select: (s: unknown) => unknown }) =>
+    select({ location: { hash: "" } }),
 }));
 
 vi.mock("@tanstack/react-start", () => ({
@@ -29,6 +36,13 @@ vi.mock("@/hooks/useAuth", () => ({
 
 vi.mock("@/hooks/useKbNav", () => ({
   useKbNav: () => ({ nav: [], loading: false }),
+}));
+
+vi.mock("@/hooks/useKbArticle", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  // The real hook, so the fetch is exercised, but without the prefetching the
+  // sidebar drives: there is no sidebar in this render.
+  useKbArticlePrefetch: () => vi.fn(),
 }));
 
 const BODY = [

--- a/src/routes/kb/$slug.test.tsx
+++ b/src/routes/kb/$slug.test.tsx
@@ -7,6 +7,7 @@
 // of the fix — the jump once the text is there, and what a reader is told when
 // the section has been renamed away since the link was written.
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
@@ -18,12 +19,6 @@ vi.mock("@tanstack/react-router", () => ({
   }),
   Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
   useNavigate: () => vi.fn(),
-  // The page reads the fragment from the router as well as from the browser,
-  // because a cross-reference between two articles is a router navigation now
-  // and those fire no `hashchange`. These tests set `window.location.hash`
-  // directly, so the router's view of it is empty throughout.
-  useRouterState: ({ select }: { select: (s: unknown) => unknown }) =>
-    select({ location: { hash: "" } }),
 }));
 
 vi.mock("@tanstack/react-start", () => ({
@@ -133,6 +128,28 @@ describe("/kb/$slug section anchors", () => {
 
     expect(await screen.findByText(/does not have/i)).toBeInTheDocument();
     expect(screen.getByText("#throws")).toBeInTheDocument();
+  });
+
+  // A cross-reference between two articles is a ROUTER navigation, and the
+  // browser fires no `hashchange` for one. The page therefore re-reads the
+  // fragment after every render rather than waiting for an event, which is the
+  // only thing that catches a router navigation that changes only the hash.
+  it("follows the fragment when it changes without a hashchange event", async () => {
+    renderArticle("");
+
+    // The article is on screen, at the top, with no section asked for.
+    await waitFor(() => expect(document.getElementById("grading")).not.toBeNull());
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+
+    // What a router navigation does: the URL changes, and no event is fired.
+    // Something unrelated then re-renders the page, the way any state change on
+    // it would.
+    window.location.hash = "#grading";
+    await userEvent.click(screen.getByRole("button", { name: /on this page/i }));
+
+    // Scrolling is the assertion; focus is covered by the first test and would
+    // race the click that caused this render.
+    await waitFor(() => expect(Element.prototype.scrollIntoView).toHaveBeenCalled());
   });
 
   // A notification about a comment sends the member to /kb/<slug>#comment-<id>.

--- a/src/routes/kb/$slug.tsx
+++ b/src/routes/kb/$slug.tsx
@@ -11,7 +11,7 @@
 // Rendered client-side rather than in the loader: the annotation layer needs to
 // know who is reading, and the reader's bearer token reaches a server function
 // through `attachSupabaseAuth` on an RPC from the browser, not during SSR.
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -32,10 +32,10 @@ import { KbArticleReader } from "@/components/site/KbArticleReader";
 import { Loading } from "@/components/site/Loading";
 import type { NewAnnotation } from "@/components/site/KbArticleReader";
 import { useKbNav } from "@/hooks/useKbNav";
+import { kbAnnotationsQueryKey, useKbArticle, useKbArticlePrefetch } from "@/hooks/useKbArticle";
 import {
   createAnnotation,
   deleteAnnotation,
-  getKbArticle,
   listAnnotations,
   markKbArticleRead,
   resolveAnnotation,
@@ -65,11 +65,12 @@ export const Route = createFileRoute("/kb/$slug")({
 
 function ArticlePage() {
   const { slug } = Route.useParams();
-  const { loading: authLoading } = useAuth();
+  const { user, loading: authLoading } = useAuth();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const { nav } = useKbNav();
+  const prefetchArticle = useKbArticlePrefetch();
 
-  const fetchArticle = useServerFn(getKbArticle);
   const fetchAnnotations = useServerFn(listAnnotations);
   const create = useServerFn(createAnnotation);
   const update = useServerFn(updateAnnotation);
@@ -78,34 +79,34 @@ function ArticlePage() {
 
   const [busy, setBusy] = useState(false);
 
-  // Wait for auth to settle before asking. The server resolves the reader from
-  // the request's bearer token, so asking too early reads a members-only article
-  // as a signed-out visitor and renders "not available to you" at somebody who
-  // is, in fact, signed in.
-  const articleQ = useQuery({
-    queryKey: ["kb-article", slug],
-    queryFn: () => fetchArticle({ data: { slug } }),
-    enabled: !authLoading,
-    retry: false,
-  });
+  const articleQ = useKbArticle(slug);
 
   const article = articleQ.data?.article ?? null;
   const viewer = articleQ.data?.viewer ?? null;
   const redirectTo = articleQ.data?.redirect_to ?? null;
 
+  // Alongside the article, not after it. This used to wait for the article to
+  // arrive, which made two slow round trips into one slow round trip followed by
+  // another: the comments could not start until the text had landed, even though
+  // all they need is the slug the router already has. They are also the reason
+  // the comment rail arrived late on a page that otherwise looked finished.
   const annotationsQ = useQuery({
-    queryKey: ["kb-annotations", slug],
+    queryKey: kbAnnotationsQueryKey(user?.id ?? null, slug),
     queryFn: () => fetchAnnotations({ data: { slug } }),
-    enabled: !authLoading && Boolean(article),
+    enabled: !authLoading,
+    // A link entry has no comments and no article, so this call refuses it.
+    // Retrying that is a wasted round trip on a page that is about to redirect.
+    retry: false,
   });
 
   // A link entry has no page of its own. The sidebar sends readers straight to
   // the destination, so this only fires for a URL somebody saved or shared
-  // before the entry became a link. A full navigation rather than a router push:
-  // the destination lives outside this shell, under the marketing chrome.
+  // before the entry became a link. `link_path` is validated site-relative
+  // (`kbLinkPathSchema`), so the router can do it without reloading the app,
+  // and `replace` keeps the signpost out of the back button.
   useEffect(() => {
-    if (redirectTo) window.location.replace(redirectTo);
-  }, [redirectTo]);
+    if (redirectTo) void navigate({ to: redirectTo, replace: true });
+  }, [redirectTo, navigate]);
 
   const headings = useMemo(() => (article ? extractHeadings(article.body_md) : []), [article]);
 
@@ -123,12 +124,17 @@ function ArticlePage() {
   const [hash, setHash] = useState(() =>
     typeof window === "undefined" ? "" : window.location.hash,
   );
+  // The router's own view of the fragment. A cross-reference between articles is
+  // a router navigation now, not a browser one, and the browser fires no
+  // `hashchange` for those: without this, following `/kb/belts#fees` from
+  // somewhere else in the knowledge base would land at the top of the article.
+  const routerHash = useRouterState({ select: (state) => state.location.hash });
   useEffect(() => {
     const sync = () => setHash(window.location.hash);
     sync();
     window.addEventListener("hashchange", sync);
     return () => window.removeEventListener("hashchange", sync);
-  }, [slug]);
+  }, [slug, routerHash]);
 
   const target = useMemo(() => findHeadingForHash(hash, headings), [hash, headings]);
   /** What the reader asked for, when it is worth saying the section is gone. */
@@ -206,7 +212,7 @@ function ArticlePage() {
   }, [slug, article?.version, viewer?.signed_in, markRead, queryClient]);
 
   const refreshAnnotations = () =>
-    queryClient.invalidateQueries({ queryKey: ["kb-annotations", slug] });
+    queryClient.invalidateQueries({ queryKey: kbAnnotationsQueryKey(user?.id ?? null, slug) });
 
   /**
    * Run a write, refresh the thread list, and report failures in words.
@@ -233,7 +239,20 @@ function ArticlePage() {
   }
 
   if (authLoading || articleQ.isPending || redirectTo) {
-    return <Loading />;
+    // Not a bare spinner in place of the page. The sidebar already knows this
+    // article's section and title, so the frame a reader clicked towards can be
+    // on screen while the text is fetched, and moving between two articles stops
+    // looking like the whole page was thrown away and rebuilt.
+    return (
+      <article>
+        <ArticleCrumbs
+          section={crumbs?.section?.slug ? crumbs.section.title : null}
+          title={entry?.title ?? null}
+        />
+        {entry?.title && <h1 className="mb-8 text-3xl font-bold md:text-4xl">{entry.title}</h1>}
+        <Loading />
+      </article>
+    );
   }
 
   if (articleQ.isError || !article || !viewer) {
@@ -264,19 +283,10 @@ function ArticlePage() {
 
   return (
     <article>
-      <nav aria-label="Breadcrumb" className="mb-4 flex flex-wrap items-center gap-1 text-sm">
-        <Link to="/kb" className="text-muted-foreground hover:text-foreground">
-          Knowledge base
-        </Link>
-        {crumbs?.section?.slug && (
-          <>
-            <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
-            <span className="text-muted-foreground">{crumbs.section.title}</span>
-          </>
-        )}
-        <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
-        <span className="font-medium">{article.title}</span>
-      </nav>
+      <ArticleCrumbs
+        section={crumbs?.section?.slug ? crumbs.section.title : null}
+        title={article.title}
+      />
 
       <header className="mb-8">
         <div className="flex flex-wrap items-center gap-2">
@@ -399,11 +409,40 @@ function ArticlePage() {
           aria-label="More in the knowledge base"
           className="mt-12 grid gap-3 border-t pt-6 sm:grid-cols-2"
         >
-          <AdjacentLink entry={previous} direction="previous" />
-          <AdjacentLink entry={next} direction="next" />
+          <AdjacentLink entry={previous} direction="previous" onPrefetch={prefetchArticle} />
+          <AdjacentLink entry={next} direction="next" onPrefetch={prefetchArticle} />
         </nav>
       )}
     </article>
+  );
+}
+
+/**
+ * Where in the knowledge base this article sits.
+ *
+ * Shared by the loading state and the article itself, so the two agree: the
+ * trail is drawn from the sidebar's copy of the contents, which is already in
+ * hand before the article's own text has been asked for.
+ */
+function ArticleCrumbs({ section, title }: { section: string | null; title: string | null }) {
+  return (
+    <nav aria-label="Breadcrumb" className="mb-4 flex flex-wrap items-center gap-1 text-sm">
+      <Link to="/kb" className="text-muted-foreground hover:text-foreground">
+        Knowledge base
+      </Link>
+      {section && (
+        <>
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="text-muted-foreground">{section}</span>
+        </>
+      )}
+      {title && (
+        <>
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="font-medium">{title}</span>
+        </>
+      )}
+    </nav>
   );
 }
 
@@ -417,9 +456,12 @@ function ArticlePage() {
 function AdjacentLink({
   entry,
   direction,
+  onPrefetch,
 }: {
   entry: KbNavEntry | null;
   direction: "previous" | "next";
+  /** Start fetching the neighbour as soon as the reader shows interest in it. */
+  onPrefetch: (slug: string) => void;
 }) {
   const isNext = direction === "next";
   if (!entry) return <div className={isNext ? "sm:col-start-2" : undefined} />;
@@ -444,11 +486,20 @@ function AdjacentLink({
     .join(" ");
 
   return entry.link_path ? (
-    <a href={entry.link_path} className={className}>
+    // A link entry points at a page on the marketing site. `link_path` is
+    // validated site-relative, so the router takes it without reloading the app.
+    <Link to={entry.link_path} className={className}>
       {inner}
-    </a>
+    </Link>
   ) : (
-    <Link to="/kb/$slug" params={{ slug: entry.slug }} className={className}>
+    <Link
+      to="/kb/$slug"
+      params={{ slug: entry.slug }}
+      className={className}
+      onMouseEnter={() => onPrefetch(entry.slug)}
+      onFocus={() => onPrefetch(entry.slug)}
+      onTouchStart={() => onPrefetch(entry.slug)}
+    >
       {inner}
     </Link>
   );

--- a/src/routes/kb/$slug.tsx
+++ b/src/routes/kb/$slug.tsx
@@ -11,7 +11,7 @@
 // Rendered client-side rather than in the loader: the annotation layer needs to
 // know who is reading, and the reader's bearer token reaches a server function
 // through `attachSupabaseAuth` on an RPC from the browser, not during SSR.
-import { createFileRoute, Link, useNavigate, useRouterState } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -94,9 +94,6 @@ function ArticlePage() {
     queryKey: kbAnnotationsQueryKey(user?.id ?? null, slug),
     queryFn: () => fetchAnnotations({ data: { slug } }),
     enabled: !authLoading,
-    // A link entry has no comments and no article, so this call refuses it.
-    // Retrying that is a wasted round trip on a page that is about to redirect.
-    retry: false,
   });
 
   // A link entry has no page of its own. The sidebar sends readers straight to
@@ -124,17 +121,27 @@ function ArticlePage() {
   const [hash, setHash] = useState(() =>
     typeof window === "undefined" ? "" : window.location.hash,
   );
-  // The router's own view of the fragment. A cross-reference between articles is
-  // a router navigation now, not a browser one, and the browser fires no
-  // `hashchange` for those: without this, following `/kb/belts#fees` from
-  // somewhere else in the knowledge base would land at the top of the article.
-  const routerHash = useRouterState({ select: (state) => state.location.hash });
   useEffect(() => {
     const sync = () => setHash(window.location.hash);
-    sync();
     window.addEventListener("hashchange", sync);
     return () => window.removeEventListener("hashchange", sync);
-  }, [slug, routerHash]);
+  }, []);
+  // Deliberately on EVERY commit, with no dependency list.
+  //
+  // There are two ways the fragment changes here and neither covers the other.
+  // A plain `#section` anchor (the contents list) fires `hashchange` but leaves
+  // the router's own location untouched; a cross-reference to another article is
+  // a router navigation, which fires no `hashchange` at all. Keying this to the
+  // router's hash instead would miss the case where the two have drifted apart
+  // and a navigation asks for the fragment the router already believes it is on.
+  // Reading `window.location.hash` after each render catches both, and costs a
+  // string comparison: React bails out of `setHash` when the value is unchanged,
+  // so this settles on the first render that sees a new fragment and cannot
+  // chain. That bail-out is exactly what the lint rule below cannot see.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    setHash(window.location.hash);
+  });
 
   const target = useMemo(() => findHeadingForHash(hash, headings), [hash, headings]);
   /** What the reader asked for, when it is worth saying the section is gone. */

--- a/src/routes/kb/index.test.tsx
+++ b/src/routes/kb/index.test.tsx
@@ -13,6 +13,10 @@ vi.mock("@tanstack/react-router", () => ({
   Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
 }));
 vi.mock("@/hooks/useKbNav", () => ({ useKbNav: () => mockUseKbNav() }));
+// The list starts fetching an article on hover. That is behaviour of its own,
+// covered in `useKbArticle`'s own tests; here it only has to not be a query
+// client this suite does not have.
+vi.mock("@/hooks/useKbArticle", () => ({ useKbArticlePrefetch: () => vi.fn() }));
 
 const { Route } = await import("./index");
 const KnowledgeBaseIndex = (Route as unknown as { component: () => ReactNode }).component;

--- a/src/routes/kb/index.tsx
+++ b/src/routes/kb/index.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { LoadFailure } from "@/components/site/LoadFailure";
 import { Loading } from "@/components/site/Loading";
 import { useKbNav } from "@/hooks/useKbNav";
+import { useKbArticlePrefetch } from "@/hooks/useKbArticle";
 import { flattenKbNav, kbProgress, readState } from "@/lib/kb-nav";
 
 export const Route = createFileRoute("/kb/")({
@@ -21,6 +22,9 @@ export const Route = createFileRoute("/kb/")({
 
 function KnowledgeBaseIndex() {
   const { nav, loading, error, refetch } = useKbNav();
+  // Every article here is one click away, so the fetch starts on the hover, the
+  // keyboard focus or the touch that precedes the click.
+  const prefetchArticle = useKbArticlePrefetch();
   const progress = kbProgress(nav);
   const started = progress.read > 0 || progress.updated > 0;
   // Where to send them: the next thing they have not read, or the very first
@@ -47,12 +51,18 @@ function KnowledgeBaseIndex() {
           </p>
           <Button asChild className="mt-4">
             {target.link_path ? (
-              <a href={target.link_path}>
+              <Link to={target.link_path}>
                 {started ? "Keep reading" : "Start reading"}
                 <ArrowRight className="ml-1 h-4 w-4" />
-              </a>
+              </Link>
             ) : (
-              <Link to="/kb/$slug" params={{ slug: target.slug }}>
+              <Link
+                to="/kb/$slug"
+                params={{ slug: target.slug }}
+                onMouseEnter={() => prefetchArticle(target.slug)}
+                onFocus={() => prefetchArticle(target.slug)}
+                onTouchStart={() => prefetchArticle(target.slug)}
+              >
                 {started ? "Keep reading" : "Start reading"}
                 <ArrowRight className="ml-1 h-4 w-4" />
               </Link>
@@ -169,11 +179,20 @@ function KnowledgeBaseIndex() {
                 return (
                   <li key={entry.slug}>
                     {entry.link_path ? (
-                      <a href={entry.link_path} className={className}>
+                      // Site-relative by validation, so the router takes it and
+                      // the browser never reloads the application to follow it.
+                      <Link to={entry.link_path} className={className}>
                         {label}
-                      </a>
+                      </Link>
                     ) : (
-                      <Link to="/kb/$slug" params={{ slug: entry.slug }} className={className}>
+                      <Link
+                        to="/kb/$slug"
+                        params={{ slug: entry.slug }}
+                        className={className}
+                        onMouseEnter={() => prefetchArticle(entry.slug)}
+                        onFocus={() => prefetchArticle(entry.slug)}
+                        onTouchStart={() => prefetchArticle(entry.slug)}
+                      >
                         {label}
                       </Link>
                     )}


### PR DESCRIPTION
Two complaints from a member reading the knowledge base: clicking a link to another article reloads the whole page, and the section is slow to load.

## What a member will feel

**Following a link stops being a page load.** A cross-reference from one article to another was a plain anchor, so following one threw the application away and rebuilt it: blank screen, the whole bundle again, the session resolved again, the sidebar fetched again, to move one page. On a phone on club wifi that is several seconds to go one page across. Those links now move within the app, and so do the sidebar's "on the main site" entries, the index list and the previous/next links.

**Opening an article is quicker, and often instant.** The article a reader is about to open starts fetching when they hover it, focus it, or touch it, so most clicks land on something already there. Moving back through a section you have just read costs nothing at all.

**Moving between articles no longer looks like starting over.** The breadcrumb and the heading are on screen while the text arrives, instead of the whole page being replaced by a spinner.

Nothing changes about who can read what, and nothing changes about how a manager publishes. Progress ticks still appear the moment an article is finished.

## What changed in the code

Navigation:

- `kb-markdown.tsx` renders a same-site path as a router link. A `#` fragment stays a plain anchor, because it names a heading in the article already on screen and the reader page listens for `hashchange` to jump to it.
- The sidebar, the index, search results and the prev/next links render `link_path` entries as router links. `kbLinkPathSchema` already guarantees they are site-relative.
- `/kb/<slug>` for a link entry bounces through the router rather than `window.location.replace`.
- The article page reads the fragment from the router as well as from the browser: a router navigation fires no `hashchange`, so `/kb/belts#fees` from another article would otherwise land at the top.

Two things fell out of the first change. `//another-host` is a protocol-relative URL to somebody else's site, and the old "is this internal" test (`/^[/#]/`) read it as a path, rendering it same-tab with no `rel="noopener"`; it now opens in a new tab like any other outside link. And the path/fragment parsing is a small pure function, `internalLinkTarget`, with its own tests.

Loading, none of which alters what anyone can read:

- New `src/hooks/useKbArticle.ts` owns the article query: its key, its five-minute `staleTime`, and `useKbArticlePrefetch` for the lists that know a slug before the click. `useKbNav` gets the same `staleTime`, so the contents is no longer refetched on every mount and every window focus. `markKbArticleRead` still invalidates it, so a tick appears immediately.
- Comments are fetched **alongside** the article rather than after it. They only ever needed the slug the router already has.
- `getKbArticle` resolves the viewer in parallel with the article row, and reads that row **once**: it used to fetch it to check for a link entry, then hand the slug to `loadKbArticle`, which fetched it again. `loadKbArticleVersion` is the extracted half that takes a row a caller already holds.
- `listKnowledgeBase` resolves the viewer alongside its two list queries, and runs the versions and reads lookups together. Five sequential waits become two.
- `listAnnotations` reads the article **row** instead of the row plus its live version, which was pulling the entire markdown body over the wire to get an id off it.

Every reader-facing cache key is scoped to the reader (`["kb-article", userId, slug]`, and the same for annotations), matching what `useKbNav` has always done. That is load-bearing now that things are held for minutes: managers-only drafts live under these keys, and a reader-agnostic key would keep one on screen after a sign-out in another tab.

## Tests

`bun run lint`, `bun run typecheck`, `bun run test` (2414 passing) and `bun run build` all pass locally.

New coverage, each case failing before this change:

- `kb-markdown.test.tsx`: a link to another article goes through the router with its fragment intact; a `#` fragment does not; `//host` is treated as leaving the site; plus `internalLinkTarget`'s own cases.
- `kb-admin.test.ts`: `loadKbArticleVersion` does not re-read a row the caller holds, asks for the live version by default and a named one when given it, and `loadKbArticle` still reads both and still returns null for an article with no live version.
- `useKbArticle.test.tsx`: the cache key is scoped to the reader, the query waits for auth to settle, a prefetch fills the cache the query then reads from, repeated prefetches fetch once, and nothing is prefetched before auth settles.

Docs: `docs/knowledge-base.md` gains a "How fast it feels, and why" section, and the linking and link-entry sections say that following a link no longer reloads.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqZ7Z4vHfiPV8BAPJCTt9C)_