### PR TITLE
Move the daily digest to 8am Sydney, not 6am

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -1192,7 +1192,9 @@ reached from a link rather than by looking the token up.
 
 Added by `20260807000000_notification_digest_cron.sql`, which enables **pg_cron**
 (schema `cron`) and **pg_net** (schema `net`) and registers one job,
-`notification-digest`, at `0 20 * * *` UTC. It replaced a GitHub Actions
+`notification-digest`, at `0 20 * * *` UTC, moved to `0 22 * * *` by
+`20260823000000_notification_digest_morning_schedule.sql` so it lands at 8am
+Sydney in AEST and 9am in AEDT rather than 6am and 7am. It replaced a GitHub Actions
 workflow: scheduling production work from CI put a credential that makes the site
 email its members into a repo that takes same-repo branches from Lovable and from
 coding agents.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -228,7 +228,9 @@ honest:
   `LOVABLE_API_KEY`, where nothing is stamped at all: those notifications are
   still owed.
 
-`0 20 * * *` is 7am in Sydney during daylight saving and 6am outside it. pg_cron
+`0 22 * * *` is 9am in Sydney during daylight saving and 8am outside it
+(`20260823000000_notification_digest_morning_schedule.sql`; it was `0 20 * * *`,
+so 7am and 6am, until the club owner saw the first real run land at 6am). pg_cron
 schedules are UTC and have no notion of DST, and an hour's drift on a club digest
 is not worth a scheduler of our own.
 
@@ -319,7 +321,8 @@ what state the club is in rather than guessing from a set of instructions.
 **The state before, checked read-only through Lovable on 2026-08-21.**
 `NOTIFICATION_DIGEST_KEY` was not set (the project had three secrets and this was
 not one of them), neither Vault secret existed, and no digest email had ever been
-sent. pg_cron was installed with job `notification-digest` active on `0 20 * * *`;
+sent. pg_cron was installed with job `notification-digest` active on `0 20 * * *`
+(since moved to `0 22 * * *`, see above);
 pg_net was installed with its extension home in `extensions` and its functions in
 `net`, which is what the migration asserts. The five runs from 17 to 21 August all
 recorded **succeeded** having done nothing. The backlog stood at **34 rows**, from
@@ -380,7 +383,7 @@ was applied, so the endpoint was still answering 503 from the old env-var path.
 Steps 3 and 4 below are the remaining verification, and they need a deploy of the
 merged code first.
 
-**3. Prove it works, without waiting for 20:00 UTC.** Run the job by hand and
+**3. Prove it works, without waiting for the scheduled run.** Run the job by hand and
 read the response back inside pg_net's 6-hour TTL:
 
 ```sql

--- a/src/lib/notification-email.server.ts
+++ b/src/lib/notification-email.server.ts
@@ -306,10 +306,13 @@ export async function sendDailyDigests(db: AdminClient, now = new Date()): Promi
     return { considered: pending.length, recipients: byUser.size, sent: 0 };
   }
 
-  // The club's date, not the UTC one. The schedule fires at 20:00 UTC, which is
-  // already tomorrow morning in Sydney, so a UTC key would label every digest
-  // with the previous day and a re-run either side of midnight UTC would mint
-  // two different keys for one morning's mail. `emailed_at` is the real guard;
+  // The club's date, not the UTC one. The schedule fires in the evening UTC
+  // (22:00, see the cron migrations), which is already tomorrow morning in
+  // Sydney, so a UTC key would label every digest with the previous day and a
+  // re-run either side of midnight UTC would mint two different keys for one
+  // morning's mail. Deliberately not restating the hour as a hard fact: it has
+  // moved once already and `clubLocalDate` does a real timezone conversion, so
+  // nothing here depends on the exact number. `emailed_at` is the real guard;
   // this key is the second belt, and a second belt that changes halfway through
   // the window is not one.
   const day = clubLocalDate(now, CLUB_TIME_ZONE);

--- a/supabase/migrations/20260823000000_notification_digest_morning_schedule.sql
+++ b/supabase/migrations/20260823000000_notification_digest_morning_schedule.sql
@@ -1,0 +1,57 @@
+-- Move the daily digest an hour and a half later: 20:00 UTC becomes 22:00 UTC.
+--
+-- WHY. `0 20 * * *` (20260807000000) lands at 6am Sydney for most of the year
+-- and 7am for the rest. The first run that ever actually reached the site went
+-- out at 6am on 2026-08-22, and 6am is too early for a club digest: it is
+-- announcements and thread activity, not anything anybody is waiting on. The
+-- club owner picked 8am/9am instead. `0 22 * * *` is 8am during AEST and 9am
+-- during AEDT, so both halves of the year land somewhere a person would
+-- reasonably read club email.
+--
+-- DST, AND WHY THIS STILL DRIFTS. pg_cron schedules are UTC and have no notion
+-- of daylight saving, so this moves by an hour twice a year exactly as the old
+-- schedule did. That is not fixed here and is not worth fixing: pinning a local
+-- time would mean a scheduler of our own, and an hour's drift on a club digest
+-- costs nothing. What the choice of 22:00 buys is that BOTH landing times are
+-- sensible (8am and 9am), where 20:00's were 6am and 7am and only one of those
+-- was.
+--
+-- SEQUENCING. Touches the schedule and nothing else. The job's name, its
+-- command, and `private.run_notification_digest()` are all unchanged, so
+-- nothing about what the digest does or who it emails changes — only when.
+-- Applying this cannot send anything: it does not run the job, it re-registers
+-- when the job runs.
+--
+-- The unschedule is belt and braces rather than a requirement, kept for
+-- symmetry with 20260807000000: pg_cron 1.4+ upserts `cron.schedule(name, ...)`
+-- on (jobname, username), so scheduling the same name again would replace the
+-- entry on its own. `cron.unschedule` DOES raise on a missing job, hence the
+-- EXISTS guard for the from-scratch case that CI replays on every PR.
+--
+-- The ::text cast is not optional. `cron.unschedule` is overloaded on (bigint)
+-- and (text), and an uncast literal arrives as `unknown`, which is exactly the
+-- shape that produces "function is not unique" at apply time.
+SELECT cron.unschedule('notification-digest'::text)
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'notification-digest');
+
+SELECT cron.schedule(
+  'notification-digest',
+  '0 22 * * *',
+  $job$SELECT private.run_notification_digest()$job$
+);
+
+-- Assert the schedule is what this file says it is. Without this the migration
+-- reports success whether or not `cron.schedule` actually took, which is the
+-- failure mode this whole area of the codebase has been bitten by twice.
+DO $$
+DECLARE
+  live TEXT;
+BEGIN
+  SELECT schedule INTO live FROM cron.job WHERE jobname = 'notification-digest';
+  IF live IS DISTINCT FROM '0 22 * * *' THEN
+    RAISE EXCEPTION
+      'notification-digest is scheduled as % after this migration, expected 0 22 * * *.',
+      COALESCE(live, 'no such job');
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## What changes for the club

The daily email summary currently goes out at **6am** Sydney time (7am during daylight saving). That was never chosen deliberately, and the first run that actually reached anybody went out at 6am yesterday morning. It carries announcements and thread activity, nothing anybody is waiting on, so 6am is the wrong hour for it.

It moves to **8am**, or 9am during daylight saving.

Nothing else changes. Same digest, same content, same people, same once-a-day. Members who have turned announcements off still have them off.

## One thing that stays imperfect, on purpose

pg_cron schedules are in UTC and have no notion of daylight saving, so the time still shifts by an hour twice a year when Sydney switches. That was true before and is not fixed here. Pinning a real local time would mean running a scheduler of our own, which is not worth it for a club digest.

What choosing 22:00 UTC buys is that **both** landing times are sensible. The old `0 20 * * *` gave 6am and 7am, and only one of those was defensible. `0 22 * * *` gives 8am and 9am.

| UTC | AEST (Apr–Oct) | AEDT (Oct–Apr) |
| --- | --- | --- |
| `0 20 * * *` (before) | 6:00am | 7:00am |
| `0 22 * * *` (after) | 8:00am | 9:00am |

## Technical detail

`supabase/migrations/20260823000000_notification_digest_morning_schedule.sql` re-registers the `notification-digest` job with the new cron expression. The job's name, its command, and `private.run_notification_digest()` are all untouched, so this changes only when it fires.

- The `unschedule` is belt and braces for symmetry with `20260807000000`, since pg_cron 1.4+ upserts `cron.schedule(name, ...)` on `(jobname, username)` anyway. It keeps the `EXISTS` guard because `cron.unschedule` raises on a missing job, which is the from-scratch case CI replays on every PR, and the `::text` cast because that function is overloaded on `(bigint)` and `(text)` and an uncast literal arrives as `unknown`.
- It **asserts the live schedule afterwards** and raises if it is not `0 22 * * *`. A migration that reports success without having done its work is the precise failure this area has already been bitten by twice (the fail-closed cron job reporting `succeeded` for five nights, and the `vault.create_secret` arity guard that would have skipped silently), so this one checks rather than assumes.

Docs updated in the same change: `docs/notifications.md` and `docs/database.md` both stated the old schedule and its Sydney equivalents.

## Applying

Per `docs/database-changes.md`'s apply gate, this needs a human to approve before the SQL runs against the live database. Applying it **cannot send anything** — it does not run the job, it only changes when the job runs. The next digest after it is applied goes out at the new time.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (2420 tests) and `bun run build` all pass locally. `bun.lock` untouched. No SQL has been run against any database.

For context on the state this lands in: the digest was armed on 2026-08-22 and its first run at 20:00 UTC returned `{"ok":true,"considered":0,"recipients":0,"sent":0}` — working, with nothing owed because the backlog had been cleared. See #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ET5aaZauFf6PjybLbVGu3Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01ET5aaZauFf6PjybLbVGu3Z)_