### PR TITLE
Stop the app reloading itself, and never lose a draft to it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,10 +165,13 @@ src/
     ui/                   shadcn/ui primitives (generated; avoid hand-editing)
     site/                 App chrome + shared UX: SiteLayout/MemberLayout/KbLayout,
                           SiteHeader, SiteFooter, SignaturePad, AuthPending,
-                          SubmitStatus, StatusPill
+                          SubmitStatus, StatusPill, Loading, LoadFailure,
+                          SaveFailure, StaleNotice, DraftRestoreBanner
   integrations/supabase/  Supabase clients + auth middleware + generated types
   lib/                    Business logic, server functions, PDF, email templates, utils
-  hooks/                  useAuth / useRoles, use-resilient-submit, use-mobile
+  hooks/                  useAuth / useRoles, use-resilient-submit, use-mobile,
+                          use-editor-draft (unsaved work kept on the device),
+                          use-persistent-query (answers that survive a relaunch)
   router.tsx              createRouter() factory (QueryClient in context)
   server.ts               SSR entry — wraps errors into a rendered error page
   start.ts                createStart(): global function + request middleware
@@ -827,7 +830,8 @@ Practical rules:
 - **Extend a seam, do not add a parallel one.** This repo already has the seam
   for most things: form rules in `src/lib/validation.ts`, server work in
   `src/lib/*.functions.ts` (`createServerFn` + Zod), writes from the browser
-  through `useResilientSubmit`, RPC shapes in `src/lib/supabase-rpc.ts`, page
+  through `useResilientSubmit`, anything kept on a device in
+  `src/lib/local-cache.ts`, RPC shapes in `src/lib/supabase-rpc.ts`, page
   chrome in `components/site/*Layout`, indexable pages in `src/lib/seo.ts`, and
   the club facts every page repeats in `src/lib/venue.ts` (name, address,
   phone), `src/lib/schedule.ts` (the weekly class times) and `src/lib/faq.ts`.
@@ -900,6 +904,32 @@ Then hold the change to this:
     `useQuery`'s `isLoading` is **false** once a query has rejected, so a hook
     that reports only `isLoading` leaves the page on "Loading..." for good.
     Surface `isError` too (`useKbNav` is the worked example).
+- **A failed SAVE is not a toast either, for the same reason.** A toast fades in
+  four seconds and what it leaves behind is a form that looks exactly like one
+  that saved, so somebody who glanced away walks off believing their work is
+  filed. Hold a `saveError` state and render **`components/site/SaveFailure`**
+  beside the form: it says the writing is still here, and carries the retry.
+  Clear it when the form is edited, or the panel starts claiming something about
+  work it never saw. The three long-form editors (blog, knowledge base, waiver
+  template) are the worked examples. A _success_ toast is still right.
+- **Anywhere somebody types at length, keep it on the device.** `beforeunload`
+  is not a safety net on a phone: iOS ignores it, and an installed app the
+  system reclaims in the background is killed without being asked to unload.
+  Use **`useEditorDraft`** + **`DraftRestoreBanner`**, which save a moment after
+  typing stops AND on `visibilitychange`/`pagehide`, and offer the result back
+  rather than restoring it silently. The waiver keeps its own module
+  (`waiver-draft.ts`) because its draft holds health answers and a signature and
+  therefore uses `sessionStorage`; everything else uses these. `docs/blog.md`
+  and `docs/pwa.md` have the reasoning.
+- **A screen that can be read on a bad connection should be.** Where an answer
+  is worth having offline and being a few minutes old is honest rather than
+  misleading, fetch it with **`usePersistentQuery`** so a relaunch paints
+  instead of spinning, and show **`components/site/StaleNotice`** when what is
+  on screen is the stored copy and the refresh failed. Such a screen must key
+  its "not available" branch on having no data, **never on `isError`** — a
+  failed refresh would otherwise hide a perfectly good cached copy. What is
+  cached and for how long is a judgement recorded in `docs/pwa.md`, not a
+  default; anything a person would act on irreversibly does not belong there.
 - **A bare `Loading...` is not a loading state.** Use
   **`components/site/Loading`**, which carries the `role="status"` /
   `aria-live="polite"` wiring `AuthPending` and `SubmitStatus` already have.

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -163,6 +163,31 @@ commenting anywhere, not just on this post. The same page has a "Blocked
 commenters" panel listing everyone currently blocked, each with an **Unblock**
 button.
 
+## Nothing typed here is lost to a closed app
+
+The composer keeps everything on the device as it is written, and flushes it the
+moment the page is hidden. That last part is the whole point: `beforeunload`,
+which was the only guard before, does not fire on a phone — iOS ignores it, and
+an installed app the system reclaims in the background is never asked to unload,
+it is simply killed and relaunched cold. A manager lost a finished draft to
+exactly that.
+
+Coming back to the composer with something stored offers it back, with the time
+it was kept from. It is an **offer**, never a silent restore: somebody who
+abandoned a draft on purpose, or who has since edited the same post from a
+laptop, must not have this device's copy pushed over what they meant to keep.
+The stored copy is thrown away once the post has really been saved, and kept
+when a save fails.
+
+A save that fails leaves a panel on screen saying so, with the writing still in
+the form and a button that tries again — not a toast, which fades in four
+seconds and leaves an editor that looks exactly like one that saved.
+
+The rules live in `src/lib/editor-draft.ts` and the wiring in
+`src/hooks/use-editor-draft.ts`; the knowledge base editor and the waiver
+template editor use the same two. `docs/pwa.md` has how long a draft is kept and
+why this uses `localStorage` where the waiver's own draft uses `sessionStorage`.
+
 ## SEO
 
 `/blog` is a normal entry in `PUBLIC_PAGES` (`src/lib/seo.ts`), like any other

--- a/docs/check-in.md
+++ b/docs/check-in.md
@@ -207,6 +207,30 @@ people in to a class that did not run.
   they attended reads as an accusation.
 - **The manager agent API** — `list_users` returns `sessions_attended`.
 
+## At the door, on a bad connection
+
+This screen is run in a university gym, on a phone, by a manager with a queue in
+front of them, so the two things it cannot afford are a spinner on launch and an
+error panel where the roster should be. The class list and the roster are kept
+**on that manager's device** and painted immediately while a fresh copy is
+fetched behind them.
+
+- **A day, and no longer.** This data carries members' names and email
+  addresses, and memberships are raised and waivers signed between classes, so a
+  roster older than that is a wrong answer rather than a convenience.
+- **Scoped to the manager who fetched it**, and wiped when anybody signs out, so
+  a club laptop passed to the next person carries nothing.
+- **When it is the stored copy on screen, the screen says so** — a notice with
+  the time it was fetched and a retry, rather than passing it off as live.
+- **The needs-attention list is deliberately not kept.** It is a worklist, and a
+  stale one sends a manager chasing check-ins somebody has already sorted out.
+
+Writing still needs the network: checking somebody in spends a session and
+resolves coverage server-side, so it is not something a phone can do on its own
+and then reconcile. Offline check-in is on the "not built, on purpose" list
+below. The terms above are in `src/lib/checkin-cache.ts`; `docs/pwa.md` has the
+storage rules they rest on.
+
 ## Not built, on purpose
 
 - **Self check-in, QR codes, kiosk mode.** A manager checks people in.

--- a/docs/knowledge-base.md
+++ b/docs/knowledge-base.md
@@ -558,6 +558,14 @@ things keep that off the reader's path.
   rather than beside it. The article page also read the same database row twice
   on every load: once to tell a link entry from a real page, once again inside
   the loader it then called.
+- **The contents and the article survive the app being closed.** Both are kept
+  on the reader's own device as well as in memory, so opening the installed app
+  paints what was there last time instead of a spinner, and a member on the mat
+  with no signal can still read an article they have opened before. When the
+  refresh behind it fails, the article stays up with a notice saying when it was
+  fetched, rather than the page reporting itself unavailable. A week, because
+  these are the club's own handbooks and they change a few times a year;
+  `docs/pwa.md` has the storage rules and the reasoning.
 - **The page keeps its frame while the text is fetched.** The contents already
   knows this article's section and title, so moving between two articles shows
   the breadcrumb and the heading straight away rather than replacing the whole
@@ -566,7 +574,18 @@ things keep that off the reader's path.
 Everything a reader is cached for is keyed by **who they are**. That is a
 security property rather than a nicety: managers-only drafts are readable data
 under these keys, and a five-minute cache under a reader-agnostic key would keep
-one on screen after a sign-out in another tab.
+one on screen after a sign-out in another tab. The copies kept on the device
+carry the same reader's id on every entry, and signing out wipes them, so a
+shared club laptop never hands one person's reading to the next.
+
+**Nothing typed into the editor is lost to a closed app.** An article is Markdown
+a manager can sit with for a long time, and it used to live only in React state,
+so the installed app being reclaimed in the background took the lot. It is now
+kept on the device as it is written and offered back when the editor reopens —
+an offer, never a silent restore. A save that fails leaves a panel on screen
+rather than a toast that fades. Same two modules as the blog composer
+(`src/lib/editor-draft.ts`, `src/hooks/use-editor-draft.ts`); `docs/blog.md` has
+the reasoning written out.
 
 **Publishing clears all of it.** The manager screen keeps its own state and
 never goes through these queries, so it drops them by hand after every write

--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -12,10 +12,11 @@ Tapping the icon opens `start_url`, which is `/app` — a route that renders not
 of its own. It works out who is holding the phone and forwards them, replacing the
 history entry so the launch route never shows up when you press back:
 
-| On launch  | Lands on                 |
-| ---------- | ------------------------ |
-| Signed in  | `/account` (member area) |
-| Signed out | `/` (public home page)   |
+| On launch                        | Lands on                 |
+| -------------------------------- | ------------------------ |
+| The app was open in the last day | The screen it was on     |
+| Signed in                        | `/account` (member area) |
+| Signed out                       | `/` (public home page)   |
 
 Signed out means the home page even for a member whose session has lapsed. There
 is no self-serve sign-up, so sending every signed-out launch to the sign-in screen
@@ -25,24 +26,87 @@ signed out reaches "Member login" from the home page header in one tap.
 The rule itself lives in `resolveLaunchScreen` (`src/lib/pwa.ts`) and is unit
 tested in `src/lib/pwa.test.ts`; `src/routes/app.tsx` is only the wiring.
 
+### Coming back to where you were
+
+The installed app has no "resume". When a phone reclaims it in the background,
+the next tap on the icon is a **cold launch at `start_url`**, so somebody
+half-way through an article, or reading tonight's roster, used to come back to
+the member home page with nothing to say anything had been lost. From the
+outside that is indistinguishable from the app reloading itself, and it was
+half of why it felt so eager to.
+
+So the root component records where the app is on every navigation
+(`src/lib/last-visit.ts`) and `/app` reads it back through
+`resolveLaunchTarget`. It returns you there only when all of this holds:
+
+- it was **within the last day** (`LAUNCH_RESUME_WINDOW_MS`);
+- the **signed-in state matches** what it was. Somebody who has signed out
+  since must not be dropped on a manager screen and bounced straight to the
+  sign-in page, and somebody who has since signed **in** wants their member
+  area, not the marketing page they were reading beforehand;
+- the path is **resumable**. Not the launch route (which would loop), not the
+  auth screens, and nothing carrying a token in its path —
+  `/email-settings/<token>` consumes its token and redirects, so returning to
+  it lands on a URL that no longer works;
+- the path is **plain and site-relative**. A protocol-relative `//host` is
+  another origin as far as a browser is concerned, and this value is read back
+  off the device.
+
+The record is owner-scoped like everything else in `local-cache`, so a shared
+club laptop never sends the next person to the last manager's screen.
+
 Android and desktop also get manifest **shortcuts** (long-press / right-click the
 icon): Your account, Class calendar, Class times.
 
 ## Files
 
-| File                             | What it is                                                      |
-| -------------------------------- | --------------------------------------------------------------- |
-| `public/manifest.webmanifest`    | Name, icons, theme colour, `start_url`, scope, shortcuts        |
-| `public/icons/*`                 | Generated icon set (192/512 plain, 192/512 maskable, iOS touch) |
-| `public/sw.js`                   | The service worker                                              |
-| `public/offline.html`            | The card shown when a page is opened with no connection         |
-| `src/lib/pwa.ts`                 | The launch rule                                                 |
-| `src/lib/service-worker.ts`      | Registration (production only)                                  |
-| `src/routes/app.tsx`             | The `start_url` route                                           |
-| `scripts/generate-pwa-icons.mjs` | Regenerates the icons from `public/logo.png`                    |
+| File                                | What it is                                                      |
+| ----------------------------------- | --------------------------------------------------------------- |
+| `public/manifest.webmanifest`       | Name, icons, theme colour, `start_url`, scope, shortcuts        |
+| `public/icons/*`                    | Generated icon set (192/512 plain, 192/512 maskable, iOS touch) |
+| `public/sw.js`                      | The service worker                                              |
+| `public/offline.html`               | The card shown when a page is opened with no connection         |
+| `src/lib/pwa.ts`                    | The launch rule, and the resume rule                            |
+| `src/lib/last-visit.ts`             | Where the app was, recorded on every navigation                 |
+| `src/lib/local-cache.ts`            | The versioned, owner-scoped device storage all of this uses     |
+| `src/hooks/use-persistent-query.ts` | A query whose answer survives the app being closed              |
+| `src/lib/service-worker.ts`         | Registration (production only)                                  |
+| `src/routes/app.tsx`                | The `start_url` route                                           |
+| `scripts/generate-pwa-icons.mjs`    | Regenerates the icons from `public/logo.png`                    |
 
 The manifest link, theme colour and iOS meta tags are in `src/routes/__root.tsx`
 alongside the rest of the site's head.
+
+## Why the app used to reload itself constantly
+
+Worth knowing before adding anything that reacts to an auth event or a window
+focus, because all three of these looked reasonable in isolation.
+
+**supabase-js re-announces the session on every visibility change.** Its
+`_onVisibilityChanged` runs `_recoverAndRefresh`, which emits a fresh
+`SIGNED_IN` whenever it finds a usable stored session. That is not a sign-in.
+It is the same person, the same token, said again, on every tab switch, every
+phone unlock and every return to the installed app. `__root.tsx` took it at
+face value and invalidated every route loader and every cached query.
+`resolveAuthRefresh` (`src/lib/auth-events.ts`) makes the rule about **identity**
+instead: refresh when the signed-in person actually changes. It also ignores the
+first event of a page's life, since that is the session the page loaded with and
+there is nothing on screen that predates it — which is what stopped every cold
+start fetching its data twice.
+
+**`useAuth` re-set its state from those announcements.** supabase builds a new
+`Session` object each time, so comparing by reference made every return to the
+app look like a change and re-rendered most of the signed-in app. It now holds
+the objects steady while the person and their access token are unchanged, and
+still moves on a real `USER_UPDATED`.
+
+**React Query ran on its own defaults.** `staleTime: 0` plus
+`refetchOnWindowFocus: true` means every mounted query re-asks the server on
+every focus. `src/router.tsx` now sets 30s fresh, focus refetch **off**,
+reconnect refetch **on** (a phone that has just found signal is the one moment
+worth interrupting for), and one retry rather than three.
+`defaultPreloadStaleTime` moved off 0 as well, so a hover preload survives long
+enough for the tap to use it instead of being thrown away and re-fetched.
 
 ## The service worker
 
@@ -61,6 +125,44 @@ stale cache.
   its whole origin storage reclaimed by the browser, auth session included.
 - **Nothing else is intercepted.** Supabase calls and server functions are `fetch`
   requests with an empty `destination`, so they fall straight through.
+
+### What is kept on the device, and what is not
+
+The service worker deliberately caches no HTML at all (above). Everything else
+this app keeps on a device goes through **`src/lib/local-cache.ts`**, which is
+the only place that writes to `localStorage` for these purposes, and which
+enforces the three rules that make it safe to rely on:
+
+- **Versioned.** A value written by an older build is discarded rather than
+  half-read.
+- **Owned.** Every entry records the user id it was written for. A different
+  person reads nothing, and signing out wipes everything belonging to whoever
+  was signed in (`clearCacheFor`, called from `__root.tsx`). This is what keeps
+  one member's data off the next member's screen on a shared club laptop.
+- **Dated.** Every entry carries a write time, so a caller can refuse one that
+  is too old and a screen can say how old what it is showing is.
+
+| What                                | How long | Why that long                                                                                                                           |
+| ----------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Knowledge base sidebar and articles | 7 days   | The club's own handbooks and policies. They change a few times a year, and a member on the mat reading last week's copy is served well. |
+| Check-in class list and roster      | 24 hours | Carries members' names and emails, and memberships are raised between classes. Older than a day is a wrong answer, not a convenience.   |
+| Unsaved editor drafts               | 14 days  | Long enough to survive being forgotten about, short enough that an offer to restore is a rescue rather than a puzzle.                   |
+| Where the app was                   | 24 hours | See "Coming back to where you were".                                                                                                    |
+| The needs-attention check-in list   | never    | A worklist. A stale one sends a manager chasing check-ins somebody already fixed.                                                       |
+
+`usePersistentQuery` is the seam: it seeds a React Query from the device during
+render (not in an effect, which would flash the spinner it exists to remove) and
+refreshes behind it. A refresh that **fails** leaves the stored copy on screen
+under a `StaleNotice` saying when it was fetched, rather than blanking the page.
+A screen using it must therefore key its "not available" branch on _having no
+data_, not on `isError` — otherwise a failed refresh hides a perfectly good
+cached copy.
+
+Opting a new query in is a judgement, not a default: the data has to be worth an
+offline read **and** being a few minutes out of date has to be honest rather
+than misleading. Its stored shape is declared with Zod (`kb-cache.ts`,
+`checkin-cache.ts`) so reading back what an older build wrote can never throw
+during a render.
 
 It only registers in production builds. In dev it actively unregisters itself:
 a worker picked up from a production visit would otherwise sit in front of the Vite

--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -48,9 +48,17 @@ So the root component records where the app is on every navigation
   auth screens, and nothing carrying a token in its path —
   `/email-settings/<token>` consumes its token and redirects, so returning to
   it lands on a URL that no longer works;
-- the path is **plain and site-relative**. A protocol-relative `//host` is
-  another origin as far as a browser is concerned, and this value is read back
-  off the device.
+- the path is **plain and site-relative**. This value is read back off the
+  device, which makes it the one input here that anything with a script foothold
+  on the origin could choose, so `isResumablePath` is strict rather than relying
+  on what the router happens to do with a bad value: a protocol-relative
+  `//host` (another origin to a browser), any backslash, any control character
+  or whitespace, and any traversal (raw or percent-encoded) are all refused, and
+  the blocklist matches case-insensitively.
+
+`isResumablePath` gates the **write** as well as the read. Recording a path the
+app would refuse to reopen still puts it on the device for a day, and an auth
+link lands with its PKCE `code` or `token_hash` in the query string.
 
 The record is owner-scoped like everything else in `local-cache`, so a shared
 club laptop never sends the next person to the last manager's screen.
@@ -137,8 +145,15 @@ enforces the three rules that make it safe to rely on:
   half-read.
 - **Owned.** Every entry records the user id it was written for. A different
   person reads nothing, and signing out wipes everything belonging to whoever
-  was signed in (`clearCacheFor`, called from `__root.tsx`). This is what keeps
-  one member's data off the next member's screen on a shared club laptop.
+  was signed in (`clearCacheFor`, called from `__root.tsx` on the
+  decision `resolveAuthRefresh` returns). This is what keeps one member's data
+  off the next member's screen on a shared club laptop. The rule lives in that
+  pure function rather than as a condition in the component, because a privacy
+  guarantee that exists only as untested wiring is not one -- and this one was
+  broken exactly that way before it moved: identity was adopted only from
+  `SIGNED_IN`, but the first event any subscriber gets is `INITIAL_SESSION`, so a
+  returning member's tab never learned who they were and signing out wiped
+  nothing at all.
 - **Dated.** Every entry carries a write time, so a caller can refuse one that
   is too old and a screen can say how old what it is showing is.
 
@@ -156,7 +171,11 @@ refreshes behind it. A refresh that **fails** leaves the stored copy on screen
 under a `StaleNotice` saying when it was fetched, rather than blanking the page.
 A screen using it must therefore key its "not available" branch on _having no
 data_, not on `isError` — otherwise a failed refresh hides a perfectly good
-cached copy.
+cached copy. That mistake has been made twice already in this
+codebase, once on `/kb/<slug>` and once in `useKbNav` (where it blanked the whole
+sidebar behind an error panel), so a hook wrapping one of these should do the
+gating itself and hand its callers a plain `error` that is only set when there is
+genuinely nothing to show.
 
 Opting a new query in is a judgement, not a default: the data has to be worth an
 offline read **and** being a few minutes out of date has to be honest rather

--- a/src/components/site/BlogPostEditor.draft.test.tsx
+++ b/src/components/site/BlogPostEditor.draft.test.tsx
@@ -1,0 +1,161 @@
+// The bug this whole safety net exists for: a manager wrote a post in the
+// installed app, left it, and came back to an editor that had been relaunched
+// empty. Everything they had typed was gone.
+//
+// The composer's only guard was `beforeunload`, which never fires for that: iOS
+// ignores it, and an app the system reclaims in the background is not asked to
+// unload, it is simply killed. So these tests drive the events a phone actually
+// sends — `visibilitychange` to hidden — and then remount from scratch, which is
+// what a relaunch is.
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { BlogPostEditor, type BlogPostEditorValue } from "@/components/site/BlogPostEditor";
+
+vi.mock("@tanstack/react-start", () => ({ useServerFn: (fn: unknown) => fn }));
+vi.mock("@/lib/blog.functions", () => ({ uploadBlogImage: vi.fn() }));
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "manager-1" }, session: null, loading: false }),
+  useRoles: () => ({ roles: ["manager"], loading: false, isManager: true }),
+}));
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+const EMPTY: BlogPostEditorValue = {
+  title: "",
+  slug: "",
+  excerpt: "",
+  body_md: "",
+  cover_image_path: "",
+  cover_image_url: null,
+  status: "draft",
+};
+
+function hidePage() {
+  // What a phone sends when the app goes to the background. jsdom reports
+  // "visible" by default and has no way to change it, so stub the getter.
+  vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("BlogPostEditor draft recovery", () => {
+  it("offers back a post the app was killed in the middle of", async () => {
+    const user = userEvent.setup();
+    const first = render(
+      <BlogPostEditor initial={EMPTY} saving={false} onSave={async () => true} />,
+    );
+
+    await user.type(screen.getByLabelText("Title"), "Grading day");
+    await user.type(screen.getByLabelText(/Body/), "Everyone did well.");
+    hidePage();
+    first.unmount();
+
+    render(<BlogPostEditor initial={EMPTY} saving={false} onSave={async () => true} />);
+
+    const banner = await screen.findByRole("status");
+    expect(banner).toHaveTextContent(/unsaved post on this device/i);
+
+    await user.click(screen.getByRole("button", { name: /bring it back/i }));
+
+    expect(screen.getByLabelText("Title")).toHaveValue("Grading day");
+    expect(screen.getByLabelText(/Body/)).toHaveValue("Everyone did well.");
+    // The offer is answered, so it does not linger over the restored form.
+    expect(screen.queryByRole("button", { name: /bring it back/i })).not.toBeInTheDocument();
+  });
+
+  it("never restores on its own — the offer has to be accepted", async () => {
+    const user = userEvent.setup();
+    const first = render(
+      <BlogPostEditor initial={EMPTY} saving={false} onSave={async () => true} />,
+    );
+    await user.type(screen.getByLabelText("Title"), "Grading day");
+    hidePage();
+    first.unmount();
+
+    render(<BlogPostEditor initial={EMPTY} saving={false} onSave={async () => true} />);
+    await screen.findByRole("button", { name: /bring it back/i });
+
+    // Somebody who abandoned this draft on purpose, or who has since edited the
+    // same post from a laptop, must not have this device's copy pushed over it.
+    expect(screen.getByLabelText("Title")).toHaveValue("");
+  });
+
+  it("forgets a draft that was discarded", async () => {
+    const user = userEvent.setup();
+    const first = render(
+      <BlogPostEditor initial={EMPTY} saving={false} onSave={async () => true} />,
+    );
+    await user.type(screen.getByLabelText("Title"), "Grading day");
+    hidePage();
+    first.unmount();
+
+    const second = render(
+      <BlogPostEditor initial={EMPTY} saving={false} onSave={async () => true} />,
+    );
+    await user.click(await screen.findByRole("button", { name: /discard it/i }));
+    second.unmount();
+
+    render(<BlogPostEditor initial={EMPTY} saving={false} onSave={async () => true} />);
+    await waitFor(() => expect(screen.getByLabelText("Title")).toHaveValue(""));
+    expect(screen.queryByRole("button", { name: /bring it back/i })).not.toBeInTheDocument();
+  });
+
+  it("offers nothing when the draft matches what is already saved", async () => {
+    const saved: BlogPostEditorValue = { ...EMPTY, title: "Grading day", body_md: "Done." };
+    const user = userEvent.setup();
+    const first = render(
+      <BlogPostEditor initial={saved} saving={false} onSave={async () => true} />,
+    );
+    // Type something and take it straight back out again.
+    await user.type(screen.getByLabelText("Title"), "!");
+    await user.type(screen.getByLabelText("Title"), "{backspace}");
+    hidePage();
+    first.unmount();
+
+    render(<BlogPostEditor initial={saved} saving={false} onSave={async () => true} />);
+    await waitFor(() => expect(screen.getByLabelText("Title")).toHaveValue("Grading day"));
+    expect(screen.queryByRole("button", { name: /bring it back/i })).not.toBeInTheDocument();
+  });
+
+  it("throws the draft away once the post has actually been saved", async () => {
+    const user = userEvent.setup();
+    const first = render(
+      <BlogPostEditor initial={EMPTY} saving={false} onSave={async () => true} />,
+    );
+    await user.type(screen.getByLabelText("Title"), "Grading day");
+    await user.type(screen.getByLabelText(/Body/), "Everyone did well.");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    // The "new post" page navigates away rather than moving its baseline, so
+    // without this the published post would be offered back as an unsaved draft
+    // the next time somebody opened the composer.
+    await waitFor(() => expect(window.localStorage.length).toBe(0));
+    first.unmount();
+
+    render(<BlogPostEditor initial={EMPTY} saving={false} onSave={async () => true} />);
+    await waitFor(() => expect(screen.getByLabelText("Title")).toHaveValue(""));
+    expect(screen.queryByRole("button", { name: /bring it back/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps the draft when the save failed", async () => {
+    const user = userEvent.setup();
+    const first = render(
+      <BlogPostEditor initial={EMPTY} saving={false} onSave={async () => false} />,
+    );
+    await user.type(screen.getByLabelText("Title"), "Grading day");
+    await user.type(screen.getByLabelText(/Body/), "Everyone did well.");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    hidePage();
+    first.unmount();
+
+    render(<BlogPostEditor initial={EMPTY} saving={false} onSave={async () => false} />);
+    await user.click(await screen.findByRole("button", { name: /bring it back/i }));
+    expect(screen.getByLabelText("Title")).toHaveValue("Grading day");
+  });
+});

--- a/src/components/site/BlogPostEditor.draft.test.tsx
+++ b/src/components/site/BlogPostEditor.draft.test.tsx
@@ -158,4 +158,44 @@ describe("BlogPostEditor draft recovery", () => {
     await user.click(await screen.findByRole("button", { name: /bring it back/i }));
     expect(screen.getByLabelText("Title")).toHaveValue("Grading day");
   });
+
+  it("keeps a failed save on screen instead of leaving it to a toast", async () => {
+    const user = userEvent.setup();
+    render(
+      <BlogPostEditor
+        initial={EMPTY}
+        saving={false}
+        onSave={async () => "We could not reach the site."}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Title"), "Grading day");
+    await user.type(screen.getByLabelText(/Body/), "Everyone did well.");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    // A toast fades in four seconds and leaves a form that looks exactly like
+    // one that saved. This has to still be here.
+    const panel = await screen.findByRole("alert");
+    expect(panel).toHaveTextContent(/was not saved/i);
+    expect(panel).toHaveTextContent(/We could not reach the site/);
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+    // And the writing is still on screen.
+    expect(screen.getByLabelText("Title")).toHaveValue("Grading day");
+  });
+
+  it("clears the failure once the writing changes", async () => {
+    const user = userEvent.setup();
+    render(<BlogPostEditor initial={EMPTY} saving={false} onSave={async () => false} />);
+
+    await user.type(screen.getByLabelText("Title"), "Grading day");
+    await user.type(screen.getByLabelText(/Body/), "Everyone did well.");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    await screen.findByRole("alert");
+
+    await user.type(screen.getByLabelText(/Body/), " Really.");
+
+    // The panel is about the save that was attempted. Left up over changed
+    // text it claims something about work it never saw.
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+  });
 });

--- a/src/components/site/BlogPostEditor.draft.test.tsx
+++ b/src/components/site/BlogPostEditor.draft.test.tsx
@@ -198,4 +198,89 @@ describe("BlogPostEditor draft recovery", () => {
     // text it claims something about work it never saw.
     await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
   });
+
+  it("keeps an offered draft on the device until it is answered", async () => {
+    // The bug this pins: the "nothing to recover, clear it" effect fired on the
+    // very render that put the offer on screen, because an unanswered offer sits
+    // in exactly that state -- the form still matches the saved version. The
+    // draft was deleted in the same breath as being offered, so anyone whose app
+    // was killed again before they clicked lost it for good.
+    const user = userEvent.setup();
+    const first = render(
+      <BlogPostEditor initial={EMPTY} saving={false} onSave={async () => true} />,
+    );
+    await user.type(screen.getByLabelText("Title"), "Grading day");
+    hidePage();
+    first.unmount();
+
+    const second = render(
+      <BlogPostEditor initial={EMPTY} saving={false} onSave={async () => true} />,
+    );
+    await screen.findByRole("button", { name: /bring it back/i });
+    // Killed again without answering.
+    second.unmount();
+
+    render(<BlogPostEditor initial={EMPTY} saving={false} onSave={async () => true} />);
+    await user.click(await screen.findByRole("button", { name: /bring it back/i }));
+    expect(screen.getByLabelText("Title")).toHaveValue("Grading day");
+  });
+
+  it("offers the right draft after switching to another post without remounting", async () => {
+    // The knowledge base and waiver template editors are single-page selectors:
+    // picking a different article changes `scope` in place, with no remount. A
+    // once-per-instance check latched onto the first document, so every one
+    // opened after it was never looked at -- and worse, the clear-when-clean
+    // effect wiped its stored draft on sight.
+    const user = userEvent.setup();
+    const a = render(
+      <BlogPostEditor postId="post-a" initial={EMPTY} saving={false} onSave={async () => true} />,
+    );
+    await user.type(screen.getByLabelText("Title"), "Post A draft");
+    hidePage();
+    a.unmount();
+
+    const b = render(
+      <BlogPostEditor postId="post-b" initial={EMPTY} saving={false} onSave={async () => true} />,
+    );
+    await user.type(screen.getByLabelText("Title"), "Post B draft");
+    hidePage();
+    b.unmount();
+
+    // Open A, then switch to B in place, exactly as the KB sidebar does.
+    const { rerender } = render(
+      <BlogPostEditor postId="post-a" initial={EMPTY} saving={false} onSave={async () => true} />,
+    );
+    await user.click(await screen.findByRole("button", { name: /bring it back/i }));
+    expect(screen.getByLabelText("Title")).toHaveValue("Post A draft");
+
+    rerender(
+      <BlogPostEditor postId="post-b" initial={EMPTY} saving={false} onSave={async () => true} />,
+    );
+    await user.click(await screen.findByRole("button", { name: /bring it back/i }));
+    expect(screen.getByLabelText("Title")).toHaveValue("Post B draft");
+  });
+
+  it("does not offer one post's draft against another post's form", async () => {
+    const user = userEvent.setup();
+    const a = render(
+      <BlogPostEditor postId="post-a" initial={EMPTY} saving={false} onSave={async () => true} />,
+    );
+    await user.type(screen.getByLabelText("Title"), "Post A draft");
+    hidePage();
+    a.unmount();
+
+    const { rerender } = render(
+      <BlogPostEditor postId="post-a" initial={EMPTY} saving={false} onSave={async () => true} />,
+    );
+    await screen.findByRole("button", { name: /bring it back/i });
+
+    // Post B has nothing stored, so switching to it must take the offer away
+    // rather than leaving post A's draft on offer against post B's form.
+    rerender(
+      <BlogPostEditor postId="post-b" initial={EMPTY} saving={false} onSave={async () => true} />,
+    );
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /bring it back/i })).not.toBeInTheDocument(),
+    );
+  });
 });

--- a/src/components/site/BlogPostEditor.tsx
+++ b/src/components/site/BlogPostEditor.tsx
@@ -38,6 +38,7 @@ import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/useAuth";
 import { useEditorDraft } from "@/hooks/use-editor-draft";
 import { DraftRestoreBanner } from "@/components/site/DraftRestoreBanner";
+import { SaveFailure } from "@/components/site/SaveFailure";
 
 /** File -> base64, same chunked approach as the paper-waiver scan upload
  * (`manager.waivers_.upload.tsx`), which avoids a giant intermediate string
@@ -115,11 +116,15 @@ export function BlogPostEditor({
   initial: BlogPostEditorValue;
   saving: boolean;
   /**
-   * Save it. Resolve `true` only when it really landed: that is the signal to
-   * throw away the on-device draft, and doing it on a failed save would delete
-   * the copy that is about to be needed.
+   * Save it.
+   *
+   * Resolve `true` only when it really landed: that is the signal to throw away
+   * the on-device draft, and doing it on a failed save would delete the copy
+   * that is about to be needed. Resolve `false`, or a message to show, when it
+   * did not — the editor keeps that on screen (`SaveFailure`) instead of
+   * leaving it to a toast that fades.
    */
-  onSave: (value: BlogPostEditorValue) => Promise<boolean>;
+  onSave: (value: BlogPostEditorValue) => Promise<boolean | string>;
   /** Called whenever the form's dirty-vs-`initial` state changes, so the
    * parent route can guard navigating away. */
   onDirtyChange?: (dirty: boolean) => void;
@@ -136,6 +141,14 @@ export function BlogPostEditor({
   const [mobileTab, setMobileTab] = useState<"write" | "preview">("write");
   const [videoDialogOpen, setVideoDialogOpen] = useState(false);
   const [videoUrl, setVideoUrl] = useState("");
+  /**
+   * The last failed save, kept on screen rather than left to a toast.
+   *
+   * Cleared when a save is attempted and when anything is edited: a stale
+   * "not saved" panel over a form somebody has since fixed and saved is its own
+   * kind of wrong answer.
+   */
+  const [saveError, setSaveError] = useState<string | null>(null);
   const bodyRef = useRef<HTMLTextAreaElement>(null);
   const imageInputRef = useRef<HTMLInputElement>(null);
   const coverInputRef = useRef<HTMLInputElement>(null);
@@ -167,6 +180,13 @@ export function BlogPostEditor({
     onDirtyChange?.(dirty);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dirty]);
+
+  // Editing anything clears the last failure: the panel is about the save that
+  // was attempted, and leaving it up over changed text claims something about
+  // work it never saw.
+  useEffect(() => {
+    setSaveError(null);
+  }, [title, slug, excerpt, body, status, coverPath]);
 
   // Covers a closed tab / refresh / typed-in address bar on a DESKTOP browser.
   // In-app navigation (clicking another sidebar link) is guarded separately by
@@ -306,8 +326,13 @@ export function BlogPostEditor({
     // also moves its baseline to match, which clears it a second time; the new
     // post page navigates away instead, and without this its draft would be
     // offered back the next time somebody opened "New post".
-    void onSave(value).then((saved) => {
-      if (saved) draft.clear();
+    setSaveError(null);
+    void onSave(value).then((result) => {
+      if (result === true) {
+        draft.clear();
+        return;
+      }
+      setSaveError(typeof result === "string" ? result : "We could not reach the site to save it.");
     });
   }
 
@@ -539,6 +564,16 @@ export function BlogPostEditor({
         <div className={cn(mobileTab === "preview" && "hidden lg:block")}>{formFields}</div>
         <div className={cn(mobileTab === "write" && "hidden lg:block")}>{previewCard}</div>
       </div>
+
+      {saveError && (
+        <SaveFailure
+          className="mt-6"
+          what="post"
+          message={saveError}
+          retrying={saving}
+          onRetry={handleSave}
+        />
+      )}
 
       <div className="sticky bottom-0 z-10 -mx-4 mt-6 border-t bg-background/95 px-4 py-3 backdrop-blur">
         <Button disabled={saving || !title.trim() || !body.trim()} onClick={handleSave}>

--- a/src/components/site/BlogPostEditor.tsx
+++ b/src/components/site/BlogPostEditor.tsx
@@ -35,6 +35,9 @@ import {
   type BlogPostStatus,
 } from "@/lib/validation";
 import { cn } from "@/lib/utils";
+import { useAuth } from "@/hooks/useAuth";
+import { useEditorDraft } from "@/hooks/use-editor-draft";
+import { DraftRestoreBanner } from "@/components/site/DraftRestoreBanner";
 
 /** File -> base64, same chunked approach as the paper-waiver scan upload
  * (`manager.waivers_.upload.tsx`), which avoids a giant intermediate string
@@ -54,6 +57,34 @@ const IMAGE_ACCEPT = blogImageMimeTypes.join(",");
 function isBlogImageMimeType(type: string): type is BlogImageMimeType {
   return (blogImageMimeTypes as readonly string[]).includes(type);
 }
+
+/**
+ * The draft's own flat shape, and the empty value of each field.
+ *
+ * Separate from `BlogPostEditorValue` on purpose: a draft has to survive being
+ * written by an older build of the site, so every field is a plain string or
+ * boolean with an obvious empty value (`cover_image_url`'s `null` becomes `""`).
+ * See `reviveDraftFields`.
+ */
+type BlogDraftFields = {
+  title: string;
+  slug: string;
+  excerpt: string;
+  body: string;
+  status: string;
+  coverPath: string;
+  coverUrl: string;
+};
+
+const BLOG_DRAFT_SHAPE: BlogDraftFields = {
+  title: "",
+  slug: "",
+  excerpt: "",
+  body: "",
+  status: "draft",
+  coverPath: "",
+  coverUrl: "",
+};
 
 export type BlogPostEditorValue = {
   title: string;
@@ -83,7 +114,12 @@ export function BlogPostEditor({
   postId?: string;
   initial: BlogPostEditorValue;
   saving: boolean;
-  onSave: (value: BlogPostEditorValue) => void;
+  /**
+   * Save it. Resolve `true` only when it really landed: that is the signal to
+   * throw away the on-device draft, and doing it on a failed save would delete
+   * the copy that is about to be needed.
+   */
+  onSave: (value: BlogPostEditorValue) => Promise<boolean>;
   /** Called whenever the form's dirty-vs-`initial` state changes, so the
    * parent route can guard navigating away. */
   onDirtyChange?: (dirty: boolean) => void;
@@ -104,6 +140,7 @@ export function BlogPostEditor({
   const imageInputRef = useRef<HTMLInputElement>(null);
   const coverInputRef = useRef<HTMLInputElement>(null);
   const upload = useServerFn(uploadBlogImage);
+  const { user } = useAuth();
 
   // Re-seed the form whenever the parent hands us a new baseline — e.g. the
   // edit page updates `initial` after a successful save, so the "unsaved
@@ -131,9 +168,12 @@ export function BlogPostEditor({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dirty]);
 
-  // Covers a closed tab / refresh / typed-in address bar. In-app navigation
-  // (clicking another sidebar link) is guarded separately by the parent
-  // route's "Back to posts" action, which checks `dirty` before navigating.
+  // Covers a closed tab / refresh / typed-in address bar on a DESKTOP browser.
+  // In-app navigation (clicking another sidebar link) is guarded separately by
+  // the parent route's "Back to posts" action, which checks `dirty` before
+  // navigating. On a phone this fires for essentially nothing — iOS ignores it,
+  // and an installed app the system reclaims in the background is never asked to
+  // unload — which is why the real safety net is the draft below, not this.
   useEffect(() => {
     if (!dirty) return;
     function handler(e: BeforeUnloadEvent) {
@@ -143,6 +183,49 @@ export function BlogPostEditor({
     window.addEventListener("beforeunload", handler);
     return () => window.removeEventListener("beforeunload", handler);
   }, [dirty]);
+
+  // The safety net. Everything typed here is kept on this device as it is
+  // written and flushed the moment the page is hidden, so leaving the app and
+  // coming back to a relaunched, empty editor no longer costs the post. See
+  // `src/lib/editor-draft.ts` for why this is localStorage where the waiver's
+  // equivalent is sessionStorage.
+  const draftFields = useMemo<BlogDraftFields>(
+    () => ({ title, slug, excerpt, body, status, coverPath, coverUrl: coverUrl ?? "" }),
+    [title, slug, excerpt, body, status, coverPath, coverUrl],
+  );
+  const draftBaseline = useMemo<BlogDraftFields>(
+    () => ({
+      title: initial.title,
+      slug: initial.slug,
+      excerpt: initial.excerpt,
+      body: initial.body_md,
+      status: initial.status,
+      coverPath: initial.cover_image_path,
+      coverUrl: initial.cover_image_url ?? "",
+    }),
+    [initial],
+  );
+  const draft = useEditorDraft<BlogDraftFields>({
+    kind: "blog-post",
+    scope: postId ?? "new",
+    owner: user?.id ?? null,
+    value: draftFields,
+    baseline: draftBaseline,
+    shape: BLOG_DRAFT_SHAPE,
+  });
+
+  function restoreDraft() {
+    const stored = draft.offered;
+    if (!stored) return;
+    setTitle(stored.title);
+    setSlug(stored.slug);
+    setExcerpt(stored.excerpt);
+    setBody(stored.body);
+    setStatus(stored.status === "published" ? "published" : "draft");
+    setCoverPath(stored.coverPath);
+    setCoverUrl(stored.coverUrl || null);
+    draft.restore();
+  }
 
   const willUnpublish = initial.status === "published" && status === "draft";
 
@@ -218,7 +301,14 @@ export function BlogPostEditor({
     // publishing it again from this same form, and the notice under the status
     // picker already says what saving will do, before the click rather than
     // after it. A modal on top of that is friction on a reversible action.
-    onSave(value);
+    //
+    // The draft is cleared only once the save has actually landed. The edit page
+    // also moves its baseline to match, which clears it a second time; the new
+    // post page navigates away instead, and without this its draft would be
+    // offered back the next time somebody opened "New post".
+    void onSave(value).then((saved) => {
+      if (saved) draft.clear();
+    });
   }
 
   const previewSlug = slug.trim() || defaultBlogSlug(title) || "your-post-title";
@@ -414,6 +504,16 @@ export function BlogPostEditor({
 
   return (
     <div>
+      {draft.offered && (
+        <DraftRestoreBanner
+          className="mb-4"
+          what="post"
+          savedAt={draft.offeredAt}
+          onRestore={restoreDraft}
+          onDiscard={draft.discard}
+        />
+      )}
+
       {/* Below `lg`, Write/Preview share the same space via a manual toggle
           rather than shadcn's Tabs: Tabs mounts both panels (or unmounts the
           inactive one) which would either duplicate every field's `id` or

--- a/src/components/site/DraftRestoreBanner.tsx
+++ b/src/components/site/DraftRestoreBanner.tsx
@@ -1,0 +1,57 @@
+import { FileClock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { describeWhen } from "@/lib/dates";
+
+/**
+ * "You have unsaved work on this device. Want it back?"
+ *
+ * Shown by an editor when `useEditorDraft` finds something on the device that
+ * differs from what the server last saved. It is an offer, not a restore: see
+ * the note in `use-editor-draft.ts` about why a draft is never pushed back over
+ * somebody's form on its own.
+ *
+ * `role="status"` rather than `alert`. Nothing is wrong — the opposite, in fact
+ * — and this appears a moment after the page settles, which is exactly the case
+ * a polite live region is for.
+ */
+export function DraftRestoreBanner({
+  savedAt,
+  what,
+  onRestore,
+  onDiscard,
+  className,
+}: {
+  /** Epoch ms the draft was written. */
+  savedAt: number | null;
+  /** What was being written, in the person's words: "post", "article". */
+  what: string;
+  onRestore: () => void;
+  onDiscard: () => void;
+  className?: string;
+}) {
+  return (
+    <div
+      role="status"
+      className={cn("rounded-lg border border-primary/40 bg-primary/5 p-4", className)}
+    >
+      <p className="flex items-start gap-2 text-sm font-medium">
+        <FileClock className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+        You have an unsaved {what} on this device.
+      </p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {savedAt ? `Kept from ${describeWhen(savedAt)}. ` : ""}
+        It was never saved to the site, so nobody else can see it. Bringing it back replaces what is
+        in the form now.
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <Button size="sm" onClick={onRestore}>
+          Bring it back
+        </Button>
+        <Button size="sm" variant="outline" onClick={onDiscard}>
+          Discard it
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/site/KbLayout.tsx
+++ b/src/components/site/KbLayout.tsx
@@ -32,6 +32,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { LoadFailure } from "@/components/site/LoadFailure";
 import { Loading } from "@/components/site/Loading";
+import { StaleNotice } from "@/components/site/StaleNotice";
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import logoAsset from "@/assets/UTS_JITSU_CMYK.png.asset.json";
@@ -43,7 +44,7 @@ import type { KbNavEntry, KbNavSection } from "@/lib/kb-nav";
 import { searchKnowledgeBase } from "@/lib/kb.functions";
 
 export function KbLayout({ children }: { children: React.ReactNode }) {
-  const { nav, loading, error, refetch } = useKbNav();
+  const { nav, loading, error, restoredAt, refetch } = useKbNav();
   const [menuOpen, setMenuOpen] = useState(false);
   const location = useLocation();
 
@@ -66,7 +67,13 @@ export function KbLayout({ children }: { children: React.ReactNode }) {
             <SheetContent side="left" className="w-[85vw] max-w-xs overflow-y-auto p-0">
               <SheetTitle className="border-b px-4 py-4 text-base">Knowledge base</SheetTitle>
               <div className="p-4">
-                <KbNavList nav={nav} loading={loading} error={error} onRetry={refetch} />
+                <KbNavList
+                  nav={nav}
+                  loading={loading}
+                  error={error}
+                  restoredAt={restoredAt}
+                  onRetry={refetch}
+                />
               </div>
             </SheetContent>
           </Sheet>
@@ -100,7 +107,13 @@ export function KbLayout({ children }: { children: React.ReactNode }) {
       <div className="mx-auto flex w-full max-w-7xl flex-1 gap-8 px-4 py-8">
         <aside className="hidden w-60 shrink-0 lg:block">
           <div className="sticky top-24 max-h-[calc(100vh-8rem)] overflow-y-auto pr-2">
-            <KbNavList nav={nav} loading={loading} error={error} onRetry={refetch} />
+            <KbNavList
+              nav={nav}
+              loading={loading}
+              error={error}
+              restoredAt={restoredAt}
+              onRetry={refetch}
+            />
           </div>
         </aside>
         <main className="min-w-0 flex-1">{children}</main>
@@ -127,11 +140,14 @@ function KbNavList({
   nav,
   loading,
   error,
+  restoredAt,
   onRetry,
 }: {
   nav: KbNavSection[];
   loading: boolean;
   error: string | null;
+  /** Set when this list is the copy kept on the device and the refresh failed. */
+  restoredAt: number | null;
   onRetry: () => void;
 }) {
   const location = useLocation();
@@ -168,8 +184,11 @@ function KbNavList({
   }
 
   // The third answer the sidebar used to fold into the second one: the list
-  // could not be fetched. Left as an empty knowledge base, a reader has no
-  // reason to try again and no way to.
+  // could not be fetched AT ALL. `useKbNav` only reports an error when there is
+  // no list to show, because the contents is kept on the device: a failed
+  // background refresh over a good cached list is a staleness notice below, not
+  // a panel in place of the sidebar. Blanking a working sidebar on a bad
+  // connection would be this cache making things worse.
   if (error) {
     return (
       <>
@@ -193,9 +212,14 @@ function KbNavList({
     );
   }
 
+  const staleNotice = restoredAt ? (
+    <StaleNotice className="mb-3" what="contents" savedAt={restoredAt} onRetry={onRetry} />
+  ) : null;
+
   return (
     <nav aria-label="Knowledge base" className="space-y-6">
       {backToMemberSpace}
+      {staleNotice}
       {nav.map((section) => (
         <div key={section.slug ?? "unsectioned"} className="space-y-1">
           <p className="px-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">

--- a/src/components/site/SaveFailure.tsx
+++ b/src/components/site/SaveFailure.tsx
@@ -1,0 +1,55 @@
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * The panel a screen shows when a SAVE did not go through.
+ *
+ * The sibling of `LoadFailure`, and it exists for the same reason: a
+ * `toast.error` is not a UI for anything that matters. It fades in four
+ * seconds, and what it leaves behind is a form that looks exactly like one that
+ * saved successfully. Somebody who glanced away walks off believing their work
+ * is filed. On a phone, where the toast can be missed entirely, that is the
+ * normal case rather than the unlucky one.
+ *
+ * So the failure stays on screen, says the work is still here, and carries the
+ * button that tries again.
+ *
+ * `role="alert"` because this reports something that did not happen, and a
+ * screen-reader user has no other signal: the form looks unchanged either way.
+ */
+export function SaveFailure({
+  what,
+  message,
+  onRetry,
+  retrying,
+  className,
+}: {
+  /** What was being saved, in the person's words: "post", "article". */
+  what: string;
+  /** Whatever the failure itself said. */
+  message: string;
+  onRetry: () => void;
+  retrying?: boolean;
+  className?: string;
+}) {
+  return (
+    <div
+      role="alert"
+      className={cn("rounded-lg border border-destructive/40 bg-destructive/5 p-4", className)}
+    >
+      <p className="flex items-start gap-2 text-sm font-medium">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" aria-hidden="true" />
+        This {what} was not saved.
+      </p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {message} Everything you have written is still on this screen and kept on this device, so
+        nothing is lost. Try again when you have a connection.
+      </p>
+      <Button className="mt-3" size="sm" variant="outline" disabled={retrying} onClick={onRetry}>
+        <RefreshCw className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+        {retrying ? "Saving..." : "Try again"}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/site/StaleNotice.tsx
+++ b/src/components/site/StaleNotice.tsx
@@ -30,19 +30,18 @@ export function StaleNotice({
   className?: string;
 }) {
   return (
-    <div
-      role="status"
-      className={cn(
-        "flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border bg-muted/50 px-3 py-2 text-sm",
-        className,
-      )}
-    >
-      <CloudOff className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-      <span className="text-muted-foreground">
-        Showing the {what} saved on this device at {describeWhen(savedAt)}. We could not reach the
-        site to check for anything newer.
-      </span>
-      <Button size="sm" variant="outline" className="ml-auto" onClick={onRetry}>
+    <div role="status" className={cn("rounded-lg border bg-muted/50 px-3 py-2 text-sm", className)}>
+      <p className="flex items-start gap-2 text-muted-foreground">
+        <CloudOff className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+        <span>
+          Showing the {what} saved on this device at {describeWhen(savedAt)}. We could not reach the
+          site to check for anything newer.
+        </span>
+      </p>
+      {/* Left-aligned under the text, like `LoadFailure` and `SaveFailure`. An
+          `ml-auto` here stranded it alone at the far right of its own line once
+          the message wrapped, which on a phone is every time. */}
+      <Button size="sm" variant="outline" className="mt-2" onClick={onRetry}>
         <RefreshCw className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" /> Try again
       </Button>
     </div>

--- a/src/components/site/StaleNotice.tsx
+++ b/src/components/site/StaleNotice.tsx
@@ -1,0 +1,50 @@
+import { CloudOff, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { describeWhen } from "@/lib/dates";
+import { cn } from "@/lib/utils";
+
+/**
+ * "This is what your phone had. We could not check for anything newer."
+ *
+ * Shown when a screen is rendering a copy kept on the device
+ * (`usePersistentQuery`) and the refresh behind it failed. Both halves matter:
+ * without the cache the screen would be an error panel, and without this notice
+ * it would be a confident, possibly out-of-date answer with no way to tell.
+ *
+ * The counterpart to `LoadFailure`, which is for a load that produced NOTHING.
+ * This one is for a load that produced something slightly old, so it is a note
+ * beside the content rather than a panel in place of it, and it is `status`
+ * rather than `alert`: nothing is broken, the screen is just behind.
+ */
+export function StaleNotice({
+  savedAt,
+  what,
+  onRetry,
+  className,
+}: {
+  /** Epoch ms the copy on screen was fetched. */
+  savedAt: number;
+  /** What is being shown, in the reader's words: "roster", "article". */
+  what: string;
+  onRetry: () => void;
+  className?: string;
+}) {
+  return (
+    <div
+      role="status"
+      className={cn(
+        "flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border bg-muted/50 px-3 py-2 text-sm",
+        className,
+      )}
+    >
+      <CloudOff className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+      <span className="text-muted-foreground">
+        Showing the {what} saved on this device at {describeWhen(savedAt)}. We could not reach the
+        site to check for anything newer.
+      </span>
+      <Button size="sm" variant="outline" className="ml-auto" onClick={onRetry}>
+        <RefreshCw className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" /> Try again
+      </Button>
+    </div>
+  );
+}

--- a/src/hooks/use-editor-draft.ts
+++ b/src/hooks/use-editor-draft.ts
@@ -1,0 +1,157 @@
+// Wiring the draft safety net onto an editor.
+//
+// The rules are in `src/lib/editor-draft.ts`; this is when to apply them. Two
+// things here are the whole point and are easy to get wrong:
+//
+// **Flush when the page is hidden, not when it unloads.** `beforeunload` is what
+// the blog composer had, and on a phone it does essentially nothing: iOS Safari
+// ignores it, and an app the operating system reclaims in the background is
+// never asked to unload at all — it is simply gone, and relaunched cold later.
+// `visibilitychange` to `hidden` (and `pagehide`, its partner for the back/
+// forward cache) are the last events a page is *guaranteed* to get, so that is
+// where the save has to happen. This is the event that would have saved the
+// draft that prompted all of this.
+//
+// **Never restore without asking.** A stored draft is offered, and the offer is
+// dismissible. Somebody who abandoned a draft on purpose, or who has since
+// edited the same post from a laptop, must not have this device's older copy
+// pushed silently over what they meant to keep.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  EDITOR_DRAFT_DEBOUNCE_MS,
+  clearEditorDraft,
+  draftVerdict,
+  readEditorDraft,
+  sameDraftFields,
+  writeEditorDraft,
+} from "@/lib/editor-draft";
+
+export type EditorDraftState<T> = {
+  /** The stored draft to offer back, or null when there is nothing to offer. */
+  offered: T | null;
+  /** When that draft was written, epoch ms, for the "from 14:32" line. */
+  offeredAt: number | null;
+  /** Take the offer: the caller seeds its form from `offered`. */
+  restore: () => void;
+  /** Refuse it, and throw the stored copy away. */
+  discard: () => void;
+  /** Drop the stored draft after a successful save. */
+  clear: () => void;
+};
+
+/**
+ * Keep `value` on the device, and offer back anything found there on mount.
+ *
+ * `scope` names the document (a post id, or "new"). `owner` is the signed-in
+ * user id, so a draft is never handed to whoever signs in next on a shared club
+ * laptop. `enabled` lets a caller hold off until it knows what the saved version
+ * is — comparing against a baseline that has not loaded would offer a draft that
+ * turns out to be identical to it.
+ */
+export function useEditorDraft<T extends Record<string, string | boolean>>({
+  kind,
+  scope,
+  owner,
+  value,
+  baseline,
+  shape,
+  enabled = true,
+}: {
+  kind: string;
+  scope: string;
+  owner: string | null;
+  /** The live form contents. */
+  value: T;
+  /** What is saved on the server right now. */
+  baseline: T;
+  /** Field list and per-field empty value; see `reviveDraftFields`. */
+  shape: T;
+  enabled?: boolean;
+}): EditorDraftState<T> {
+  const [offered, setOffered] = useState<T | null>(null);
+  const [offeredAt, setOfferedAt] = useState<number | null>(null);
+  const [checked, setChecked] = useState(false);
+
+  // Read once the caller says it is ready, and only once: re-reading after the
+  // person has already answered the offer would put it back on screen.
+  useEffect(() => {
+    if (!enabled || checked) return;
+    setChecked(true);
+    const hit = readEditorDraft(kind, scope, owner, shape);
+    const verdict = draftVerdict(hit?.data ?? null, baseline, sameDraftFields);
+    if (verdict === "stale") {
+      clearEditorDraft(kind, scope);
+      return;
+    }
+    if (verdict === "offer" && hit) {
+      setOffered(hit.data);
+      setOfferedAt(hit.savedAt);
+    }
+    // `baseline` and `shape` are read at the moment this first runs and are not
+    // re-checked; adding them would re-offer a draft the person just dismissed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, checked, kind, scope, owner]);
+
+  // The live value, in a ref, so the hidden-page flush below can read it without
+  // re-registering its listeners on every keystroke.
+  const latest = useRef(value);
+  latest.current = value;
+  const dirty = enabled && !sameDraftFields(value, baseline);
+  const dirtyRef = useRef(dirty);
+  dirtyRef.current = dirty;
+
+  const save = useCallback(() => {
+    if (!dirtyRef.current) return;
+    writeEditorDraft(kind, scope, owner, latest.current);
+  }, [kind, scope, owner]);
+
+  // The ordinary path: a moment after typing stops.
+  useEffect(() => {
+    if (!enabled) return;
+    if (!dirty) {
+      // Back to matching what is saved (an undo, or a successful save that moved
+      // the baseline). Nothing to recover, so nothing should be offered later.
+      clearEditorDraft(kind, scope);
+      return;
+    }
+    const timer = setTimeout(save, EDITOR_DRAFT_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [enabled, dirty, value, kind, scope, save]);
+
+  // The path that actually matters on a phone. Both events, because they cover
+  // different exits: `visibilitychange` fires when the app goes to the
+  // background (the case that lost the draft), `pagehide` when the page is
+  // frozen or replaced. Neither is cancellable, so there is nothing to interrupt
+  // and no dialog: it just quietly saves.
+  useEffect(() => {
+    if (!enabled) return;
+    const onHide = () => {
+      if (document.visibilityState === "hidden") save();
+    };
+    const onPageHide = () => save();
+    document.addEventListener("visibilitychange", onHide);
+    window.addEventListener("pagehide", onPageHide);
+    return () => {
+      document.removeEventListener("visibilitychange", onHide);
+      window.removeEventListener("pagehide", onPageHide);
+    };
+  }, [enabled, save]);
+
+  const restore = useCallback(() => {
+    setOffered(null);
+    setOfferedAt(null);
+  }, []);
+
+  const discard = useCallback(() => {
+    clearEditorDraft(kind, scope);
+    setOffered(null);
+    setOfferedAt(null);
+  }, [kind, scope]);
+
+  const clear = useCallback(() => {
+    clearEditorDraft(kind, scope);
+  }, [kind, scope]);
+
+  return { offered, offeredAt, restore, discard, clear };
+}

--- a/src/hooks/use-editor-draft.ts
+++ b/src/hooks/use-editor-draft.ts
@@ -69,15 +69,29 @@ export function useEditorDraft<T extends Record<string, string | boolean>>({
   shape: T;
   enabled?: boolean;
 }): EditorDraftState<T> {
-  const [offered, setOffered] = useState<T | null>(null);
-  const [offeredAt, setOfferedAt] = useState<number | null>(null);
-  const [checked, setChecked] = useState(false);
+  /**
+   * Which document this hook has looked on the device for.
+   *
+   * Keyed rather than a bare "have we checked yet" boolean, because two of the
+   * three editors using this (`manager.kb.tsx`, `manager.waiver-template.tsx`)
+   * are single-page selectors: picking a different article or version changes
+   * `scope` in place, with no remount. A boolean latched on the first document
+   * and never looked at any other one again, so every document opened after the
+   * first silently lost its draft instead of being offered it -- the exact
+   * opposite of what this is for.
+   */
+  const scopeKey = `${kind}\u0000${scope}\u0000${owner ?? ""}`;
+  const [checkedScope, setCheckedScope] = useState<string | null>(null);
+  /** The offer, tagged with the document it belongs to. */
+  const [offer, setOffer] = useState<{ scope: string; data: T; savedAt: number } | null>(null);
 
-  // Read once the caller says it is ready, and only once: re-reading after the
-  // person has already answered the offer would put it back on screen.
+  // Look once per document. Not on every render: re-reading after the person has
+  // answered would put the offer straight back on screen.
   useEffect(() => {
-    if (!enabled || checked) return;
-    setChecked(true);
+    if (!enabled || checkedScope === scopeKey) return;
+    setCheckedScope(scopeKey);
+    // Whatever was being offered belonged to the document we just left.
+    setOffer(null);
     const hit = readEditorDraft(kind, scope, owner, shape);
     const verdict = draftVerdict(hit?.data ?? null, baseline, sameDraftFields);
     if (verdict === "stale") {
@@ -85,13 +99,20 @@ export function useEditorDraft<T extends Record<string, string | boolean>>({
       return;
     }
     if (verdict === "offer" && hit) {
-      setOffered(hit.data);
-      setOfferedAt(hit.savedAt);
+      setOffer({ scope: scopeKey, data: hit.data, savedAt: hit.savedAt });
     }
-    // `baseline` and `shape` are read at the moment this first runs and are not
-    // re-checked; adding them would re-offer a draft the person just dismissed.
+    // `baseline` and `shape` are read at the moment this runs for a given
+    // document and are not re-checked; adding them would re-offer a draft the
+    // person just dismissed. Both editors set the new scope and the new
+    // baseline in the same commit, so the baseline read here is the right one.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, checked, kind, scope, owner]);
+  }, [enabled, checkedScope, scopeKey, kind, scope, owner]);
+
+  // Only ever the offer for the document on screen. Tagging and comparing, so a
+  // scope change cannot leave the previous document's draft on offer for one
+  // render against the wrong form.
+  const offered = offer && offer.scope === scopeKey ? offer.data : null;
+  const offeredAt = offer && offer.scope === scopeKey ? offer.savedAt : null;
 
   // The live value, in a ref, so the hidden-page flush below can read it without
   // re-registering its listeners on every keystroke.
@@ -109,15 +130,26 @@ export function useEditorDraft<T extends Record<string, string | boolean>>({
   // The ordinary path: a moment after typing stops.
   useEffect(() => {
     if (!enabled) return;
+    // Never delete a draft we have not looked at yet. On the first render for a
+    // document the form has just been seeded from the saved version, so it
+    // matches the baseline and reads as "nothing to recover" -- which would
+    // delete that document's stored draft on sight, before anyone was ever
+    // shown it.
+    if (checkedScope !== scopeKey) return;
     if (!dirty) {
       // Back to matching what is saved (an undo, or a successful save that moved
       // the baseline). Nothing to recover, so nothing should be offered later.
-      clearEditorDraft(kind, scope);
+      //
+      // Unless an offer is still on screen: an unanswered offer sits in exactly
+      // this state (the form still matches the baseline, the draft is the thing
+      // being offered), so clearing here deleted the draft in the same breath as
+      // offering it back. Anyone who was killed again before answering lost it.
+      if (!offered) clearEditorDraft(kind, scope);
       return;
     }
     const timer = setTimeout(save, EDITOR_DRAFT_DEBOUNCE_MS);
     return () => clearTimeout(timer);
-  }, [enabled, dirty, value, kind, scope, save]);
+  }, [enabled, checkedScope, scopeKey, offered, dirty, value, kind, scope, save]);
 
   // The path that actually matters on a phone. Both events, because they cover
   // different exits: `visibilitychange` fires when the app goes to the
@@ -138,15 +170,11 @@ export function useEditorDraft<T extends Record<string, string | boolean>>({
     };
   }, [enabled, save]);
 
-  const restore = useCallback(() => {
-    setOffered(null);
-    setOfferedAt(null);
-  }, []);
+  const restore = useCallback(() => setOffer(null), []);
 
   const discard = useCallback(() => {
     clearEditorDraft(kind, scope);
-    setOffered(null);
-    setOfferedAt(null);
+    setOffer(null);
   }, [kind, scope]);
 
   const clear = useCallback(() => {

--- a/src/hooks/use-persistent-query.test.tsx
+++ b/src/hooks/use-persistent-query.test.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from "react";
 import { z } from "zod";
 import { usePersistentQuery } from "@/hooks/use-persistent-query";
 import { cacheReviver } from "@/lib/kb-cache";
+import * as localCache from "@/lib/local-cache";
 import { readCache, writeCache } from "@/lib/local-cache";
 import { PERSISTENT_QUERY_VERSION } from "@/hooks/use-persistent-query";
 
@@ -134,5 +135,29 @@ describe("usePersistentQuery", () => {
       { wrapper },
     );
     await waitFor(() => expect(window.localStorage.length).toBe(0));
+  });
+
+  it("reads the device once per key, not on every render", async () => {
+    writeCache("thing", { items: ["from the device"] }, PERSISTENT_QUERY_VERSION, "user-1");
+    const spy = vi.spyOn(localCache, "readCache");
+
+    const { rerender } = renderHook(
+      () => usePersistentQuery<Payload>(options(() => new Promise(() => {}))),
+      { wrapper },
+    );
+    const afterFirst = spy.mock.calls.length;
+    // Guard against this test passing vacuously: if the spy never intercepted
+    // the read at all, the count below would be 0 === 0 and prove nothing.
+    expect(afterFirst).toBeGreaterThan(0);
+    rerender();
+    rerender();
+    rerender();
+
+    // Re-reading per render means a synchronous localStorage read and a
+    // JSON.parse of the whole payload on every keystroke into any field on the
+    // page. The check-in screen puts a search box directly above a roster of
+    // every member, which is exactly the worst case.
+    expect(spy.mock.calls.length).toBe(afterFirst);
+    spy.mockRestore();
   });
 });

--- a/src/hooks/use-persistent-query.test.tsx
+++ b/src/hooks/use-persistent-query.test.tsx
@@ -1,0 +1,138 @@
+// The behaviour that makes a launch on a bad connection paint instead of spin.
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { z } from "zod";
+import { usePersistentQuery } from "@/hooks/use-persistent-query";
+import { cacheReviver } from "@/lib/kb-cache";
+import { readCache, writeCache } from "@/lib/local-cache";
+import { PERSISTENT_QUERY_VERSION } from "@/hooks/use-persistent-query";
+
+type Payload = { items: string[] };
+const schema = z.object({ items: z.array(z.string()) });
+const revive = cacheReviver<Payload>(schema);
+const terms = { version: PERSISTENT_QUERY_VERSION, owner: "user-1", maxAgeMs: 60_000, revive };
+
+function wrapper({ children }: { children: ReactNode }) {
+  // Retries off so a rejecting query settles inside the test rather than
+  // spending the default backoff.
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function options(queryFn: () => Promise<Payload>, overrides: Record<string, unknown> = {}) {
+  return {
+    queryKey: ["thing", "user-1"],
+    queryFn,
+    cacheKey: "thing",
+    owner: "user-1",
+    maxAgeMs: 60_000,
+    revive,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.useRealTimers();
+});
+
+describe("usePersistentQuery", () => {
+  it("has the stored answer on the very first render, with no loading state", () => {
+    writeCache("thing", { items: ["from the device"] }, PERSISTENT_QUERY_VERSION, "user-1");
+    // A promise that never settles: this is the "no signal" case, and the point
+    // is that the screen is useful anyway.
+    const { result } = renderHook(
+      () => usePersistentQuery<Payload>(options(() => new Promise(() => {}))),
+      {
+        wrapper,
+      },
+    );
+
+    // Not "after an effect" — immediately. Reading in an effect would flash the
+    // spinner this exists to remove.
+    expect(result.current.data).toEqual({ items: ["from the device"] });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.restoredAt).toBeGreaterThan(0);
+  });
+
+  it("replaces the stored answer with the network's, and stops calling it restored", async () => {
+    writeCache("thing", { items: ["old"] }, PERSISTENT_QUERY_VERSION, "user-1");
+    const { result } = renderHook(
+      () =>
+        usePersistentQuery<Payload>(options(async () => ({ items: ["fresh"] }), { staleTime: 0 })),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual({ items: ["fresh"] }));
+    expect(result.current.restoredAt).toBeNull();
+  });
+
+  it("writes what the network returned back to the device", async () => {
+    const { result } = renderHook(
+      () => usePersistentQuery<Payload>(options(async () => ({ items: ["fresh"] }))),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual({ items: ["fresh"] }));
+    await waitFor(() => expect(readCache("thing", terms)?.data).toEqual({ items: ["fresh"] }));
+  });
+
+  it("does not hand one person's stored answer to another", () => {
+    writeCache("thing", { items: ["theirs"] }, PERSISTENT_QUERY_VERSION, "user-2");
+    const { result } = renderHook(
+      () => usePersistentQuery<Payload>(options(() => new Promise(() => {}))),
+      { wrapper },
+    );
+
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("ignores a stored answer that no longer parses", () => {
+    // Written by an older build with a different shape. Handing it to a
+    // component would be a white screen on launch, which is worse than the
+    // spinner.
+    writeCache("thing", { items: [1, 2, 3] }, PERSISTENT_QUERY_VERSION, "user-1");
+    const { result } = renderHook(
+      () => usePersistentQuery<Payload>(options(() => new Promise(() => {}))),
+      { wrapper },
+    );
+
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("keeps showing the stored answer when the network fails outright", async () => {
+    writeCache("thing", { items: ["from the device"] }, PERSISTENT_QUERY_VERSION, "user-1");
+    const { result } = renderHook(
+      () =>
+        usePersistentQuery<Payload>(
+          options(
+            async () => {
+              throw new Error("offline");
+            },
+            { staleTime: 0 },
+          ),
+        ),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    // The whole point at the door of a gym: a failed refresh must not blank the
+    // roster that was already on screen.
+    expect(result.current.data).toEqual({ items: ["from the device"] });
+    // And the failure must not have overwritten the good copy on the device.
+    expect(readCache("thing", terms)?.data).toEqual({ items: ["from the device"] });
+  });
+
+  it("stores nothing while disabled", async () => {
+    renderHook(
+      () =>
+        usePersistentQuery<Payload>(
+          options(async () => ({ items: ["fresh"] }), { enabled: false }),
+        ),
+      { wrapper },
+    );
+    await waitFor(() => expect(window.localStorage.length).toBe(0));
+  });
+});

--- a/src/hooks/use-persistent-query.ts
+++ b/src/hooks/use-persistent-query.ts
@@ -26,9 +26,9 @@
 // offline read AND being a few minutes out of date is honest rather than
 // misleading. Anything a manager would act on irreversibly does not belong here.
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useQuery, type QueryKey, type UseQueryResult } from "@tanstack/react-query";
-import { readCache, writeCache } from "@/lib/local-cache";
+import { readCache, writeCache, type CacheHit } from "@/lib/local-cache";
 
 /** Bumped when the envelope changes; the payload's own shape is `revive`'s job. */
 export const PERSISTENT_QUERY_VERSION = 1;
@@ -75,9 +75,24 @@ export function usePersistentQuery<T>({
   // Read during render, not in an effect. An effect runs after the first paint,
   // which would mean a flash of the loading state before the cached answer
   // appeared — exactly the spinner this exists to remove.
-  const seed = enabled
-    ? readCache<T>(cacheKey, { version: PERSISTENT_QUERY_VERSION, owner, maxAgeMs, revive })
-    : null;
+  //
+  // Once per key, though, and that is what the ref is for. Reading on every
+  // render would mean a synchronous `localStorage` read and a `JSON.parse` of
+  // the whole payload on every keystroke into any field on the page — the
+  // check-in screen has a search box directly above a roster of every member,
+  // which is precisely the worst case. It is also what keeps `seed` stable, so
+  // `restoredAt` below does not change identity under a re-render.
+  const seedKey = `${cacheKey}\u0000${owner ?? ""}\u0000${enabled}`;
+  const seedRef = useRef<{ key: string; hit: CacheHit<T> | null } | null>(null);
+  if (seedRef.current?.key !== seedKey) {
+    seedRef.current = {
+      key: seedKey,
+      hit: enabled
+        ? readCache<T>(cacheKey, { version: PERSISTENT_QUERY_VERSION, owner, maxAgeMs, revive })
+        : null,
+    };
+  }
+  const seed = seedRef.current.hit;
 
   const query = useQuery({
     queryKey,

--- a/src/hooks/use-persistent-query.ts
+++ b/src/hooks/use-persistent-query.ts
@@ -1,0 +1,110 @@
+// A query whose answer survives the app being closed.
+//
+// React Query already caches, but only in memory: the moment the tab is
+// discarded or the installed app is reclaimed by the phone, every answer it
+// held is gone. That is fine on a laptop and wrong on the two screens this club
+// actually uses on bad connections:
+//
+//   * **Check-in**, run at the door of a university gym, on a phone, by a
+//     manager with a queue of people in front of them. Relaunching to a spinner
+//     (or worse, to "could not load the roster") is the failure that matters.
+//   * **The knowledge base**, which members read on the mat between rounds. It
+//     is the club's own prose and it changes a few times a year, so re-fetching
+//     it on every launch is pure cost.
+//
+// So this seeds a query from the device and then refreshes it in the background:
+// what was there last time paints immediately, and the network result replaces
+// it when it arrives. Same shape as the service worker's stale-while-revalidate
+// for assets, one layer up.
+//
+// **What is allowed in here.** Everything stored is scoped to the signed-in
+// person, dropped the moment they sign out (`clearCacheFor` in `__root.tsx`),
+// and given a hard expiry so a stale answer cannot outlive its usefulness. That
+// is a deliberate line: `public/sw.js` refuses to cache HTML precisely so that
+// no signed-in page can be served to the next person on a shared device, and
+// this must not quietly undo it. Only opt a query in when the data is worth an
+// offline read AND being a few minutes out of date is honest rather than
+// misleading. Anything a manager would act on irreversibly does not belong here.
+
+import { useEffect } from "react";
+import { useQuery, type QueryKey, type UseQueryResult } from "@tanstack/react-query";
+import { readCache, writeCache } from "@/lib/local-cache";
+
+/** Bumped when the envelope changes; the payload's own shape is `revive`'s job. */
+export const PERSISTENT_QUERY_VERSION = 1;
+
+export type PersistentQueryOptions<T> = {
+  /** React Query's key. Include the reader's id, as the KB queries already do. */
+  queryKey: QueryKey;
+  queryFn: () => Promise<T>;
+  /**
+   * The storage key. Deliberately separate from `queryKey` rather than derived
+   * from it: a key is a shape somebody will change one day, and deriving would
+   * silently orphan every entry already on every device the next time it moved.
+   */
+  cacheKey: string;
+  /** Who this belongs to. `null` reads and writes the signed-out slot. */
+  owner: string | null;
+  /** Refuse anything stored longer ago than this. */
+  maxAgeMs: number;
+  /** Total, and required — see `CacheTerms.revive`. */
+  revive: (value: unknown) => T | null;
+  staleTime?: number;
+  enabled?: boolean;
+};
+
+export type PersistentQueryResult<T> = UseQueryResult<T> & {
+  /**
+   * When the data on screen was fetched, if it came off the device rather than
+   * the network. Null once a fresh answer has landed, so a screen can say "this
+   * is what was here at 18:40" only while that is actually true.
+   */
+  restoredAt: number | null;
+};
+
+export function usePersistentQuery<T>({
+  queryKey,
+  queryFn,
+  cacheKey,
+  owner,
+  maxAgeMs,
+  revive,
+  staleTime,
+  enabled = true,
+}: PersistentQueryOptions<T>): PersistentQueryResult<T> {
+  // Read during render, not in an effect. An effect runs after the first paint,
+  // which would mean a flash of the loading state before the cached answer
+  // appeared — exactly the spinner this exists to remove.
+  const seed = enabled
+    ? readCache<T>(cacheKey, { version: PERSISTENT_QUERY_VERSION, owner, maxAgeMs, revive })
+    : null;
+
+  const query = useQuery({
+    queryKey,
+    queryFn,
+    enabled,
+    staleTime,
+    initialData: seed?.data,
+    // Without this the seeded answer would count as having arrived just now, so
+    // `staleTime` would hold it on screen without ever checking. Dating it
+    // honestly is what makes the refresh-in-the-background half happen.
+    initialDataUpdatedAt: seed?.savedAt,
+  });
+
+  const { data, isSuccess, isFetching } = query;
+
+  useEffect(() => {
+    if (!enabled || !isSuccess || data === undefined) return;
+    // While a fetch is in flight, `data` is still the seeded copy. Writing then
+    // would refresh its timestamp without refreshing its contents, and an entry
+    // that keeps re-dating itself never expires.
+    if (isFetching) return;
+    writeCache(cacheKey, data, PERSISTENT_QUERY_VERSION, owner);
+  }, [enabled, isSuccess, isFetching, data, cacheKey, owner]);
+
+  // Only while what is on screen really is the stored copy: as soon as the
+  // background refresh lands, `dataUpdatedAt` moves past it.
+  const restoredAt = seed && query.dataUpdatedAt <= seed.savedAt ? seed.savedAt : null;
+
+  return Object.assign(query, { restoredAt });
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -4,19 +4,45 @@ import { supabase } from "@/integrations/supabase/client";
 
 export type AppRole = "manager" | "member";
 
+/**
+ * Whether two sessions differ in any way a screen could care about.
+ *
+ * supabase-js re-reads the stored session on every visibilitychange and hands
+ * back a freshly built object each time, so comparing by reference makes every
+ * return to the app look like a change. That re-rendered every consumer of this
+ * hook (which is most of the signed-in app) for no reason at all, and any effect
+ * keyed on `session` re-ran with it. Compare the two things that actually decide
+ * what a screen shows instead: who it is, and which token their requests carry.
+ */
+function sameSession(a: Session | null, b: Session | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.user.id === b.user.id && a.access_token === b.access_token;
+}
+
 export function useAuth() {
   const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const { data: sub } = supabase.auth.onAuthStateChange((_e, s) => {
-      setSession(s);
-      setUser(s?.user ?? null);
-    });
+    const apply = (next: Session | null) => {
+      setSession((current) => (sameSession(current, next) ? current : next));
+      setUser((current) => {
+        const nextUser = next?.user ?? null;
+        // Keep the same `User` object while it is the same person, unchanged:
+        // `user` is an effect dependency and a query-key ingredient all over the
+        // app. `updated_at` is what moves when a profile or email really changes
+        // (USER_UPDATED), so this holds identity steady without going stale.
+        if (!current || !nextUser) return nextUser;
+        if (current.id === nextUser.id && current.updated_at === nextUser.updated_at)
+          return current;
+        return nextUser;
+      });
+    };
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, s) => apply(s));
     supabase.auth.getSession().then(({ data }) => {
-      setSession(data.session);
-      setUser(data.session?.user ?? null);
+      apply(data.session);
       setLoading(false);
     });
     return () => sub.subscription.unsubscribe();

--- a/src/hooks/useKbArticle.ts
+++ b/src/hooks/useKbArticle.ts
@@ -16,10 +16,14 @@
 //    the article is simply there, which is the difference between the knowledge
 //    base feeling like a set of pages and feeling like an app.
 import { useCallback } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
 import { useAuth } from "@/hooks/useAuth";
+import { usePersistentQuery } from "@/hooks/use-persistent-query";
+import { KB_CACHE_MAX_AGE_MS, cacheReviver, kbArticleCacheSchema } from "@/lib/kb-cache";
 import { getKbArticle } from "@/lib/kb.functions";
+
+type KbArticlePayload = Awaited<ReturnType<typeof getKbArticle>>;
 
 /**
  * How long a fetched article counts as fresh.
@@ -66,9 +70,19 @@ export function kbAnnotationsQueryKey(userId: string | null, slug: string) {
 export function useKbArticle(slug: string) {
   const { user, loading: authLoading } = useAuth();
   const fetchArticle = useServerFn(getKbArticle);
-  return useQuery({
-    ...articleQueryOptions(fetchArticle, user?.id ?? null, slug),
+  const userId = user?.id ?? null;
+  return usePersistentQuery<KbArticlePayload>({
+    ...articleQueryOptions(fetchArticle, userId, slug),
     enabled: !authLoading,
+    // Kept on the device so an article read once is readable again with no
+    // signal, and so relaunching the installed app onto an article shows the
+    // text rather than a spinner. Scoped to the reader and dropped on sign-out
+    // (`clearCacheFor` in `__root.tsx`) for the same reason the query key is:
+    // a managers-only draft must not outlive the session that could read it.
+    cacheKey: `kb-article.${userId ?? "anon"}.${slug}`,
+    owner: userId,
+    maxAgeMs: KB_CACHE_MAX_AGE_MS,
+    revive: cacheReviver<KbArticlePayload>(kbArticleCacheSchema),
   });
 }
 

--- a/src/hooks/useKbNav.test.tsx
+++ b/src/hooks/useKbNav.test.tsx
@@ -4,8 +4,10 @@
 // a failed fetch stops being a load and starts being an error.
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
+import { PERSISTENT_QUERY_VERSION } from "@/hooks/use-persistent-query";
+import { writeCache } from "@/lib/local-cache";
 
 const fetchNav = vi.fn();
 
@@ -19,6 +21,31 @@ function wrapper({ children }: { children: ReactNode }) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }
+
+/** Older than KB_NAV_STALE_TIME, so the hook actually refreshes behind it. */
+const STALE_ENOUGH = () => Date.now() - 10 * 60_000;
+
+const NAV = {
+  sections: [{ slug: "start", title: "Getting started", position: 10 }],
+  entries: [
+    {
+      slug: "your-first-class",
+      title: "Your first class",
+      link_path: null,
+      section_slug: "start",
+      position: 10,
+      visibility: "members",
+      version: 1,
+      read_version: null,
+      updated_at: "2026-08-01T00:00:00Z",
+    },
+  ],
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.clearAllMocks();
+});
 
 describe("useKbNav", () => {
   it("reports the failure instead of loading forever", async () => {
@@ -36,5 +63,42 @@ describe("useKbNav", () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.error).toBeNull();
+  });
+
+  it("keeps a cached sidebar on screen when the refresh fails", async () => {
+    // The trap this pins, and the reason it is worth a test: `docs/pwa.md` says
+    // a screen must key its "not available" branch on having NO data, never on
+    // `isError`. Reporting an error here blanked a working sidebar behind a
+    // panel on exactly the bad connection the caching exists for.
+    writeCache("kb-nav.u1", NAV, PERSISTENT_QUERY_VERSION, "u1", STALE_ENOUGH());
+    fetchNav.mockRejectedValue(new Error("Failed to fetch"));
+
+    const { result } = renderHook(() => useKbNav(), { wrapper });
+
+    await waitFor(() => expect(result.current.restoredAt).not.toBeNull());
+    expect(result.current.nav).toHaveLength(1);
+    expect(result.current.nav[0].entries[0].slug).toBe("your-first-class");
+    // Not an error: there is a perfectly good list to read.
+    expect(result.current.error).toBeNull();
+  });
+
+  it("says nothing about staleness once the refresh lands", async () => {
+    writeCache("kb-nav.u1", NAV, PERSISTENT_QUERY_VERSION, "u1", STALE_ENOUGH());
+    fetchNav.mockResolvedValue(NAV);
+
+    const { result } = renderHook(() => useKbNav(), { wrapper });
+
+    await waitFor(() => expect(result.current.nav).toHaveLength(1));
+    await waitFor(() => expect(fetchNav).toHaveBeenCalled());
+    expect(result.current.restoredAt).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("still reports a real failure when there is nothing cached", async () => {
+    fetchNav.mockRejectedValue(new Error("Failed to fetch"));
+    const { result } = renderHook(() => useKbNav(), { wrapper });
+
+    await waitFor(() => expect(result.current.error).toBe("Failed to fetch"));
+    expect(result.current.restoredAt).toBeNull();
   });
 });

--- a/src/hooks/useKbNav.ts
+++ b/src/hooks/useKbNav.ts
@@ -32,8 +32,9 @@ export function useKbNav(): {
   error: string | null;
   refetch: () => void;
   /**
-   * When the sidebar on screen was fetched, if it came off this device rather
-   * than the network. Null once a fresh copy has landed.
+   * When the sidebar on screen was fetched, set only while it is the copy kept
+   * on this device AND the refresh behind it failed. Null otherwise, including
+   * once a fresh copy has landed.
    */
   restoredAt: number | null;
 } {
@@ -81,13 +82,23 @@ export function useKbNav(): {
   // `isLoading` is false once a query has failed, and it was the only thing
   // reported here: /kb sat on "Loading..." for good, with no error and no way
   // out, because nothing downstream could see that the fetch had rejected.
+  //
+  // `error` is now gated on there being NO contents, not on `isError` alone.
+  // With the sidebar kept on the device, a failed background refresh leaves a
+  // perfectly good list in `query.data` -- and reporting that as an error blanked
+  // the whole sidebar behind a panel on exactly the bad connection this caching
+  // exists for. A stale list is reported through `restoredAt` instead, which is
+  // the rule `docs/pwa.md` states and `/kb/<slug>` already follows.
+  const failedOutright = query.isError && !query.data;
   return {
     nav,
     loading: authLoading || query.isLoading,
-    error: query.isError
+    error: failedOutright
       ? describeLoadError(query.error, "Could not load the knowledge base")
       : null,
     refetch: () => void query.refetch(),
-    restoredAt: query.restoredAt,
+    // Set only while what is on screen is the stored copy AND the refresh behind
+    // it failed, so a screen can say so without having to work it out.
+    restoredAt: query.isError ? query.restoredAt : null,
   };
 }

--- a/src/hooks/useKbNav.ts
+++ b/src/hooks/useKbNav.ts
@@ -9,8 +9,9 @@
 // They share one query key, so moving between articles reuses the cached nav
 // instead of refetching the whole structure on every click.
 import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
+import { usePersistentQuery } from "@/hooks/use-persistent-query";
+import { KB_CACHE_MAX_AGE_MS, cacheReviver, kbNavCacheSchema } from "@/lib/kb-cache";
 import { useAuth } from "@/hooks/useAuth";
 import { describeLoadError } from "@/lib/load-error";
 import { buildKbNav } from "@/lib/kb-nav";
@@ -22,16 +23,23 @@ import { listKnowledgeBase } from "@/lib/kb.functions";
  */
 export const KB_NAV_STALE_TIME = 5 * 60_000;
 
+type KbNavPayload = Awaited<ReturnType<typeof listKnowledgeBase>>;
+
 export function useKbNav(): {
   nav: KbNavSection[];
   loading: boolean;
   /** Set when the fetch rejected. Null while it is in flight and once it lands. */
   error: string | null;
   refetch: () => void;
+  /**
+   * When the sidebar on screen was fetched, if it came off this device rather
+   * than the network. Null once a fresh copy has landed.
+   */
+  restoredAt: number | null;
 } {
   const { user, loading: authLoading } = useAuth();
   const fetchNav = useServerFn(listKnowledgeBase);
-  const query = useQuery({
+  const query = usePersistentQuery<KbNavPayload>({
     // Keyed by WHO it was fetched for. `__root.tsx` deliberately does not
     // invalidate the query cache on SIGNED_OUT, which was safe while every
     // screen holding privileged data lived under `_authenticated` and navigated
@@ -54,6 +62,16 @@ export function useKbNav(): {
     // the nav again. `markKbArticleRead` invalidates this key when a tick needs
     // to appear, so progress is still immediate.
     staleTime: KB_NAV_STALE_TIME,
+    // Kept on the device as well as in memory, so opening the installed app
+    // paints the sidebar it had last time instead of a spinner, and a member
+    // with no signal can still see what the knowledge base contains. Scoped to
+    // the reader for the same reason the query key is (a manager's drafts must
+    // not survive into the next person's session), and dropped outright on sign
+    // out by `clearCacheFor` in `__root.tsx`.
+    cacheKey: `kb-nav.${user?.id ?? "anon"}`,
+    owner: user?.id ?? null,
+    maxAgeMs: KB_CACHE_MAX_AGE_MS,
+    revive: cacheReviver<KbNavPayload>(kbNavCacheSchema),
   });
 
   const nav = useMemo(
@@ -70,5 +88,6 @@ export function useKbNav(): {
       ? describeLoadError(query.error, "Could not load the knowledge base")
       : null,
     refetch: () => void query.refetch(),
+    restoredAt: query.restoredAt,
   };
 }

--- a/src/lib/auth-events.test.ts
+++ b/src/lib/auth-events.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { resolveAuthRefresh } from "@/lib/auth-events";
+
+const nothing = { invalidateRouter: false, invalidateQueries: false };
+
+describe("resolveAuthRefresh", () => {
+  it("ignores the SIGNED_IN supabase re-emits when the page becomes visible", () => {
+    // The regression this exists for: supabase-js recovers the stored session on
+    // every visibilitychange and announces it as SIGNED_IN. Same person, same
+    // token, so nothing on screen is out of date.
+    expect(resolveAuthRefresh("SIGNED_IN", "user-1", "user-1")).toEqual(nothing);
+  });
+
+  it("ignores the first event of the page's life", () => {
+    // The page just loaded with this session. Invalidating here makes every cold
+    // start fetch its data twice.
+    expect(resolveAuthRefresh("SIGNED_IN", undefined, "user-1")).toEqual(nothing);
+    expect(resolveAuthRefresh("SIGNED_OUT", undefined, null)).toEqual(nothing);
+  });
+
+  it("refreshes everything when a different person signs in", () => {
+    expect(resolveAuthRefresh("SIGNED_IN", null, "user-1")).toEqual({
+      invalidateRouter: true,
+      invalidateQueries: true,
+    });
+    expect(resolveAuthRefresh("SIGNED_IN", "user-1", "user-2")).toEqual({
+      invalidateRouter: true,
+      invalidateQueries: true,
+    });
+  });
+
+  it("re-runs the loaders on sign-out but does not refetch queries", () => {
+    expect(resolveAuthRefresh("SIGNED_OUT", "user-1", null)).toEqual({
+      invalidateRouter: true,
+      invalidateQueries: false,
+    });
+  });
+
+  it("acts on USER_UPDATED even though the id is unchanged", () => {
+    expect(resolveAuthRefresh("USER_UPDATED", "user-1", "user-1")).toEqual({
+      invalidateRouter: true,
+      invalidateQueries: true,
+    });
+  });
+
+  it("ignores token refreshes and every other event", () => {
+    for (const event of [
+      "TOKEN_REFRESHED",
+      "PASSWORD_RECOVERY",
+      "INITIAL_SESSION",
+      "MFA_CHALLENGE_VERIFIED",
+    ]) {
+      expect(resolveAuthRefresh(event, "user-1", "user-1")).toEqual(nothing);
+    }
+    // A token refresh must stay quiet even though supabase hands over a brand
+    // new access token each time.
+    expect(resolveAuthRefresh("TOKEN_REFRESHED", "user-1", "user-1")).toEqual(nothing);
+  });
+});

--- a/src/lib/auth-events.test.ts
+++ b/src/lib/auth-events.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { resolveAuthRefresh } from "@/lib/auth-events";
+import { reportsIdentity, resolveAuthRefresh } from "@/lib/auth-events";
 
-const nothing = { invalidateRouter: false, invalidateQueries: false };
+const nothing = { invalidateRouter: false, invalidateQueries: false, clearDeviceCache: null };
 
 describe("resolveAuthRefresh", () => {
   it("ignores the SIGNED_IN supabase re-emits when the page becomes visible", () => {
@@ -22,10 +22,12 @@ describe("resolveAuthRefresh", () => {
     expect(resolveAuthRefresh("SIGNED_IN", null, "user-1")).toEqual({
       invalidateRouter: true,
       invalidateQueries: true,
+      clearDeviceCache: { owner: null },
     });
     expect(resolveAuthRefresh("SIGNED_IN", "user-1", "user-2")).toEqual({
       invalidateRouter: true,
       invalidateQueries: true,
+      clearDeviceCache: { owner: "user-1" },
     });
   });
 
@@ -33,6 +35,7 @@ describe("resolveAuthRefresh", () => {
     expect(resolveAuthRefresh("SIGNED_OUT", "user-1", null)).toEqual({
       invalidateRouter: true,
       invalidateQueries: false,
+      clearDeviceCache: { owner: "user-1" },
     });
   });
 
@@ -40,6 +43,7 @@ describe("resolveAuthRefresh", () => {
     expect(resolveAuthRefresh("USER_UPDATED", "user-1", "user-1")).toEqual({
       invalidateRouter: true,
       invalidateQueries: true,
+      clearDeviceCache: null,
     });
   });
 
@@ -55,5 +59,143 @@ describe("resolveAuthRefresh", () => {
     // A token refresh must stay quiet even though supabase hands over a brand
     // new access token each time.
     expect(resolveAuthRefresh("TOKEN_REFRESHED", "user-1", "user-1")).toEqual(nothing);
+  });
+
+  describe("clearing the device", () => {
+    // The privacy guarantee behind every cached article, roster and draft: a
+    // club laptop handed to the next person must carry nothing of the last.
+    it("wipes the previous person's data when somebody signs out", () => {
+      expect(resolveAuthRefresh("SIGNED_OUT", "user-1", null).clearDeviceCache).toEqual({
+        owner: "user-1",
+      });
+    });
+
+    it("wipes it when a DIFFERENT person signs in without a sign-out in between", () => {
+      expect(resolveAuthRefresh("SIGNED_IN", "user-1", "user-2").clearDeviceCache).toEqual({
+        owner: "user-1",
+      });
+    });
+
+    it("keeps it when the same person is re-announced", () => {
+      // This fires on every visibility change. Wiping here would throw away an
+      // unsaved draft every time somebody switched apps, which is the exact
+      // failure the draft net exists to prevent.
+      expect(resolveAuthRefresh("SIGNED_IN", "user-1", "user-1").clearDeviceCache).toBeNull();
+      expect(resolveAuthRefresh("TOKEN_REFRESHED", "user-1", "user-1").clearDeviceCache).toBeNull();
+    });
+
+    it("keeps it when the same person's profile changes", () => {
+      expect(resolveAuthRefresh("USER_UPDATED", "user-1", "user-1").clearDeviceCache).toBeNull();
+    });
+
+    it("can name the signed-out slot, distinctly from clearing nothing", () => {
+      // `{ owner: null }` and `null` are different answers. A bare
+      // `string | null` would collapse them and make one unreachable.
+      expect(resolveAuthRefresh("SIGNED_IN", null, "user-1").clearDeviceCache).toEqual({
+        owner: null,
+      });
+      expect(resolveAuthRefresh("SIGNED_IN", "user-1", "user-1").clearDeviceCache).toBeNull();
+    });
+  });
+
+  describe("the real event sequence a subscription receives", () => {
+    /**
+     * What `__root.tsx` does, in miniature: feed events through in order,
+     * adopting identity exactly as the wiring does, and report what each one
+     * asked for. The bug that made this necessary was invisible to every test
+     * that called `resolveAuthRefresh` on its own, because it lived in WHICH
+     * events were allowed to update `previousUserId`.
+     */
+    function drive(events: [string, string | null][]) {
+      let previousUserId: string | null | undefined = undefined;
+      return events.map(([event, userId]) => {
+        const refresh = resolveAuthRefresh(event, previousUserId, userId);
+        if (reportsIdentity(event, userId)) previousUserId = userId;
+        return refresh;
+      });
+    }
+
+    it("wipes the device when a returning member signs out", () => {
+      // The sequence a returning member's tab actually sees. supabase fires
+      // INITIAL_SESSION first, carrying the stored session -- never SIGNED_IN.
+      // Adopting only from SIGNED_IN meant this sign-out had nobody to clear
+      // for, and the cached roster, articles and drafts stayed on the device.
+      const [initial, signedOut] = drive([
+        ["INITIAL_SESSION", "user-1"],
+        ["SIGNED_OUT", null],
+      ]);
+
+      expect(initial.clearDeviceCache).toBeNull();
+      expect(signedOut.clearDeviceCache).toEqual({ owner: "user-1" });
+      expect(signedOut.invalidateRouter).toBe(true);
+    });
+
+    it("wipes it when the tab did see a SIGNED_IN first", () => {
+      const [, , signedOut] = drive([
+        ["INITIAL_SESSION", "user-1"],
+        ["SIGNED_IN", "user-1"],
+        ["SIGNED_OUT", null],
+      ]);
+      expect(signedOut.clearDeviceCache).toEqual({ owner: "user-1" });
+    });
+
+    it("stays quiet through a whole session of tab switches", () => {
+      // Every visibility change re-announces the session. None of these should
+      // refetch anything or touch what is on the device.
+      const results = drive([
+        ["INITIAL_SESSION", "user-1"],
+        ["SIGNED_IN", "user-1"],
+        ["TOKEN_REFRESHED", "user-1"],
+        ["SIGNED_IN", "user-1"],
+        ["SIGNED_IN", "user-1"],
+      ]);
+      for (const r of results) {
+        expect(r).toEqual({
+          invalidateRouter: false,
+          invalidateQueries: false,
+          clearDeviceCache: null,
+        });
+      }
+    });
+
+    it("wipes the first person's data when a second signs in on the same device", () => {
+      const [, , , second] = drive([
+        ["INITIAL_SESSION", "user-1"],
+        ["SIGNED_OUT", null],
+        ["INITIAL_SESSION", null],
+        ["SIGNED_IN", "user-2"],
+      ]);
+      // user-1's data went at the sign-out; this clears the signed-out slot.
+      expect(second.clearDeviceCache).toEqual({ owner: null });
+      expect(second.invalidateQueries).toBe(true);
+    });
+
+    it("starting signed out and staying so asks for nothing", () => {
+      const results = drive([
+        ["INITIAL_SESSION", null],
+        ["SIGNED_OUT", null],
+      ]);
+      for (const r of results) expect(r.clearDeviceCache).toBeNull();
+    });
+  });
+
+  describe("reportsIdentity", () => {
+    it("believes any event that carries a session", () => {
+      for (const event of ["INITIAL_SESSION", "SIGNED_IN", "TOKEN_REFRESHED", "USER_UPDATED"]) {
+        expect(reportsIdentity(event, "user-1")).toBe(true);
+      }
+    });
+
+    it("believes the two events that legitimately report nobody", () => {
+      expect(reportsIdentity("SIGNED_OUT", null)).toBe(true);
+      expect(reportsIdentity("INITIAL_SESSION", null)).toBe(true);
+    });
+
+    it("does not forget who somebody is because an event arrived without a session", () => {
+      // A sessionless TOKEN_REFRESHED is not evidence that the person left, and
+      // forgetting them here would lose the id the device needs wiping for.
+      expect(reportsIdentity("TOKEN_REFRESHED", null)).toBe(false);
+      expect(reportsIdentity("USER_UPDATED", null)).toBe(false);
+    });
   });
 });

--- a/src/lib/auth-events.ts
+++ b/src/lib/auth-events.ts
@@ -23,9 +23,30 @@ export type AuthRefresh = {
   invalidateRouter: boolean;
   /** Re-fetch cached queries as well. */
   invalidateQueries: boolean;
+  /**
+   * Whose data to wipe off this device, or null to keep everything.
+   *
+   * Wrapped in an object rather than a bare `string | null` so that "clear the
+   * signed-out slot" (`{ owner: null }`) stays expressible and distinct from
+   * "clear nothing" (`null`). A bare union would collapse the two and quietly
+   * make one of them unreachable.
+   *
+   * This is the privacy rule for everything `local-cache.ts` stores: a cached
+   * knowledge base, a check-in roster full of members' names and emails, an
+   * unsaved draft. It lives here, next to the identity rule it depends on,
+   * rather than as a condition inside the root component, because it is the
+   * guarantee that makes storing any of it defensible on a club laptop several
+   * people use -- and a guarantee that exists only as untested wiring is not
+   * one.
+   */
+  clearDeviceCache: { owner: string | null } | null;
 };
 
-const NOTHING: AuthRefresh = { invalidateRouter: false, invalidateQueries: false };
+const NOTHING: AuthRefresh = {
+  invalidateRouter: false,
+  invalidateQueries: false,
+  clearDeviceCache: null,
+};
 
 /**
  * Decide what an auth event is worth.
@@ -47,14 +68,19 @@ export function resolveAuthRefresh(
   // A profile or email change keeps the same id but changes what the app should
   // be showing, so it is the one event that is always worth acting on.
   if (event === "USER_UPDATED") {
-    return { invalidateRouter: true, invalidateQueries: true };
+    // The same person, so their own cached data is still theirs to see.
+    return { invalidateRouter: true, invalidateQueries: true, clearDeviceCache: null };
   }
 
   if (event !== "SIGNED_IN" && event !== "SIGNED_OUT") return NOTHING;
 
-  // First event of the page's life: adopt it, don't act on it.
+  // First event of the page's life: adopt it, don't act on it. Nothing to clear
+  // either: this IS the session the page loaded with, so whatever is on the
+  // device already belongs to whoever is holding it.
   if (previousUserId === undefined) return NOTHING;
 
+  // Includes the SIGNED_IN supabase re-emits on every visibility change. Signing
+  // the same person back in is not a handover, so their cache survives it.
   if (previousUserId === nextUserId) return NOTHING;
 
   // Signing out: re-run the loaders so the auth gate redirects, but do NOT
@@ -62,7 +88,42 @@ export function resolveAuthRefresh(
   // keyed by reader id (see `useKbNav`), so they are already unreachable, and
   // refetching them on the way out would fire a screenful of requests as the
   // session that could answer them disappears.
-  if (nextUserId === null) return { invalidateRouter: true, invalidateQueries: false };
+  //
+  // Either way the person at the keyboard has changed, so everything this app
+  // kept on the device for the previous one goes.
+  if (nextUserId === null) {
+    return {
+      invalidateRouter: true,
+      invalidateQueries: false,
+      clearDeviceCache: { owner: previousUserId },
+    };
+  }
 
-  return { invalidateRouter: true, invalidateQueries: true };
+  return {
+    invalidateRouter: true,
+    invalidateQueries: true,
+    clearDeviceCache: { owner: previousUserId },
+  };
+}
+
+/**
+ * Whether an event's session tells us who is signed in.
+ *
+ * This exists because of a bug worth remembering: `previousUserId` used to be
+ * adopted only from `SIGNED_IN` / `SIGNED_OUT`, but the FIRST event supabase
+ * hands any new subscriber is `INITIAL_SESSION`, carrying whatever session
+ * already exists. A returning member's tab therefore never learned who they
+ * were, so when they later signed out there was no id to wipe the device for --
+ * and the cached roster, articles and drafts stayed behind on a shared laptop.
+ * The privacy guarantee was, in the ordinary case, not being kept at all.
+ *
+ * So identity is adopted from every event that actually reports it. An event
+ * carrying a session names its user; `SIGNED_OUT` and `INITIAL_SESSION` are the
+ * two that legitimately report nobody. Anything else arriving with no session is
+ * not evidence that the person left, so it is ignored rather than forgetting who
+ * they are.
+ */
+export function reportsIdentity(event: string, nextUserId: string | null): boolean {
+  if (nextUserId !== null) return true;
+  return event === "SIGNED_OUT" || event === "INITIAL_SESSION";
 }

--- a/src/lib/auth-events.ts
+++ b/src/lib/auth-events.ts
@@ -1,0 +1,68 @@
+// Which Supabase auth events actually mean something changed.
+//
+// supabase-js re-reads the stored session every single time the page becomes
+// visible (`_onVisibilityChanged` -> `_recoverAndRefresh`) and, when it finds a
+// usable one, announces it as `SIGNED_IN`. That is not a sign-in. It is the same
+// person, the same token, said again, and it fires on every tab switch, every
+// phone unlock and every return to the installed app.
+//
+// The app used to take it at face value and throw away every route loader and
+// every cached query on each one, so coming back to the app re-fetched the whole
+// screen from scratch. That is the single biggest reason the installed app felt
+// so eager to reload, and on a phone in a gym it is seconds of spinners over a
+// connection that was the problem in the first place.
+//
+// So the rule here is about identity rather than about the event's name: refresh
+// when the signed-in person actually changes, and leave the screen alone
+// otherwise. Kept side-effect free and free of React and Supabase imports so it
+// can be unit tested directly, the same way `auth-persistence.ts` is.
+
+/** What a given auth event should cause the app to throw away. */
+export type AuthRefresh = {
+  /** Re-run the route loaders (who the page is for has changed). */
+  invalidateRouter: boolean;
+  /** Re-fetch cached queries as well. */
+  invalidateQueries: boolean;
+};
+
+const NOTHING: AuthRefresh = { invalidateRouter: false, invalidateQueries: false };
+
+/**
+ * Decide what an auth event is worth.
+ *
+ * `previousUserId` is deliberately three-valued:
+ *
+ *  - `undefined` — we have not seen an event yet. The very first one is the
+ *    session the page loaded with, so there is nothing on screen that predates
+ *    it and nothing to invalidate. Adopting it silently is what stops every cold
+ *    start fetching its data twice.
+ *  - `null` — we know the person is signed out.
+ *  - a string — we know who they are.
+ */
+export function resolveAuthRefresh(
+  event: string,
+  previousUserId: string | null | undefined,
+  nextUserId: string | null,
+): AuthRefresh {
+  // A profile or email change keeps the same id but changes what the app should
+  // be showing, so it is the one event that is always worth acting on.
+  if (event === "USER_UPDATED") {
+    return { invalidateRouter: true, invalidateQueries: true };
+  }
+
+  if (event !== "SIGNED_IN" && event !== "SIGNED_OUT") return NOTHING;
+
+  // First event of the page's life: adopt it, don't act on it.
+  if (previousUserId === undefined) return NOTHING;
+
+  if (previousUserId === nextUserId) return NOTHING;
+
+  // Signing out: re-run the loaders so the auth gate redirects, but do NOT
+  // invalidate the query cache. The queries that hold anything privileged are
+  // keyed by reader id (see `useKbNav`), so they are already unreachable, and
+  // refetching them on the way out would fire a screenful of requests as the
+  // session that could answer them disappears.
+  if (nextUserId === null) return { invalidateRouter: true, invalidateQueries: false };
+
+  return { invalidateRouter: true, invalidateQueries: true };
+}

--- a/src/lib/checkin-cache.test.ts
+++ b/src/lib/checkin-cache.test.ts
@@ -1,0 +1,116 @@
+// These schemas decide what the door screen shows when there is no signal, so
+// they have to describe what the server really returns — and they have to keep
+// working when a new warning code or a new field is added, because a schema that
+// rejects those empties the cache it exists to fill.
+import { describe, expect, it } from "vitest";
+import {
+  CHECKIN_CACHE_MAX_AGE_MS,
+  checkInBoardCacheSchema,
+  checkInEventsCacheSchema,
+  knownCheckInWarnings,
+} from "@/lib/checkin-cache";
+import { KB_CACHE_MAX_AGE_MS } from "@/lib/kb-cache";
+
+const event = {
+  id: "event-1",
+  title: "Beginners",
+  instructor_name: "Sam",
+  location: "UTS Ultimo",
+  starts_at: "2026-08-26T08:00:00Z",
+  ends_at: "2026-08-26T09:30:00Z",
+  status: "scheduled",
+};
+
+const board = {
+  event,
+  roster: [
+    {
+      user_id: "user-1",
+      name: "Jane L.",
+      email: "jane@example.com",
+      coverage: "trial",
+      plan_name: "Free trial",
+      sessions_remaining_before: 2,
+      consumes_credit: true,
+      warnings: ["last_credit"],
+    },
+  ],
+  checkins: [
+    {
+      id: "checkin-1",
+      user_id: "user-1",
+      name: "Jane L.",
+      checked_in_at: "2026-08-26T08:02:00Z",
+      coverage: "none",
+      plan_name: null,
+      consumed_credit: false,
+      warnings: ["no_cover"],
+    },
+  ],
+};
+
+describe("checkInEventsCacheSchema", () => {
+  it("accepts a real class list", () => {
+    expect(checkInEventsCacheSchema.safeParse([{ ...event, checked_in_count: 4 }]).success).toBe(
+      true,
+    );
+  });
+
+  it("accepts an empty list, which is a real answer", () => {
+    expect(checkInEventsCacheSchema.safeParse([]).success).toBe(true);
+  });
+
+  it("rejects a list whose fields have changed type", () => {
+    expect(checkInEventsCacheSchema.safeParse([{ ...event, checked_in_count: "4" }]).success).toBe(
+      false,
+    );
+  });
+});
+
+describe("checkInBoardCacheSchema", () => {
+  it("accepts a real roster", () => {
+    expect(checkInBoardCacheSchema.safeParse(board).success).toBe(true);
+  });
+
+  it("accepts every coverage the app can produce", () => {
+    for (const coverage of ["trial", "session", "period", "none"]) {
+      const one = { ...board, roster: [{ ...board.roster[0], coverage }] };
+      expect(checkInBoardCacheSchema.safeParse(one).success).toBe(true);
+    }
+  });
+
+  it("rejects a coverage the app does not know", () => {
+    const one = { ...board, roster: [{ ...board.roster[0], coverage: "freebie" }] };
+    expect(checkInBoardCacheSchema.safeParse(one).success).toBe(false);
+  });
+
+  it("accepts every warning code the app has today", () => {
+    const one = { ...board, roster: [{ ...board.roster[0], warnings: [...knownCheckInWarnings] }] };
+    expect(checkInBoardCacheSchema.safeParse(one).success).toBe(true);
+  });
+
+  it("accepts a warning code it has never seen", () => {
+    // Deliberate. Warnings are stored as codes precisely so the wording can
+    // change without a migration, and the screen prints an unknown one
+    // verbatim. Pinning the enum here would invalidate every stored roster on
+    // every phone the day a new code shipped.
+    const one = { ...board, roster: [{ ...board.roster[0], warnings: ["brand_new_code"] }] };
+    expect(checkInBoardCacheSchema.safeParse(one).success).toBe(true);
+  });
+
+  it("rejects anything that is not a roster", () => {
+    for (const value of [null, [], {}, { event }, "text"]) {
+      expect(checkInBoardCacheSchema.safeParse(value).success).toBe(false);
+    }
+  });
+});
+
+describe("CHECKIN_CACHE_MAX_AGE_MS", () => {
+  it("is a day, and shorter than the knowledge base's", () => {
+    // The judgement written down in `checkin-cache.ts`: this one carries
+    // members' names and emails and goes out of date between classes, so it
+    // must never outlive the club's own prose.
+    expect(CHECKIN_CACHE_MAX_AGE_MS).toBe(24 * 60 * 60 * 1000);
+    expect(CHECKIN_CACHE_MAX_AGE_MS).toBeLessThan(KB_CACHE_MAX_AGE_MS);
+  });
+});

--- a/src/lib/checkin-cache.ts
+++ b/src/lib/checkin-cache.ts
@@ -1,0 +1,90 @@
+// What the door screen is allowed to keep on the device.
+//
+// Check-in is run in a university gym, on a phone, by a manager with a queue of
+// people in front of them and whatever reception the building allows. Opening
+// the app to a spinner — or to "the roster could not be loaded" — is the failure
+// that matters there, so the class list and the roster are kept on the device
+// and shown immediately while a fresh copy is fetched behind them.
+//
+// **This one carries members' names and email addresses, so its terms are
+// tighter than the knowledge base's.** Three things make it defensible:
+//
+//   * It is scoped to the manager who fetched it and wiped the moment anybody
+//     signs out (`clearCacheFor` in `__root.tsx`), so a club laptop passed to
+//     the next person carries nothing.
+//   * It expires after a day rather than a week. Memberships are raised and
+//     people sign waivers between classes; a roster older than that is not a
+//     convenience, it is a wrong answer.
+//   * When it IS the stored copy on screen, the screen says so
+//     (`StaleNotice`) rather than presenting it as live.
+//
+// The **needs-attention list is deliberately NOT cached.** It is a worklist, and
+// a stale one invites a manager to chase check-ins somebody already fixed. It
+// stays memory-only and shows its ordinary empty state.
+//
+// Shapes are declared with Zod for the same reason the knowledge base's are —
+// see the note at the top of `kb-cache.ts`.
+
+import { z } from "zod";
+import { checkInWarnings, coverageSources } from "./validation";
+
+/** Bumped when a stored payload's meaning changes. Adding a field does not. */
+export const CHECKIN_CACHE_VERSION = 1;
+
+/**
+ * How long a stored roster or class list is worth showing. See above: a day,
+ * because the club's membership picture genuinely moves between classes.
+ */
+export const CHECKIN_CACHE_MAX_AGE_MS = 24 * 60 * 60_000;
+
+// Warnings are stored as codes so their wording can change without a migration,
+// and the screen already falls back to printing an unknown code verbatim. So
+// this accepts any string rather than the enum: pinning it would make a NEW
+// warning code invalidate every stored roster on every device.
+const warning = z.string();
+const coverage = z.enum(coverageSources);
+
+const calendarEvent = z.object({
+  id: z.string(),
+  title: z.string(),
+  instructor_name: z.string().nullable(),
+  location: z.string().nullable(),
+  starts_at: z.string(),
+  ends_at: z.string(),
+  status: z.string(),
+});
+
+export const checkInEventsCacheSchema = z.array(
+  calendarEvent.extend({ checked_in_count: z.number() }),
+);
+
+export const checkInBoardCacheSchema = z.object({
+  event: calendarEvent,
+  roster: z.array(
+    z.object({
+      user_id: z.string(),
+      name: z.string().nullable(),
+      email: z.string().nullable(),
+      coverage,
+      plan_name: z.string().nullable(),
+      sessions_remaining_before: z.number().nullable(),
+      consumes_credit: z.boolean(),
+      warnings: z.array(warning),
+    }),
+  ),
+  checkins: z.array(
+    z.object({
+      id: z.string(),
+      user_id: z.string(),
+      name: z.string().nullable(),
+      checked_in_at: z.string(),
+      coverage,
+      plan_name: z.string().nullable(),
+      consumed_credit: z.boolean(),
+      warnings: z.array(warning),
+    }),
+  ),
+});
+
+/** Re-exported so a test can assert the warning list is still the app's own. */
+export const knownCheckInWarnings = checkInWarnings;

--- a/src/lib/dates.test.ts
+++ b/src/lib/dates.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { EMPTY, formatDate, formatDateOnly, formatDateTime } from "./dates";
+import { EMPTY, describeWhen, formatDate, formatDateOnly, formatDateTime } from "./dates";
 
 describe("formatDate", () => {
   it("shows the empty glyph for a missing date", () => {
@@ -43,5 +43,34 @@ describe("formatDateOnly", () => {
 
   it("passes through anything that is not a plain YYYY-MM-DD", () => {
     expect(formatDateOnly("1990-04-05T00:00:00Z")).toBe("1990-04-05T00:00:00Z");
+  });
+});
+
+describe("describeWhen", () => {
+  // Fixed local times: a draft banner is read by a person in Sydney looking at
+  // their own clock, so these are built in local time on purpose.
+  const now = new Date(2026, 7, 26, 14, 0, 0).getTime();
+
+  it("gives just the time for something written today", () => {
+    const earlier = new Date(2026, 7, 26, 9, 30, 0).getTime();
+    expect(describeWhen(earlier, now)).toMatch(/9:30/);
+    expect(describeWhen(earlier, now)).not.toMatch(/yesterday|Aug/);
+  });
+
+  it("says yesterday rather than a date", () => {
+    const yesterday = new Date(2026, 7, 25, 21, 5, 0).getTime();
+    expect(describeWhen(yesterday, now)).toMatch(/^yesterday at /);
+  });
+
+  it("gives a date for anything older", () => {
+    // The point of the distinction: knowing whether this is the work you just
+    // lost or something you had forgotten about.
+    const older = new Date(2026, 7, 20, 11, 15, 0).getTime();
+    expect(describeWhen(older, now)).toMatch(/20 Aug at /);
+  });
+
+  it("treats a draft written a minute after midnight as today", () => {
+    const justAfterMidnight = new Date(2026, 7, 26, 0, 1, 0).getTime();
+    expect(describeWhen(justAfterMidnight, now)).not.toMatch(/yesterday/);
   });
 });

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -31,3 +31,22 @@ export function formatDateOnly(value: string | null | undefined): string {
   const parts = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
   return parts ? `${parts[3]}/${parts[2]}/${parts[1]}` : value;
 }
+
+/**
+ * "14:32", "yesterday at 14:32", "12 Aug at 14:32".
+ *
+ * A bare timestamp is the wrong answer for the common case, which is a draft
+ * from ten minutes ago: the useful thing to know is whether this is the work
+ * they just lost or something much older they had forgotten about.
+ */
+export function describeWhen(savedAt: number, now = Date.now()): string {
+  const then = new Date(savedAt);
+  const time = then.toLocaleTimeString("en-AU", { hour: "numeric", minute: "2-digit" });
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+  if (savedAt >= startOfToday.getTime()) return time;
+  const startOfYesterday = startOfToday.getTime() - 24 * 60 * 60_000;
+  if (savedAt >= startOfYesterday) return `yesterday at ${time}`;
+  const date = then.toLocaleDateString("en-AU", { day: "numeric", month: "short" });
+  return `${date} at ${time}`;
+}

--- a/src/lib/editor-draft.test.ts
+++ b/src/lib/editor-draft.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  EDITOR_DRAFT_MAX_AGE_MS,
+  clearEditorDraft,
+  draftVerdict,
+  editorDraftKey,
+  readEditorDraft,
+  reviveDraftFields,
+  sameDraftFields,
+  writeEditorDraft,
+} from "@/lib/editor-draft";
+import { LOCAL_CACHE_PREFIX } from "@/lib/local-cache";
+
+type Fields = { title: string; body: string; published: boolean };
+const shape: Fields = { title: "", body: "", published: false };
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("draftVerdict", () => {
+  const baseline: Fields = { title: "Belts", body: "One", published: false };
+
+  it("says none when there is nothing stored", () => {
+    expect(draftVerdict(null, baseline, sameDraftFields)).toBe("none");
+  });
+
+  it("offers a draft that differs from what was saved", () => {
+    const stored: Fields = { ...baseline, body: "One and a half" };
+    expect(draftVerdict(stored, baseline, sameDraftFields)).toBe("offer");
+  });
+
+  it("calls a draft matching the saved version stale, so it is not offered back", () => {
+    expect(draftVerdict({ ...baseline }, baseline, sameDraftFields)).toBe("stale");
+  });
+
+  it("notices a difference in a boolean field, not just the text", () => {
+    expect(draftVerdict({ ...baseline, published: true }, baseline, sameDraftFields)).toBe("offer");
+  });
+});
+
+describe("sameDraftFields", () => {
+  it("compares every field on either side", () => {
+    expect(sameDraftFields({ a: "1", b: "2" }, { a: "1", b: "2" })).toBe(true);
+    expect(sameDraftFields({ a: "1", b: "2" }, { a: "1", b: "3" })).toBe(false);
+    // A field present on one side only counts as a difference, even when its
+    // value is the empty string. In practice both sides always carry the full
+    // field list (a stored draft comes back through `reviveDraftFields`, which
+    // fills every field from the shape), so this is about never quietly
+    // treating "absent" and "blank" as the same thing.
+    expect(sameDraftFields({ a: "1", b: "" }, { a: "1" } as Record<string, string>)).toBe(false);
+  });
+});
+
+describe("reviveDraftFields", () => {
+  const revive = reviveDraftFields(shape);
+
+  it("fills in a field that is missing or the wrong type from the shape", () => {
+    // A draft written before `published` existed must restore, not be binned:
+    // the alternative loses somebody's half-written article over a field they
+    // never set.
+    expect(revive({ title: "Belts", body: "One" })).toEqual({
+      title: "Belts",
+      body: "One",
+      published: false,
+    });
+    expect(revive({ title: 7, body: null, published: "yes" })).toEqual(shape);
+  });
+
+  it("ignores fields it was not asked for", () => {
+    expect(revive({ ...shape, sneaky: "value" })).toEqual(shape);
+  });
+
+  it("refuses anything that is not an object", () => {
+    expect(revive(null)).toBeNull();
+    expect(revive("text")).toBeNull();
+    expect(revive(7)).toBeNull();
+  });
+});
+
+describe("storage", () => {
+  it("keeps drafts of different documents apart", () => {
+    expect(editorDraftKey("blog-post", "new")).not.toBe(editorDraftKey("blog-post", "abc"));
+
+    writeEditorDraft("blog-post", "new", "user-1", { ...shape, title: "Untitled" });
+    writeEditorDraft("blog-post", "abc", "user-1", { ...shape, title: "Belts" });
+
+    expect(readEditorDraft("blog-post", "new", "user-1", shape)?.data.title).toBe("Untitled");
+    expect(readEditorDraft("blog-post", "abc", "user-1", shape)?.data.title).toBe("Belts");
+  });
+
+  it("does not hand one manager's draft to whoever signs in next", () => {
+    writeEditorDraft("blog-post", "new", "user-1", { ...shape, title: "Belts" });
+    expect(readEditorDraft("blog-post", "new", "user-2", shape)).toBeNull();
+  });
+
+  it("clears a draft", () => {
+    writeEditorDraft("blog-post", "new", "user-1", { ...shape, title: "Belts" });
+    clearEditorDraft("blog-post", "new");
+    expect(readEditorDraft("blog-post", "new", "user-1", shape)).toBeNull();
+  });
+
+  it("forgets a draft nobody came back for", () => {
+    const key = `${LOCAL_CACHE_PREFIX}${editorDraftKey("blog-post", "new")}`;
+    writeEditorDraft("blog-post", "new", "user-1", { ...shape, title: "Belts" });
+    const stored = JSON.parse(window.localStorage.getItem(key)!);
+    stored.at = Date.now() - EDITOR_DRAFT_MAX_AGE_MS - 1;
+    window.localStorage.setItem(key, JSON.stringify(stored));
+
+    expect(readEditorDraft("blog-post", "new", "user-1", shape)).toBeNull();
+  });
+});

--- a/src/lib/editor-draft.ts
+++ b/src/lib/editor-draft.ts
@@ -1,0 +1,163 @@
+// Never lose what somebody typed.
+//
+// The waiver already had this (`waiver-draft.ts`): it keeps a half-filled form
+// on the device so a reload, a crash, or a phone backgrounding the page long
+// enough to be evicted does not cost twenty fields and a signature. Every other
+// place in this app where somebody writes at length had nothing — a blog post, a
+// knowledge base article, the waiver template itself. All three are Markdown
+// somebody may sit with for half an hour, and all three lived only in React
+// state.
+//
+// A manager lost a finished blog draft to exactly that: they left the installed
+// app, the phone reclaimed it, and coming back relaunched the app from scratch
+// with an empty editor. `beforeunload` is the guard the composer had, and it is
+// no guard at all here — iOS ignores it outright, and an app the system kills in
+// the background never gets the chance to fire it.
+//
+// So this is the third occurrence, and the shape worth having in one place. The
+// waiver keeps its own module: its draft is one specific form with a typed
+// shape, health answers and a signature image, and folding it in here would make
+// both worse.
+//
+// **localStorage, not the sessionStorage the waiver uses.** The two are storing
+// different things for different people. The waiver holds a stranger's health
+// answers and signature on a phone that might be borrowed at the door, and it
+// only has to survive a reload — sessionStorage is exactly right for that. These
+// drafts are a manager's own writing on their own device, they hold no personal
+// data about anybody else, and the failure they exist for *is* the app being
+// killed and relaunched, which is precisely when sessionStorage is emptied.
+// Using sessionStorage here would leave the reported bug unfixed.
+//
+// Kept pure and free of React so the rules below can be tested directly; the
+// wiring (when to save, when to ask) is `src/hooks/use-editor-draft.ts`.
+
+import { readCache, removeCache, writeCache, type CacheHit } from "@/lib/local-cache";
+
+/**
+ * Bumped when the *envelope* changes. Individual editors version their own
+ * payload through `revive` — a field added to an editor should restore as blank
+ * rather than binning everybody's in-progress work, the same reasoning as the
+ * `giSize` note in `waiver-draft.ts`.
+ */
+export const EDITOR_DRAFT_VERSION = 1;
+
+/**
+ * How long an unsaved draft is worth offering back.
+ *
+ * Long, because the whole point is to survive being forgotten about: a manager
+ * who starts a post on Tuesday and comes back on Thursday should find it. Not
+ * unbounded, because an offer to restore something from months ago is a puzzle
+ * rather than a rescue, and it would sit against the origin's quota forever.
+ */
+export const EDITOR_DRAFT_MAX_AGE_MS = 14 * 24 * 60 * 60_000;
+
+/**
+ * How long to wait after the last keystroke before writing.
+ *
+ * Long enough not to touch storage on every character, short enough that what is
+ * on the device is never meaningfully behind what is on screen. Whatever this
+ * is, a draft is also flushed the instant the page is hidden (see the hook),
+ * which is the moment that actually matters on a phone.
+ */
+export const EDITOR_DRAFT_DEBOUNCE_MS = 800;
+
+/**
+ * The storage key for one editor's draft.
+ *
+ * `scope` identifies *which document*, so two posts open in two tabs do not
+ * overwrite each other, and so a new post and an existing one are separate. Use
+ * a stable id: the post/article id, or the literal "new" for an unsaved one.
+ */
+export function editorDraftKey(kind: string, scope: string): string {
+  return `draft.${kind}.${scope}`;
+}
+
+/**
+ * What a stored draft is worth on the screen that just opened.
+ *
+ * - `"none"` — nothing stored, or nothing worth restoring.
+ * - `"offer"` — a draft that differs from what the server just handed us. This
+ *   is unsaved work, so ask before touching the form. Never restore silently:
+ *   somebody who deliberately abandoned a draft, or who has since edited the
+ *   same post from a laptop, must not have this device's copy pushed back over
+ *   what they meant to keep.
+ * - `"stale"` — a draft identical to the saved version. It was saved after all,
+ *   so there is nothing to offer and the entry can go.
+ */
+export type DraftVerdict = "none" | "offer" | "stale";
+
+export function draftVerdict<T>(
+  stored: T | null,
+  baseline: T,
+  isSame: (a: T, b: T) => boolean,
+): DraftVerdict {
+  if (stored === null) return "none";
+  return isSame(stored, baseline) ? "stale" : "offer";
+}
+
+/**
+ * A plain-object comparison good enough for these editors.
+ *
+ * Every field in all three is a string or a boolean, so this is exact rather
+ * than approximate. Kept here so each editor does not write its own and quietly
+ * leave a field out of the check, which would make its drafts look "stale" and
+ * be thrown away.
+ */
+export function sameDraftFields<T extends Record<string, string | boolean>>(a: T, b: T): boolean {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const key of keys) {
+    if (a[key as keyof T] !== b[key as keyof T]) return false;
+  }
+  return true;
+}
+
+/**
+ * Build a `revive` for a flat record of strings and booleans.
+ *
+ * `shape` supplies both the field list and the fallback for a field that is
+ * missing or the wrong type, so a draft written before a field existed restores
+ * with that field's empty value rather than being rejected wholesale.
+ */
+export function reviveDraftFields<T extends Record<string, string | boolean>>(
+  shape: T,
+): (value: unknown) => T | null {
+  return (value) => {
+    if (!value || typeof value !== "object") return null;
+    const source = value as Record<string, unknown>;
+    const out: Record<string, string | boolean> = {};
+    for (const [key, fallback] of Object.entries(shape)) {
+      const stored = source[key];
+      out[key] = typeof stored === typeof fallback ? (stored as string | boolean) : fallback;
+    }
+    return out as T;
+  };
+}
+
+/* ---------------- Storage, over `local-cache` ---------------- */
+
+export function readEditorDraft<T extends Record<string, string | boolean>>(
+  kind: string,
+  scope: string,
+  owner: string | null,
+  shape: T,
+): CacheHit<T> | null {
+  return readCache(editorDraftKey(kind, scope), {
+    version: EDITOR_DRAFT_VERSION,
+    owner,
+    maxAgeMs: EDITOR_DRAFT_MAX_AGE_MS,
+    revive: reviveDraftFields(shape),
+  });
+}
+
+export function writeEditorDraft(
+  kind: string,
+  scope: string,
+  owner: string | null,
+  data: Record<string, string | boolean>,
+): void {
+  writeCache(editorDraftKey(kind, scope), data, EDITOR_DRAFT_VERSION, owner);
+}
+
+export function clearEditorDraft(kind: string, scope: string): void {
+  removeCache(editorDraftKey(kind, scope));
+}

--- a/src/lib/kb-cache.test.ts
+++ b/src/lib/kb-cache.test.ts
@@ -1,0 +1,118 @@
+// These schemas decide what comes back off a device, so they have to describe
+// what the server functions really return. A field the server starts sending
+// that these do not know about must not invalidate every stored copy; a field
+// whose meaning changed must be caught here rather than on somebody's phone.
+import { describe, expect, it } from "vitest";
+import {
+  cacheReviver,
+  kbArticleCacheSchema,
+  kbNavCacheSchema,
+  KB_CACHE_MAX_AGE_MS,
+} from "@/lib/kb-cache";
+
+const nav = {
+  sections: [{ slug: "getting-started", title: "Getting started", position: 10 }],
+  entries: [
+    {
+      slug: "your-first-class",
+      title: "Your first class",
+      link_path: null,
+      section_slug: "getting-started",
+      position: 10,
+      visibility: "members",
+      version: 3,
+      read_version: 2,
+      updated_at: "2026-08-01T00:00:00Z",
+    },
+    {
+      slug: "pricing-link",
+      title: "Pricing",
+      link_path: "/pricing",
+      section_slug: null,
+      position: 20,
+      visibility: "members",
+      version: null,
+      read_version: null,
+      updated_at: "2026-08-01T00:00:00Z",
+    },
+  ],
+};
+
+const article = {
+  redirect_to: null,
+  article: {
+    slug: "your-first-class",
+    title: "Your first class",
+    body_md: "## What to bring\n\nA water bottle.",
+    version: 3,
+    is_current_version: true,
+    change_note: null,
+    visibility: "members",
+    annotations_enabled: true,
+    nav_title: null,
+    updated_at: "2026-08-01T00:00:00Z",
+    sections: [
+      { id: "what-to-bring", text: "What to bring", depth: 2, pinned: false, url: "/kb/x#y" },
+    ],
+  },
+  viewer: { signed_in: true, user_id: "user-1", is_manager: false, can_annotate: true },
+};
+
+describe("kbNavCacheSchema", () => {
+  it("accepts a real sidebar payload, articles and link entries alike", () => {
+    expect(kbNavCacheSchema.safeParse(nav).success).toBe(true);
+  });
+
+  it("rejects one whose fields have changed type", () => {
+    const broken = { ...nav, entries: [{ ...nav.entries[0], position: "10" }] };
+    expect(kbNavCacheSchema.safeParse(broken).success).toBe(false);
+  });
+
+  it("rejects a visibility the app does not know", () => {
+    // `public` does not exist for an article (docs/knowledge-base.md), and a
+    // stored entry claiming one would be a permission level nothing enforces.
+    const broken = { ...nav, entries: [{ ...nav.entries[0], visibility: "public" }] };
+    expect(kbNavCacheSchema.safeParse(broken).success).toBe(false);
+  });
+
+  it("rejects anything that is not the payload at all", () => {
+    for (const value of [null, "text", 7, [], {}, { sections: [] }]) {
+      expect(kbNavCacheSchema.safeParse(value).success).toBe(false);
+    }
+  });
+});
+
+describe("kbArticleCacheSchema", () => {
+  it("accepts a real article payload", () => {
+    expect(kbArticleCacheSchema.safeParse(article).success).toBe(true);
+  });
+
+  it("accepts the redirect a link entry returns, which has no article", () => {
+    expect(
+      kbArticleCacheSchema.safeParse({ redirect_to: "/pricing", article: null, viewer: null })
+        .success,
+    ).toBe(true);
+  });
+
+  it("rejects a payload missing the body", () => {
+    const { body_md: _dropped, ...rest } = article.article;
+    expect(kbArticleCacheSchema.safeParse({ ...article, article: rest }).success).toBe(false);
+  });
+});
+
+describe("cacheReviver", () => {
+  it("returns null rather than throwing on anything it cannot parse", () => {
+    const revive = cacheReviver(kbNavCacheSchema);
+    expect(revive(nav)).toEqual(nav);
+    expect(revive(undefined)).toBeNull();
+    expect(revive({ sections: "no" })).toBeNull();
+  });
+});
+
+describe("KB_CACHE_MAX_AGE_MS", () => {
+  it("is a week", () => {
+    // Pinned because it is a judgement about how out of date the club's own
+    // handbooks may be before showing them stops being a service.
+    expect(KB_CACHE_MAX_AGE_MS).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/src/lib/kb-cache.ts
+++ b/src/lib/kb-cache.ts
@@ -1,0 +1,113 @@
+// What the knowledge base is allowed to keep on the device, and how it is read
+// back.
+//
+// `usePersistentQuery` needs a `revive` that is TOTAL: it parses data written by
+// a previous build of the site, possibly mangled, possibly typed in by hand, and
+// it runs during a render. A cast would turn leftover storage into a white
+// screen on launch, which is a worse failure than the spinner this removes.
+//
+// So the shapes are declared with Zod, the same seam every form in this app
+// already validates through (`src/lib/validation.ts`), rather than a second
+// hand-rolled set of type guards. `safeParse` IS the total function the cache
+// wants, and declaring the shape once means a server function that changes what
+// it returns fails a test here instead of silently poisoning every device.
+//
+// `.catch(...)` on the soft fields and `.passthrough()` are deliberate: a field
+// ADDED to one of these payloads must not invalidate every stored copy, or a
+// deploy would empty the cache it exists to fill. A field whose TYPE changed is
+// a different matter, and bumping `KB_CACHE_VERSION` is how that is handled.
+
+import { z } from "zod";
+import { articleVisibilities } from "./kb";
+
+/**
+ * Bumped when a stored payload's meaning changes in a way `safeParse` would not
+ * catch — a renamed field, a repurposed one. Adding a field does not need it.
+ */
+export const KB_CACHE_VERSION = 1;
+
+/**
+ * How long a stored copy of the knowledge base is worth showing.
+ *
+ * A week. These are the club's own handbooks and policies; they change a few
+ * times a year, and a member on the mat reading last week's copy of the grading
+ * syllabus is being served well, not misled. The background refresh replaces it
+ * within a second of the page opening anyway — this bound is about the case
+ * where there is no network at all.
+ */
+export const KB_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60_000;
+
+const visibility = z.enum(articleVisibilities);
+
+const navSection = z.object({
+  slug: z.string(),
+  title: z.string(),
+  position: z.number(),
+});
+
+const navEntry = z.object({
+  slug: z.string(),
+  title: z.string(),
+  link_path: z.string().nullable(),
+  section_slug: z.string().nullable(),
+  position: z.number(),
+  visibility,
+  version: z.number().nullable(),
+  read_version: z.number().nullable(),
+  updated_at: z.string().nullable(),
+});
+
+export const kbNavCacheSchema = z.object({
+  sections: z.array(navSection),
+  entries: z.array(navEntry),
+});
+
+const articleHeading = z.object({
+  id: z.string(),
+  text: z.string(),
+  depth: z.number(),
+  pinned: z.boolean(),
+  url: z.string(),
+});
+
+export const kbArticleCacheSchema = z.object({
+  redirect_to: z.string().nullable(),
+  article: z
+    .object({
+      slug: z.string(),
+      title: z.string(),
+      body_md: z.string(),
+      version: z.number(),
+      is_current_version: z.boolean(),
+      change_note: z.string().nullable(),
+      visibility,
+      annotations_enabled: z.boolean(),
+      nav_title: z.string().nullable(),
+      updated_at: z.string().nullable(),
+      sections: z.array(articleHeading),
+    })
+    .nullable(),
+  viewer: z
+    .object({
+      signed_in: z.boolean(),
+      user_id: z.string().nullable(),
+      is_manager: z.boolean(),
+      can_annotate: z.boolean(),
+    })
+    .nullable(),
+});
+
+/**
+ * Turn a schema into the `revive` the cache wants.
+ *
+ * The cast at the end is the one place this is unavoidable and it is safe: the
+ * server function's return type is what was written, the schema describes it,
+ * and `schema.test.ts` is what keeps the two honest. Everything reaching a
+ * component has been through `safeParse`, so nothing unparsed is ever rendered.
+ */
+export function cacheReviver<T>(schema: z.ZodType): (value: unknown) => T | null {
+  return (value) => {
+    const parsed = schema.safeParse(value);
+    return parsed.success ? (parsed.data as T) : null;
+  };
+}

--- a/src/lib/last-visit.test.ts
+++ b/src/lib/last-visit.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { clearLastVisit, readLastVisit, writeLastVisit } from "@/lib/last-visit";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("last visit", () => {
+  it("reads back what was written, dated", () => {
+    const before = Date.now();
+    writeLastVisit("user-1", "/kb/your-first-class", true);
+    const visit = readLastVisit("user-1");
+
+    expect(visit?.path).toBe("/kb/your-first-class");
+    expect(visit?.hasSession).toBe(true);
+    expect(visit?.at).toBeGreaterThanOrEqual(before);
+  });
+
+  it("keeps a signed-out visit under its own slot", () => {
+    writeLastVisit(null, "/pricing", false);
+    expect(readLastVisit(null)?.path).toBe("/pricing");
+    // Not offered to somebody who has since signed in — that is a different
+    // owner, and `resolveLaunchTarget` refuses the mismatch anyway.
+    expect(readLastVisit("user-1")).toBeNull();
+  });
+
+  it("does not return one manager's last screen to the next person", () => {
+    writeLastVisit("user-1", "/manager/check-in", true);
+    expect(readLastVisit("user-2")).toBeNull();
+  });
+
+  it("clears", () => {
+    writeLastVisit("user-1", "/account", true);
+    clearLastVisit();
+    expect(readLastVisit("user-1")).toBeNull();
+  });
+
+  it("returns null rather than throwing on rubbish in storage", () => {
+    writeLastVisit("user-1", "/account", true);
+    const key = Object.keys(window.localStorage).find((k) => k.includes("last-visit"))!;
+    window.localStorage.setItem(key, "{not json");
+    expect(readLastVisit("user-1")).toBeNull();
+  });
+});

--- a/src/lib/last-visit.ts
+++ b/src/lib/last-visit.ts
@@ -1,0 +1,40 @@
+// Remembering where the installed app was, so a relaunch can go back there.
+//
+// Storage only. The rule about whether to USE what is stored lives in `pwa.ts`
+// (`resolveLaunchTarget`), free of browser globals so it can be unit tested; this
+// is the half that touches the device.
+//
+// Recorded on every navigation, which is why it writes through `local-cache`
+// rather than reaching for `localStorage` directly: it gets the owner scoping
+// (so a manager's last screen is not restored for whoever signs in next), the
+// clock-safe timestamp, and the never-throws guarantee for Safari's private
+// mode, all of which this would otherwise have to repeat.
+
+import { readCache, removeCache, writeCache } from "@/lib/local-cache";
+import type { LastVisit } from "@/lib/pwa";
+
+const KEY = "last-visit";
+const VERSION = 1;
+
+function revive(value: unknown): LastVisit | null {
+  if (!value || typeof value !== "object") return null;
+  const v = value as Partial<LastVisit>;
+  if (typeof v.path !== "string" || !v.path) return null;
+  if (typeof v.hasSession !== "boolean") return null;
+  return { path: v.path, at: typeof v.at === "number" ? v.at : 0, hasSession: v.hasSession };
+}
+
+export function readLastVisit(owner: string | null): LastVisit | null {
+  const hit = readCache<LastVisit>(KEY, { version: VERSION, owner, revive });
+  // `at` comes off the envelope rather than the payload: the envelope is what
+  // `local-cache` stamps, so it cannot drift from what was actually written.
+  return hit ? { ...hit.data, at: hit.savedAt } : null;
+}
+
+export function writeLastVisit(owner: string | null, path: string, hasSession: boolean): void {
+  writeCache(KEY, { path, at: 0, hasSession }, VERSION, owner);
+}
+
+export function clearLastVisit(): void {
+  removeCache(KEY);
+}

--- a/src/lib/local-cache.test.ts
+++ b/src/lib/local-cache.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  LOCAL_CACHE_PREFIX,
+  clearCacheFor,
+  packCache,
+  readCache,
+  removeCache,
+  unpackCache,
+  writeCache,
+} from "@/lib/local-cache";
+
+const revive = (value: unknown) =>
+  value && typeof value === "object" ? (value as { note?: string }) : null;
+
+const terms = { version: 1, owner: "user-1", revive };
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("unpackCache", () => {
+  it("reads back what packCache wrote", () => {
+    const raw = packCache({ note: "hi" }, 1, "user-1", 1_000);
+    expect(unpackCache(raw, terms, 2_000)).toEqual({ data: { note: "hi" }, savedAt: 1_000 });
+  });
+
+  it("refuses an entry written by an older payload version", () => {
+    const raw = packCache({ note: "hi" }, 0, "user-1", 1_000);
+    expect(unpackCache(raw, terms, 2_000)).toBeNull();
+  });
+
+  it("refuses an entry belonging to somebody else", () => {
+    // The rule that keeps one member's data off the next member's screen on a
+    // shared club laptop.
+    const raw = packCache({ note: "hi" }, 1, "user-2", 1_000);
+    expect(unpackCache(raw, terms, 2_000)).toBeNull();
+    expect(unpackCache(raw, { ...terms, owner: "user-2" }, 2_000)).not.toBeNull();
+  });
+
+  it("refuses an entry older than maxAgeMs, and accepts one inside it", () => {
+    const raw = packCache({ note: "hi" }, 1, "user-1", 1_000);
+    expect(unpackCache(raw, { ...terms, maxAgeMs: 500 }, 2_000)).toBeNull();
+    expect(unpackCache(raw, { ...terms, maxAgeMs: 5_000 }, 2_000)).not.toBeNull();
+  });
+
+  it("does not hide an entry because the device clock moved backwards", () => {
+    // A phone correcting its clock would otherwise make a just-written entry
+    // look like one from the future and, with maxAgeMs, unreadable forever.
+    const raw = packCache({ note: "hi" }, 1, "user-1", 9_000);
+    expect(unpackCache(raw, { ...terms, maxAgeMs: 1_000 }, 2_000)).not.toBeNull();
+  });
+
+  it("never throws on rubbish", () => {
+    expect(unpackCache(null, terms, 0)).toBeNull();
+    expect(unpackCache("", terms, 0)).toBeNull();
+    expect(unpackCache("{not json", terms, 0)).toBeNull();
+    expect(unpackCache("42", terms, 0)).toBeNull();
+    expect(unpackCache('{"v":1,"o":"user-1"}', terms, 0)).toBeNull();
+  });
+
+  it("rejects an entry whose payload the caller's revive refuses", () => {
+    const raw = packCache("not an object", 1, "user-1", 1_000);
+    expect(unpackCache(raw, terms, 2_000)).toBeNull();
+  });
+});
+
+describe("storage", () => {
+  it("round-trips through localStorage under the app's prefix", () => {
+    writeCache("thing", { note: "hi" }, 1, "user-1", 1_000);
+    expect(window.localStorage.getItem(`${LOCAL_CACHE_PREFIX}thing`)).toBeTruthy();
+    expect(readCache("thing", terms, 2_000)?.data).toEqual({ note: "hi" });
+  });
+
+  it("drops an entry it had to reject rather than leaving it against the quota", () => {
+    writeCache("thing", { note: "hi" }, 1, "user-2", 1_000);
+    expect(readCache("thing", terms, 2_000)).toBeNull();
+    expect(window.localStorage.getItem(`${LOCAL_CACHE_PREFIX}thing`)).toBeNull();
+  });
+
+  it("removes one entry", () => {
+    writeCache("thing", { note: "hi" }, 1, "user-1", 1_000);
+    removeCache("thing");
+    expect(readCache("thing", terms, 2_000)).toBeNull();
+  });
+
+  it("clears only the entries belonging to one person", () => {
+    writeCache("mine", { note: "a" }, 1, "user-1", 1_000);
+    writeCache("theirs", { note: "b" }, 1, "user-2", 1_000);
+    window.localStorage.setItem("unrelated", "leave me alone");
+
+    clearCacheFor("user-1");
+
+    expect(readCache("mine", terms, 2_000)).toBeNull();
+    expect(readCache("theirs", { ...terms, owner: "user-2" }, 2_000)?.data).toEqual({ note: "b" });
+    expect(window.localStorage.getItem("unrelated")).toBe("leave me alone");
+  });
+
+  it("clears every entry when given no owner", () => {
+    writeCache("mine", { note: "a" }, 1, "user-1", 1_000);
+    writeCache("theirs", { note: "b" }, 1, "user-2", 1_000);
+    window.localStorage.setItem("unrelated", "leave me alone");
+
+    clearCacheFor();
+
+    expect(readCache("mine", terms, 2_000)).toBeNull();
+    expect(readCache("theirs", { ...terms, owner: "user-2" }, 2_000)).toBeNull();
+    expect(window.localStorage.getItem("unrelated")).toBe("leave me alone");
+  });
+});

--- a/src/lib/local-cache.ts
+++ b/src/lib/local-cache.ts
@@ -1,0 +1,216 @@
+// The one place this app writes something to the device on purpose.
+//
+// Three separate problems needed the same small thing — a value, kept between
+// page loads, that must never crash a page load and must never outlive the
+// person it belongs to:
+//
+//   * an unsaved draft somebody is part-way through typing (`editor-draft.ts`),
+//   * an answer worth painting immediately on the next launch instead of a
+//     spinner (`use-persistent-query.ts`),
+//   * where the installed app was when the phone took it away (`pwa.ts`).
+//
+// Rather than three hand-rolled `try { JSON.parse(localStorage...) }` blocks
+// this is the seam, and it enforces the three rules that make storage on a
+// device safe to rely on:
+//
+//   1. **Versioned.** A value written by an older build of the site is discarded
+//      rather than half-read. A renamed field that restores as `undefined` is
+//      worse than no restore at all, because nobody can see what went missing.
+//   2. **Owned.** Every entry records who it was written for. A different person
+//      signing in on the same device reads nothing, and signing out can wipe
+//      everything belonging to that person in one call. This is what keeps one
+//      member's data off the next member's screen on a shared club laptop.
+//   3. **Dated.** Every entry records when it was written, so a caller can
+//      refuse one that is too old to be trustworthy and can tell somebody how
+//      old the thing they are looking at is.
+//
+// Deliberately free of React, of server imports and of side effects at module
+// scope, so the pure half is unit-testable without a DOM — the same shape as
+// `auth-persistence.ts` and `waiver-draft.ts`.
+
+/** Everything under this app's control on the device shares this prefix. */
+export const LOCAL_CACHE_PREFIX = "uts-jitsu.cache.";
+
+/** What actually goes into storage. Short keys: it is written on a keystroke. */
+type Envelope = {
+  /** Schema version of the *payload*, chosen by the caller. */
+  v: number;
+  /** When it was written, epoch ms. */
+  at: number;
+  /** The user id it belongs to, or null for "signed out / belongs to nobody". */
+  o: string | null;
+  d: unknown;
+};
+
+export type CacheHit<T> = {
+  data: T;
+  /** Epoch ms. What to show when telling somebody how old this is. */
+  savedAt: number;
+};
+
+export type CacheTerms<T> = {
+  /** Bump when the payload's shape changes. Older entries are then ignored. */
+  version: number;
+  /** Who the entry belongs to. A mismatch reads as a miss. */
+  owner: string | null;
+  /** Refuse an entry older than this. Omit to accept any age. */
+  maxAgeMs?: number;
+  /**
+   * Coerce whatever was stored into `T`, or return null to reject it.
+   *
+   * Required, and required to be total: this parses data that a previous build
+   * of the site wrote, that a browser extension may have mangled, or that
+   * somebody typed into devtools. Trusting it with a cast is how leftover
+   * storage takes a page down on load.
+   */
+  revive: (value: unknown) => T | null;
+};
+
+/* ---------------- The pure half ---------------- */
+
+/** Wrap a payload for storage. Exported for tests; callers use `writeCache`. */
+export function packCache(
+  data: unknown,
+  version: number,
+  owner: string | null,
+  now: number,
+): string {
+  return JSON.stringify({ v: version, at: now, o: owner, d: data } satisfies Envelope);
+}
+
+/**
+ * Read a stored string back, or null if it is not a usable entry.
+ *
+ * Never throws. The caller is always a page load or a render, and a page that
+ * will not start because of something left in storage is a worse failure than
+ * the one this is trying to prevent.
+ */
+export function unpackCache<T>(
+  raw: string | null,
+  terms: CacheTerms<T>,
+  now: number,
+): CacheHit<T> | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const envelope = parsed as Partial<Envelope>;
+  if (envelope.v !== terms.version) return null;
+  if (typeof envelope.at !== "number" || !Number.isFinite(envelope.at)) return null;
+  const owner = envelope.o === undefined ? null : envelope.o;
+  if (owner !== terms.owner) return null;
+  // A clock that moved backwards (a phone correcting itself, a timezone change
+  // on a device that keeps local time) would otherwise make a fresh entry look
+  // like one from the future and, with `maxAgeMs`, hide it forever.
+  const age = Math.max(0, now - envelope.at);
+  if (terms.maxAgeMs !== undefined && age > terms.maxAgeMs) return null;
+  const data = terms.revive(envelope.d);
+  if (data === null) return null;
+  return { data, savedAt: envelope.at };
+}
+
+/* ---------------- The storage half ---------------- */
+
+/**
+ * `localStorage`, or null when there isn't one.
+ *
+ * Not only an SSR guard: Safari in private browsing and locked-down enterprise
+ * profiles throw on the property access itself rather than returning null.
+ */
+export function localCacheStore(): Storage | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return window.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function fullKey(key: string): string {
+  return `${LOCAL_CACHE_PREFIX}${key}`;
+}
+
+export function readCache<T>(
+  key: string,
+  terms: CacheTerms<T>,
+  now = Date.now(),
+): CacheHit<T> | null {
+  const store = localCacheStore();
+  if (!store) return null;
+  let raw: string | null;
+  try {
+    raw = store.getItem(fullKey(key));
+  } catch {
+    return null;
+  }
+  const hit = unpackCache(raw, terms, now);
+  // A rejected entry is never coming back — wrong version, wrong owner, or past
+  // its age. Drop it now rather than leaving it to sit against the quota until
+  // something else needs the room.
+  if (!hit && raw !== null) removeCache(key);
+  return hit;
+}
+
+export function writeCache(
+  key: string,
+  data: unknown,
+  version: number,
+  owner: string | null,
+  now = Date.now(),
+): void {
+  const store = localCacheStore();
+  if (!store) return;
+  try {
+    store.setItem(fullKey(key), packCache(data, version, owner, now));
+  } catch {
+    // Out of quota, or storage refused. Everything still works; it just will not
+    // survive the page going away. Never surface this: there is nothing the
+    // person on the other end could do about it.
+  }
+}
+
+export function removeCache(key: string): void {
+  const store = localCacheStore();
+  if (!store) return;
+  try {
+    store.removeItem(fullKey(key));
+  } catch {
+    /* nothing to do */
+  }
+}
+
+/**
+ * Drop every entry belonging to `owner` (or every entry at all, when `owner` is
+ * undefined).
+ *
+ * This is what sign-out calls. It reads each entry's envelope rather than
+ * guessing from the key, so an entry can be keyed however its caller likes and
+ * still be cleaned up correctly.
+ */
+export function clearCacheFor(owner?: string | null): void {
+  const store = localCacheStore();
+  if (!store) return;
+  let keys: string[];
+  try {
+    keys = Object.keys(store).filter((key) => key.startsWith(LOCAL_CACHE_PREFIX));
+  } catch {
+    return;
+  }
+  for (const key of keys) {
+    try {
+      if (owner !== undefined) {
+        const parsed = JSON.parse(store.getItem(key) ?? "null") as Partial<Envelope> | null;
+        // An unreadable entry has no owner we can trust, so treat it as ours to
+        // remove: leaving it would mean it can never be cleaned up at all.
+        if (parsed && typeof parsed === "object" && (parsed.o ?? null) !== owner) continue;
+      }
+      store.removeItem(key);
+    } catch {
+      /* skip whatever we cannot read or remove */
+    }
+  }
+}

--- a/src/lib/pwa.test.ts
+++ b/src/lib/pwa.test.ts
@@ -99,6 +99,37 @@ describe("isResumablePath", () => {
     }
   });
 
+  it("refuses the tricks that make one parser disagree with another", () => {
+    // This value is read back off the device, so it is the one input here an
+    // attacker with any script foothold could choose. None of these can come
+    // from a real navigation: a browser normalises them long before
+    // `location.pathname` is readable.
+    const bs = String.fromCharCode(92);
+    expect(isResumablePath(`/${bs}evil.example`)).toBe(false);
+    expect(isResumablePath(`/${bs}${bs}evil.example`)).toBe(false);
+    expect(isResumablePath("/%5cevil.example")).toBe(false);
+    // Traversal back out of a blocked prefix, raw and encoded.
+    expect(isResumablePath("/x/../email-settings/token")).toBe(false);
+    expect(isResumablePath("/x/%2e%2e/email-settings/token")).toBe(false);
+    expect(isResumablePath("/x%2f%2e%2e/auth")).toBe(false);
+    // A blocked screen reached through a spelling the list does not recognise.
+    expect(isResumablePath("/Auth")).toBe(false);
+    expect(isResumablePath("/EMAIL-SETTINGS/token")).toBe(false);
+    expect(isResumablePath("/API/calendar/token")).toBe(false);
+    // Control characters and whitespace, the classic smuggling vector.
+    expect(isResumablePath("/account\n")).toBe(false);
+    expect(isResumablePath("/\taccount")).toBe(false);
+    expect(isResumablePath("/acc\u0000ount")).toBe(false);
+    expect(isResumablePath("/account ")).toBe(false);
+  });
+
+  it("still allows the ordinary paths after all that", () => {
+    // The hardening must not break the feature it guards.
+    for (const path of ["/account", "/kb/your-first-class", "/manager/users?q=jane%20doe"]) {
+      expect(isResumablePath(path)).toBe(true);
+    }
+  });
+
   it("refuses anything that is not a plain site-relative path", () => {
     // "//evil.example" is a protocol-relative URL, which a browser treats as
     // another origin. It must never reach a redirect.

--- a/src/lib/pwa.test.ts
+++ b/src/lib/pwa.test.ts
@@ -1,7 +1,13 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { PWA_LAUNCH_PATH, resolveLaunchScreen } from "./pwa";
+import {
+  LAUNCH_RESUME_WINDOW_MS,
+  PWA_LAUNCH_PATH,
+  isResumablePath,
+  resolveLaunchScreen,
+  resolveLaunchTarget,
+} from "./pwa";
 
 describe("resolveLaunchScreen", () => {
   it("opens the member area when there is a session", () => {
@@ -57,5 +63,113 @@ describe("web manifest", () => {
     for (const shortcut of manifest.shortcuts as Array<{ url: string }>) {
       expect(shortcut.url.startsWith("/")).toBe(true);
     }
+  });
+});
+
+describe("isResumablePath", () => {
+  it("allows the ordinary screens somebody could be looking at", () => {
+    for (const path of ["/account", "/kb/your-first-class", "/manager/check-in", "/blog", "/"]) {
+      expect(isResumablePath(path)).toBe(true);
+    }
+  });
+
+  it("allows a path with a query string", () => {
+    expect(isResumablePath("/manager/users?q=jane")).toBe(true);
+  });
+
+  it("refuses the launch route itself, which would loop", () => {
+    expect(isResumablePath(PWA_LAUNCH_PATH)).toBe(false);
+  });
+
+  it("refuses a token-bearing path", () => {
+    // `/email-settings/<token>` consumes its token and redirects, so coming
+    // back to it later lands on a URL that no longer works.
+    expect(isResumablePath("/email-settings/abc123")).toBe(false);
+    expect(isResumablePath("/api/calendar/abc123")).toBe(false);
+  });
+
+  it("refuses the auth screens", () => {
+    for (const path of [
+      "/auth",
+      "/auth?redirect=/account",
+      "/reset-password",
+      "/update-password",
+    ]) {
+      expect(isResumablePath(path)).toBe(false);
+    }
+  });
+
+  it("refuses anything that is not a plain site-relative path", () => {
+    // "//evil.example" is a protocol-relative URL, which a browser treats as
+    // another origin. It must never reach a redirect.
+    for (const path of ["//evil.example", "https://evil.example/x", "account", ""]) {
+      expect(isResumablePath(path)).toBe(false);
+    }
+  });
+
+  it("does not confuse a longer path with a blocked one", () => {
+    // `/authors` is not `/auth`.
+    expect(isResumablePath("/authors")).toBe(true);
+  });
+});
+
+describe("resolveLaunchTarget", () => {
+  const now = 1_000_000_000_000;
+  const recent = { path: "/kb/your-first-class", at: now - 60_000, hasSession: true };
+
+  it("returns to the screen the app was on", () => {
+    // The whole point: a phone reclaimed the app mid-article, and the next tap
+    // on the icon is a cold launch. Landing on the member home page instead is
+    // what made that read as the app reloading itself.
+    expect(resolveLaunchTarget({ hasSession: true, lastVisit: recent, now })).toEqual({
+      path: "/kb/your-first-class",
+    });
+  });
+
+  it("falls back to the usual launch screen when there is nothing recorded", () => {
+    expect(resolveLaunchTarget({ hasSession: true, lastVisit: null, now })).toEqual({
+      screen: "member",
+    });
+    expect(resolveLaunchTarget({ hasSession: false, lastVisit: null, now })).toEqual({
+      screen: "home",
+    });
+  });
+
+  it("does not return to a screen from days ago", () => {
+    const old = { ...recent, at: now - LAUNCH_RESUME_WINDOW_MS - 1 };
+    expect(resolveLaunchTarget({ hasSession: true, lastVisit: old, now })).toEqual({
+      screen: "member",
+    });
+  });
+
+  it("ignores a record from before the person signed out", () => {
+    // Otherwise a launch drops them on a manager screen and bounces straight to
+    // the sign-in page, which is worse than starting at the home page.
+    expect(resolveLaunchTarget({ hasSession: false, lastVisit: recent, now })).toEqual({
+      screen: "home",
+    });
+  });
+
+  it("ignores a record from before the person signed in", () => {
+    // They now want their member area, not the marketing page they were reading
+    // before they had a login.
+    const signedOutVisit = { path: "/pricing", at: now - 60_000, hasSession: false };
+    expect(resolveLaunchTarget({ hasSession: true, lastVisit: signedOutVisit, now })).toEqual({
+      screen: "member",
+    });
+  });
+
+  it("ignores a record the device clock puts in the future", () => {
+    const future = { ...recent, at: now + 60_000 };
+    expect(resolveLaunchTarget({ hasSession: true, lastVisit: future, now })).toEqual({
+      screen: "member",
+    });
+  });
+
+  it("never resumes into a path it is not allowed to", () => {
+    const blocked = { path: "/email-settings/token", at: now - 60_000, hasSession: true };
+    expect(resolveLaunchTarget({ hasSession: true, lastVisit: blocked, now })).toEqual({
+      screen: "member",
+    });
   });
 });

--- a/src/lib/pwa.ts
+++ b/src/lib/pwa.ts
@@ -81,17 +81,45 @@ const NON_RESUMABLE_PREFIXES = [
   "/update-password",
 ];
 
-/** Whether a recorded path is one the app may open on. */
+/**
+ * Whether a path is one the app may record and open on.
+ *
+ * Deliberately strict, and deliberately not relying on what the router happens
+ * to do with a bad value. This string is read back off the device, so it is the
+ * one input here that an attacker with any script foothold on the origin could
+ * choose; today's router normalises its way out of most of it, but that is its
+ * internals, not a guarantee this code owns.
+ */
 export function isResumablePath(path: string): boolean {
   // Site-relative only. A protocol-relative "//evil.example" is a URL a browser
-  // would happily treat as another origin, so it is refused explicitly rather
-  // than left to the router.
+  // treats as another origin. So is a backslash form in several parsers, which
+  // is why a backslash anywhere is refused outright rather than reasoned about.
   if (!path.startsWith("/") || path.startsWith("//")) return false;
+  if (path.includes("\\")) return false;
+  // Control characters and whitespace never appear in a path a real navigation
+  // produced, and are the classic way to smuggle one parser past another.
+  // Checked by code point rather than a regex literal, which would need a
+  // `no-control-regex` suppression to say the same thing less clearly.
+  for (const character of path) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code <= 0x20 || code === 0x7f) return false;
+  }
+
   const pathname = path.split(/[?#]/)[0];
+  // Traversal, raw or encoded. A browser resolves ".." before `location.pathname`
+  // is ever readable, so this can only come from a value somebody planted -- and
+  // "/x/../email-settings/tok" must not slip past the prefix list below.
+  const lowered = pathname.toLowerCase();
+  if (lowered.includes("..") || lowered.includes("%2e") || lowered.includes("%2f")) return false;
+  if (lowered.includes("%5c")) return false;
+
+  // Case-insensitively: the blocklist is about which SCREEN this is, and a
+  // server that resolves "/Auth" to the auth screen would otherwise be reachable
+  // through a spelling the list does not recognise.
   return !NON_RESUMABLE_PREFIXES.some((prefix) =>
     prefix.endsWith("/")
-      ? pathname.startsWith(prefix)
-      : pathname === prefix || pathname.startsWith(`${prefix}/`),
+      ? lowered.startsWith(prefix)
+      : lowered === prefix || lowered.startsWith(`${prefix}/`),
   );
 }
 

--- a/src/lib/pwa.ts
+++ b/src/lib/pwa.ts
@@ -34,3 +34,92 @@ export type LaunchScreen = "member" | "home";
 export function resolveLaunchScreen({ hasSession }: LaunchState): LaunchScreen {
   return hasSession ? "member" : "home";
 }
+
+/* ---------------- Picking up where you left off ---------------- */
+
+/**
+ * How long a recorded location is worth returning to.
+ *
+ * The problem this solves: a phone reclaims the installed app in the
+ * background, and the next tap on the icon is not a resume, it is a cold launch
+ * at `start_url`. So somebody who was half-way through an article, or reading
+ * the roster for tonight's class, comes back to the member home page with no
+ * sign that anything was lost. To them it looks like the app reloaded itself.
+ *
+ * A day, because that is the span over which "I was just looking at this" is
+ * still true. Beyond it, the member area is the more useful answer than
+ * whatever screen happened to be open last week.
+ */
+export const LAUNCH_RESUME_WINDOW_MS = 24 * 60 * 60_000;
+
+/** Where the app was, and who it was for, the last time anybody looked. */
+export type LastVisit = {
+  /** A site-relative path, including any query string. */
+  path: string;
+  /** Epoch ms. */
+  at: number;
+  /** Whether somebody was signed in at the time. */
+  hasSession: boolean;
+};
+
+/**
+ * Paths that must never be resumed into, whatever was recorded.
+ *
+ * The token-bearing ones are the important half: `/email-settings/<token>` is
+ * an exchange that consumes its token and redirects, so returning to it later
+ * lands on a URL that no longer works. The auth screens are the other half —
+ * coming back to a half-finished sign-in, or to a password reset whose link has
+ * since expired, is worse than starting from the home page.
+ */
+const NON_RESUMABLE_PREFIXES = [
+  "/app",
+  "/api/",
+  "/lovable/",
+  "/email-settings/",
+  "/auth",
+  "/reset-password",
+  "/update-password",
+];
+
+/** Whether a recorded path is one the app may open on. */
+export function isResumablePath(path: string): boolean {
+  // Site-relative only. A protocol-relative "//evil.example" is a URL a browser
+  // would happily treat as another origin, so it is refused explicitly rather
+  // than left to the router.
+  if (!path.startsWith("/") || path.startsWith("//")) return false;
+  const pathname = path.split(/[?#]/)[0];
+  return !NON_RESUMABLE_PREFIXES.some((prefix) =>
+    prefix.endsWith("/")
+      ? pathname.startsWith(prefix)
+      : pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+/**
+ * Where a launch should actually go.
+ *
+ * Returns the recorded path when returning to it is right, and otherwise falls
+ * back to `resolveLaunchScreen`. The `hasSession` comparison matters as much as
+ * the clock: somebody who has signed out since must not be dropped back onto a
+ * manager screen and bounced straight to the sign-in page, and somebody who has
+ * since signed IN wants their member area, not the marketing page they were
+ * reading beforehand.
+ */
+export function resolveLaunchTarget({
+  hasSession,
+  lastVisit,
+  now,
+}: LaunchState & { lastVisit: LastVisit | null; now: number }):
+  | { path: string }
+  | { screen: LaunchScreen } {
+  if (
+    lastVisit &&
+    lastVisit.hasSession === hasSession &&
+    now - lastVisit.at >= 0 &&
+    now - lastVisit.at <= LAUNCH_RESUME_WINDOW_MS &&
+    isResumablePath(lastVisit.path)
+  ) {
+    return { path: lastVisit.path };
+  }
+  return { screen: resolveLaunchScreen({ hasSession }) };
+}

--- a/src/lib/waiver-template-editor.test.ts
+++ b/src/lib/waiver-template-editor.test.ts
@@ -3,6 +3,7 @@ import {
   hasMediaAcknowledgement,
   isDirty,
   meaningfulAcks,
+  parseAcksJson,
   versionLabel,
 } from "./waiver-template-editor";
 import type { AcknowledgementDef } from "./validation";
@@ -114,5 +115,30 @@ describe("versionLabel", () => {
 
   it("calls everything a draft when nothing is live", () => {
     expect(versionLabel({ version: 1, is_current: false }, null)).toBe("Draft");
+  });
+});
+
+describe("parseAcksJson", () => {
+  const current = [ack({ id: "a", label: "Media consent" })];
+
+  it("reads back a list that was stored as JSON", () => {
+    const stored = [ack({ id: "b", label: "Something else" })];
+    expect(parseAcksJson(JSON.stringify(stored), current)).toEqual(stored);
+  });
+
+  it("falls back to what is on screen rather than to nothing", () => {
+    // Restoring into an empty list would put the editor into a state it refuses
+    // to save from (the media consent row is required), with no obvious way out.
+    expect(parseAcksJson("{not json", current)).toEqual(current);
+    expect(parseAcksJson("", current)).toEqual(current);
+    expect(parseAcksJson('{"not":"an array"}', current)).toEqual(current);
+    expect(parseAcksJson("null", current)).toEqual(current);
+    expect(parseAcksJson("42", current)).toEqual(current);
+  });
+
+  it("accepts a genuinely empty list, which is a real answer", () => {
+    // Distinct from the fallback above: "[]" is somebody having removed every
+    // row, which the save then refuses on its own terms with a message.
+    expect(parseAcksJson("[]", current)).toEqual([]);
   });
 });

--- a/src/lib/waiver-template-editor.ts
+++ b/src/lib/waiver-template-editor.ts
@@ -112,3 +112,20 @@ export function versionLabel(
   if (liveVersion !== null && version.version < liveVersion) return "Previous";
   return "Draft";
 }
+
+/**
+ * Read the acknowledgements back out of a restored draft.
+ *
+ * Falls back to what is already on screen rather than to an empty list: the
+ * media consent row is required, and restoring a draft into no acknowledgements
+ * at all would put the editor into a state it refuses to save from, with no
+ * obvious way out.
+ */
+export function parseAcksJson(raw: string, fallback: AcknowledgementDef[]): AcknowledgementDef[] {
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as AcknowledgementDef[]) : fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -2,14 +2,67 @@ import { QueryClient } from "@tanstack/react-query";
 import { createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
+/**
+ * How long a fetched answer counts as fresh before React Query will consider
+ * asking again.
+ *
+ * React Query's own default is zero, which means "stale the instant it lands":
+ * every remount, every reconnect and (with the focus refetch below) every return
+ * to the app re-asks the server for something it already has on screen. On a
+ * desktop that is invisible. On a phone in a gym, on the club's actual traffic,
+ * it is a screenful of spinners every time somebody unlocks their phone.
+ *
+ * Thirty seconds is short enough that a manager who just changed something and
+ * navigated away sees it on the way back, and long enough that moving between
+ * screens costs nothing. Screens whose data genuinely changes more slowly set
+ * their own longer `staleTime` (the knowledge base uses five minutes).
+ */
+const DEFAULT_STALE_TIME = 30_000;
+
+/**
+ * How long an unused answer is kept in memory after the last screen using it
+ * unmounts. A day, because the installed app is opened and left over and over
+ * across a single day, and the whole point is that coming back is cheap.
+ */
+const DEFAULT_GC_TIME = 24 * 60 * 60_000;
+
 export const getRouter = () => {
-  const queryClient = new QueryClient();
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: DEFAULT_STALE_TIME,
+        gcTime: DEFAULT_GC_TIME,
+        // Off, deliberately. This is the single most-felt cause of the installed
+        // app reloading the moment you come back to it: every tab switch and
+        // every phone unlock re-fetched every mounted query at once. Coming back
+        // to a screen you were already looking at should show you that screen.
+        // `refetchOnReconnect` below is what covers the case that actually
+        // matters, which is data fetched while the connection was down.
+        refetchOnWindowFocus: false,
+        // On, and the reason the setting above can be off: a phone that has just
+        // found signal again is the one moment a refetch is worth interrupting
+        // for, because what is on screen may have been fetched against nothing.
+        refetchOnReconnect: true,
+        // Stale data still refetches when a screen mounts. Fresh data does not,
+        // which is what makes navigating back and forth free.
+        refetchOnMount: true,
+        // One retry, not three. A server function that refused (not a manager,
+        // no such article) will refuse again, and three rounds of backoff is
+        // several seconds of a screen sitting on a spinner before it can say so.
+        retry: 1,
+      },
+    },
+  });
 
   const router = createRouter({
     routeTree,
     context: { queryClient },
     scrollRestoration: true,
-    defaultPreloadStaleTime: 0,
+    // Preloading a route on hover/touch is only worth it if the result is still
+    // there when the tap lands. At 0 every preload was thrown away immediately
+    // and the click re-fetched from scratch, so the preload was pure extra
+    // traffic on the connection least able to afford it.
+    defaultPreloadStaleTime: DEFAULT_STALE_TIME,
   });
 
   return router;

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -14,6 +14,7 @@ import appCss from "../styles.css?url";
 import { reportLovableError } from "../lib/lovable-error-reporting";
 import { SOCIAL_IMAGE } from "../lib/seo";
 import { setUpServiceWorker } from "../lib/service-worker";
+import { resolveAuthRefresh } from "../lib/auth-events";
 
 // `data-page-state` marks a page that rendered a boundary instead of itself.
 // The end-to-end tour (e2e/tour/site.spec.ts) treats its presence as a
@@ -197,10 +198,15 @@ function RootComponent() {
       if (mounted) applyRememberPreference(initialHref);
     });
     import("@/integrations/supabase/client").then(({ supabase }) => {
-      const { data: sub } = supabase.auth.onAuthStateChange((event) => {
-        if (event !== "SIGNED_IN" && event !== "SIGNED_OUT" && event !== "USER_UPDATED") return;
-        router.invalidate();
-        if (event !== "SIGNED_OUT") queryClient.invalidateQueries();
+      // Three-valued on purpose: `undefined` means no event has arrived yet.
+      // See `resolveAuthRefresh` for why that is not the same as signed out.
+      let previousUserId: string | null | undefined = undefined;
+      const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
+        const nextUserId = session?.user?.id ?? null;
+        const refresh = resolveAuthRefresh(event, previousUserId, nextUserId);
+        if (event === "SIGNED_IN" || event === "SIGNED_OUT") previousUserId = nextUserId;
+        if (refresh.invalidateRouter) router.invalidate();
+        if (refresh.invalidateQueries) queryClient.invalidateQueries();
       });
       // The import resolves asynchronously, so the effect may already have been
       // cleaned up by the time we get here.

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,7 +7,7 @@ import {
   HeadContent,
   Scripts,
 } from "@tanstack/react-router";
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import { Toaster } from "sonner";
 
 import appCss from "../styles.css?url";
@@ -16,6 +16,7 @@ import { SOCIAL_IMAGE } from "../lib/seo";
 import { setUpServiceWorker } from "../lib/service-worker";
 import { resolveAuthRefresh } from "../lib/auth-events";
 import { clearCacheFor } from "../lib/local-cache";
+import { writeLastVisit } from "../lib/last-visit";
 
 // `data-page-state` marks a page that rendered a boundary instead of itself.
 // The end-to-end tour (e2e/tour/site.spec.ts) treats its presence as a
@@ -189,8 +190,41 @@ const initialHref = typeof window === "undefined" ? "" : window.location.href;
 function RootComponent() {
   const { queryClient } = Route.useRouteContext();
   const router = useRouter();
+  /**
+   * Who is signed in right now, as a ref rather than state.
+   *
+   * Read by the last-visit recorder on every navigation and written by the auth
+   * subscription below. A ref because nothing renders from it: as state it would
+   * re-render the whole tree on sign-in for no visible change.
+   */
+  const signedInUserId = useRef<string | null>(null);
 
   useEffect(() => setUpServiceWorker(), []);
+
+  // Remember where the app is, so a relaunch can come back to it.
+  //
+  // The installed app has no "resume": when a phone reclaims it in the
+  // background, the next tap on the icon is a COLD launch at `start_url`. Until
+  // now that always landed on the member home page, so somebody half-way
+  // through an article, or reading tonight's roster, came back to a different
+  // screen with no sign that anything had been lost. From the outside that is
+  // indistinguishable from the app reloading itself, and it was half of what
+  // made it feel so eager to. `/app` reads this back (`resolveLaunchTarget`).
+  useEffect(() => {
+    const record = () => {
+      const { pathname, searchStr } = router.state.location;
+      // `signedInUserId` is kept up to date by the auth subscription below
+      // rather than asking Supabase here, which would be a storage read and a
+      // promise on every navigation for something already known.
+      writeLastVisit(
+        signedInUserId.current,
+        `${pathname}${searchStr}`,
+        signedInUserId.current !== null,
+      );
+    };
+    record();
+    return router.subscribe("onResolved", record);
+  }, [router]);
 
   useEffect(() => {
     let mounted = true;
@@ -218,6 +252,7 @@ function RootComponent() {
           }
           previousUserId = nextUserId;
         }
+        signedInUserId.current = nextUserId;
         if (refresh.invalidateRouter) router.invalidate();
         if (refresh.invalidateQueries) queryClient.invalidateQueries();
       });

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -15,6 +15,7 @@ import { reportLovableError } from "../lib/lovable-error-reporting";
 import { SOCIAL_IMAGE } from "../lib/seo";
 import { setUpServiceWorker } from "../lib/service-worker";
 import { resolveAuthRefresh } from "../lib/auth-events";
+import { clearCacheFor } from "../lib/local-cache";
 
 // `data-page-state` marks a page that rendered a boundary instead of itself.
 // The end-to-end tour (e2e/tour/site.spec.ts) treats its presence as a
@@ -204,7 +205,19 @@ function RootComponent() {
       const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
         const nextUserId = session?.user?.id ?? null;
         const refresh = resolveAuthRefresh(event, previousUserId, nextUserId);
-        if (event === "SIGNED_IN" || event === "SIGNED_OUT") previousUserId = nextUserId;
+        if (event === "SIGNED_IN" || event === "SIGNED_OUT") {
+          // Whoever was signed in is no longer the person at the keyboard, so
+          // everything this app kept on the device for them goes: the knowledge
+          // base it cached to work offline, the check-in roster, unsaved drafts.
+          // This is what makes storing any of it defensible on a club laptop
+          // that several people use, and it is why every entry records its
+          // owner (`src/lib/local-cache.ts`). Signing the SAME person back in is
+          // not a handover, so their cache survives it.
+          if (previousUserId !== undefined && previousUserId !== nextUserId) {
+            clearCacheFor(previousUserId);
+          }
+          previousUserId = nextUserId;
+        }
         if (refresh.invalidateRouter) router.invalidate();
         if (refresh.invalidateQueries) queryClient.invalidateQueries();
       });

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -14,9 +14,10 @@ import appCss from "../styles.css?url";
 import { reportLovableError } from "../lib/lovable-error-reporting";
 import { SOCIAL_IMAGE } from "../lib/seo";
 import { setUpServiceWorker } from "../lib/service-worker";
-import { resolveAuthRefresh } from "../lib/auth-events";
+import { reportsIdentity, resolveAuthRefresh } from "../lib/auth-events";
 import { clearCacheFor } from "../lib/local-cache";
 import { writeLastVisit } from "../lib/last-visit";
+import { isResumablePath } from "../lib/pwa";
 
 // `data-page-state` marks a page that rendered a boundary instead of itself.
 // The end-to-end tour (e2e/tour/site.spec.ts) treats its presence as a
@@ -216,11 +217,14 @@ function RootComponent() {
       // `signedInUserId` is kept up to date by the auth subscription below
       // rather than asking Supabase here, which would be a storage read and a
       // promise on every navigation for something already known.
-      writeLastVisit(
-        signedInUserId.current,
-        `${pathname}${searchStr}`,
-        signedInUserId.current !== null,
-      );
+      const path = `${pathname}${searchStr}`;
+      // Filtered on the way IN, not just on the way out. `resolveLaunchTarget`
+      // refuses to reopen these, but recording one still writes it to the
+      // device -- and an auth link lands with its PKCE `code` or `token_hash`
+      // in the query string, which has no business sitting in storage for a day
+      // just to be refused later.
+      if (!isResumablePath(path)) return;
+      writeLastVisit(signedInUserId.current, path, signedInUserId.current !== null);
     };
     record();
     return router.subscribe("onResolved", record);
@@ -239,20 +243,21 @@ function RootComponent() {
       const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
         const nextUserId = session?.user?.id ?? null;
         const refresh = resolveAuthRefresh(event, previousUserId, nextUserId);
-        if (event === "SIGNED_IN" || event === "SIGNED_OUT") {
-          // Whoever was signed in is no longer the person at the keyboard, so
-          // everything this app kept on the device for them goes: the knowledge
-          // base it cached to work offline, the check-in roster, unsaved drafts.
-          // This is what makes storing any of it defensible on a club laptop
-          // that several people use, and it is why every entry records its
-          // owner (`src/lib/local-cache.ts`). Signing the SAME person back in is
-          // not a handover, so their cache survives it.
-          if (previousUserId !== undefined && previousUserId !== nextUserId) {
-            clearCacheFor(previousUserId);
-          }
+        // Adopted from every event that reports who is signed in, NOT just
+        // SIGNED_IN/SIGNED_OUT. `reportsIdentity` has the reasoning: the first
+        // event any subscriber gets is INITIAL_SESSION, and ignoring it left a
+        // returning member's tab never knowing who they were, so signing out
+        // wiped nothing off the device.
+        if (reportsIdentity(event, nextUserId)) {
           previousUserId = nextUserId;
+          signedInUserId.current = nextUserId;
         }
-        signedInUserId.current = nextUserId;
+        // Whoever was signed in is no longer the person at the keyboard, so
+        // everything this app kept on the device for them goes: the knowledge
+        // base it cached to work offline, the check-in roster, unsaved drafts.
+        // The rule for WHEN is `resolveAuthRefresh`'s, so it is unit tested
+        // rather than living here as a condition nothing checks.
+        if (refresh.clearDeviceCache) clearCacheFor(refresh.clearDeviceCache.owner);
         if (refresh.invalidateRouter) router.invalidate();
         if (refresh.invalidateQueries) queryClient.invalidateQueries();
       });

--- a/src/routes/_authenticated/manager.blog_.$id.tsx
+++ b/src/routes/_authenticated/manager.blog_.$id.tsx
@@ -64,7 +64,7 @@ function EditBlogPostPage() {
     navigate({ to: "/manager/blog" });
   }
 
-  async function onSave(value: BlogPostEditorValue): Promise<boolean> {
+  async function onSave(value: BlogPostEditorValue): Promise<boolean | string> {
     setSaving(true);
     try {
       const res = await update({
@@ -100,8 +100,9 @@ function EditBlogPostPage() {
       );
       return true;
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Could not save that post");
-      return false;
+      // Returned rather than toasted: the editor keeps it on screen in a panel
+      // that does not fade, beside the writing it failed to save.
+      return e instanceof Error && e.message ? e.message : "Could not save that post.";
     } finally {
       setSaving(false);
     }

--- a/src/routes/_authenticated/manager.blog_.$id.tsx
+++ b/src/routes/_authenticated/manager.blog_.$id.tsx
@@ -64,7 +64,7 @@ function EditBlogPostPage() {
     navigate({ to: "/manager/blog" });
   }
 
-  async function onSave(value: BlogPostEditorValue) {
+  async function onSave(value: BlogPostEditorValue): Promise<boolean> {
     setSaving(true);
     try {
       const res = await update({
@@ -98,8 +98,10 @@ function EditBlogPostPage() {
             }
           : prev,
       );
+      return true;
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Could not save that post");
+      return false;
     } finally {
       setSaving(false);
     }

--- a/src/routes/_authenticated/manager.blog_.new.tsx
+++ b/src/routes/_authenticated/manager.blog_.new.tsx
@@ -50,7 +50,7 @@ function NewBlogPostPage() {
     [],
   );
 
-  async function onSave(value: BlogPostEditorValue): Promise<boolean> {
+  async function onSave(value: BlogPostEditorValue): Promise<boolean | string> {
     setSaving(true);
     try {
       await create({
@@ -67,8 +67,9 @@ function NewBlogPostPage() {
       navigate({ to: "/manager/blog" });
       return true;
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Could not save that post");
-      return false;
+      // Returned rather than toasted: the editor keeps it on screen in a panel
+      // that does not fade, beside the writing it failed to save.
+      return e instanceof Error && e.message ? e.message : "Could not save that post.";
     } finally {
       setSaving(false);
     }

--- a/src/routes/_authenticated/manager.blog_.new.tsx
+++ b/src/routes/_authenticated/manager.blog_.new.tsx
@@ -50,7 +50,7 @@ function NewBlogPostPage() {
     [],
   );
 
-  async function onSave(value: BlogPostEditorValue) {
+  async function onSave(value: BlogPostEditorValue): Promise<boolean> {
     setSaving(true);
     try {
       await create({
@@ -65,8 +65,10 @@ function NewBlogPostPage() {
       });
       toast.success(value.status === "published" ? "Post published" : "Draft saved");
       navigate({ to: "/manager/blog" });
+      return true;
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Could not save that post");
+      return false;
     } finally {
       setSaving(false);
     }

--- a/src/routes/_authenticated/manager.check-in.test.tsx
+++ b/src/routes/_authenticated/manager.check-in.test.tsx
@@ -1,0 +1,184 @@
+// Check-in is run at the door of a university gym, on a phone, by a manager with
+// a queue of people in front of them. These pin the two things that decide
+// whether it is usable there: the roster is on screen when there is no signal,
+// and the manager is told when what they are reading is not live.
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { CHECKIN_CACHE_MAX_AGE_MS } from "@/lib/checkin-cache";
+import { PERSISTENT_QUERY_VERSION } from "@/hooks/use-persistent-query";
+import { writeCache } from "@/lib/local-cache";
+
+const listCheckInEvents = vi.fn();
+const getCheckInBoard = vi.fn();
+const listUncoveredCheckIns = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => opts,
+  useNavigate: () => vi.fn(),
+  Link: ({ children }: { children: ReactNode }) => <a href="#">{children}</a>,
+}));
+vi.mock("@tanstack/react-start", () => ({ useServerFn: (fn: unknown) => fn }));
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "manager-1" }, session: null, loading: false }),
+  useRoles: () => ({ roles: ["manager"], loading: false, isManager: true }),
+}));
+vi.mock("@/lib/checkin.functions", () => ({
+  listCheckInEvents: (...a: unknown[]) => listCheckInEvents(...a),
+  getCheckInBoard: (...a: unknown[]) => getCheckInBoard(...a),
+  listUncoveredCheckIns: (...a: unknown[]) => listUncoveredCheckIns(...a),
+  checkInPerson: vi.fn(),
+  undoCheckIn: vi.fn(),
+  attachCheckInCoverage: vi.fn(),
+}));
+
+const { Route } = await import("./manager.check-in");
+const CheckInPage = (Route as unknown as { component: () => ReactNode }).component;
+
+const EVENT = {
+  id: "event-1",
+  title: "Beginners",
+  instructor_name: "Sam",
+  location: "UTS Ultimo",
+  // Far enough out that `pickDefaultEvent` has an obvious answer whatever the
+  // clock says when this runs.
+  starts_at: new Date(Date.now() + 60 * 60_000).toISOString(),
+  ends_at: new Date(Date.now() + 150 * 60_000).toISOString(),
+  status: "scheduled",
+};
+
+const BOARD = {
+  event: EVENT,
+  roster: [
+    {
+      user_id: "user-1",
+      name: "Jane L.",
+      email: "jane@example.com",
+      coverage: "period",
+      plan_name: "Semester",
+      sessions_remaining_before: null,
+      consumes_credit: false,
+      warnings: [],
+    },
+  ],
+  checkins: [
+    {
+      id: "checkin-1",
+      user_id: "user-1",
+      name: "Jane L.",
+      checked_in_at: new Date().toISOString(),
+      coverage: "period",
+      plan_name: "Semester",
+      consumed_credit: false,
+      warnings: [],
+    },
+  ],
+};
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <CheckInPage />
+    </QueryClientProvider>,
+  );
+}
+
+/** Put a class list and a roster on the device, as a previous visit would have. */
+function seedDevice(savedAt: number) {
+  writeCache(
+    "checkin-events.manager-1",
+    [{ ...EVENT, checked_in_count: 1 }],
+    PERSISTENT_QUERY_VERSION,
+    "manager-1",
+    savedAt,
+  );
+  writeCache(
+    "checkin-board.manager-1.event-1",
+    BOARD,
+    PERSISTENT_QUERY_VERSION,
+    "manager-1",
+    savedAt,
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.clearAllMocks();
+  listUncoveredCheckIns.mockResolvedValue([]);
+});
+
+describe("/manager/check-in offline", () => {
+  it("shows the roster from the device when the network is gone", async () => {
+    seedDevice(Date.now() - 60_000);
+    listCheckInEvents.mockRejectedValue(new Error("Failed to fetch"));
+    getCheckInBoard.mockRejectedValue(new Error("Failed to fetch"));
+
+    renderPage();
+
+    // The person on the mat is listed, even though every request failed.
+    expect(await screen.findByText("Jane L.")).toBeInTheDocument();
+    // And the failure is NOT dressed up as an empty room.
+    expect(screen.queryByText("Nobody yet.")).not.toBeInTheDocument();
+  });
+
+  it("says so, rather than passing the stored roster off as live", async () => {
+    seedDevice(Date.now() - 60_000);
+    listCheckInEvents.mockRejectedValue(new Error("Failed to fetch"));
+    getCheckInBoard.mockRejectedValue(new Error("Failed to fetch"));
+
+    renderPage();
+
+    const notice = await screen.findByText(/saved on this device/i);
+    expect(notice).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it("says nothing about staleness once the refresh lands", async () => {
+    seedDevice(Date.now() - 60_000);
+    listCheckInEvents.mockResolvedValue([{ ...EVENT, checked_in_count: 1 }]);
+    getCheckInBoard.mockResolvedValue(BOARD);
+
+    renderPage();
+
+    expect(await screen.findByText("Jane L.")).toBeInTheDocument();
+    await waitFor(() => expect(getCheckInBoard).toHaveBeenCalled());
+    expect(screen.queryByText(/saved on this device/i)).not.toBeInTheDocument();
+  });
+
+  it("does not use a roster older than a day", async () => {
+    seedDevice(Date.now() - CHECKIN_CACHE_MAX_AGE_MS - 1);
+    listCheckInEvents.mockRejectedValue(new Error("Failed to fetch"));
+    getCheckInBoard.mockRejectedValue(new Error("Failed to fetch"));
+
+    renderPage();
+
+    // Memberships are raised and waivers signed between classes, so a roster
+    // this old is a wrong answer rather than a convenience. The screen falls
+    // back to saying it could not load, which is honest.
+    await waitFor(() =>
+      expect(screen.getByText(/The class list could not be loaded/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Jane L.")).not.toBeInTheDocument();
+  });
+
+  it("does not hand one manager's roster to a different manager", async () => {
+    writeCache(
+      "checkin-board.manager-1.event-1",
+      BOARD,
+      PERSISTENT_QUERY_VERSION,
+      "someone-else",
+      Date.now(),
+    );
+    listCheckInEvents.mockRejectedValue(new Error("Failed to fetch"));
+    getCheckInBoard.mockRejectedValue(new Error("Failed to fetch"));
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/The class list could not be loaded/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Jane L.")).not.toBeInTheDocument();
+  });
+});

--- a/src/routes/_authenticated/manager.check-in.test.tsx
+++ b/src/routes/_authenticated/manager.check-in.test.tsx
@@ -130,9 +130,12 @@ describe("/manager/check-in offline", () => {
 
     renderPage();
 
-    const notice = await screen.findByText(/saved on this device/i);
-    expect(notice).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+    // Both halves say so, not just the roster: a manager acting on a stale class
+    // list (a class added since, a wrong attendance count) has no other way to
+    // tell it is not live.
+    expect(await screen.findByText(/roster saved on this device/i)).toBeInTheDocument();
+    expect(screen.getByText(/class list saved on this device/i)).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /try again/i }).length).toBeGreaterThan(0);
   });
 
   it("says nothing about staleness once the refresh lands", async () => {

--- a/src/routes/_authenticated/manager.check-in.tsx
+++ b/src/routes/_authenticated/manager.check-in.tsx
@@ -12,6 +12,15 @@ import { cn } from "@/lib/utils";
 import { useAuth, useRoles } from "@/hooks/useAuth";
 import { CLUB_TIME_ZONE } from "@/lib/calendar";
 import { coveragePreviewLabel, pickDefaultEvent } from "@/lib/checkin";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { usePersistentQuery } from "@/hooks/use-persistent-query";
+import { StaleNotice } from "@/components/site/StaleNotice";
+import {
+  CHECKIN_CACHE_MAX_AGE_MS,
+  checkInBoardCacheSchema,
+  checkInEventsCacheSchema,
+} from "@/lib/checkin-cache";
+import { cacheReviver } from "@/lib/kb-cache";
 import {
   attachCheckInCoverage,
   checkInPerson,
@@ -107,16 +116,7 @@ function CheckInPage() {
   const undo = useServerFn(undoCheckIn);
   const attach = useServerFn(attachCheckInCoverage);
 
-  const [events, setEvents] = useState<EventRow[]>([]);
   const [eventId, setEventId] = useState<string | null>(null);
-  const [board, setBoard] = useState<Board | null>(null);
-  const [uncovered, setUncovered] = useState<UncoveredRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  // Two loads, two failures, and they mean different things: no classes on the
-  // calendar is a reason to add one, and no roster means nobody is in the room.
-  // Both used to fade with a toast and leave the ordinary empty state saying so.
-  const [eventsError, setEventsError] = useState<string | null>(null);
-  const [boardError, setBoardError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [search, setSearch] = useState("");
   const [openAttach, setOpenAttach] = useState<string | null>(null);
@@ -126,60 +126,82 @@ function CheckInPage() {
     if (!rolesLoading && user && !isManager) navigate({ to: "/account" });
   }, [rolesLoading, isManager, user, navigate]);
 
-  // The class list, and the one the screen opens on: today's, or the nearest.
-  const loadEvents = useCallback(() => {
-    setLoading(true);
-    return fetchEvents()
-      .then((rows) => {
-        const list = rows as EventRow[];
-        setEvents(list);
-        setEventId((current) => current ?? pickDefaultEvent(list, new Date())?.id ?? null);
-        setEventsError(null);
-      })
-      .catch((e) => {
-        const message = describeLoadError(e, "Could not load the classes");
-        setEventsError(message);
-        toast.error(message);
-      })
-      .finally(() => setLoading(false));
-  }, [fetchEvents]);
+  /**
+   * The class list and the roster, both kept on this device.
+   *
+   * This screen is run at the door of a gym on a phone, so the two things it
+   * cannot afford are a spinner on launch and an error panel where the roster
+   * should be. `usePersistentQuery` paints what was here last time immediately
+   * and refreshes behind it; `checkin-cache.ts` sets the terms, including why
+   * this one expires in a day where the knowledge base's lasts a week.
+   */
+  const eventsQ = usePersistentQuery<EventRow[]>({
+    queryKey: ["checkin-events", user?.id ?? null],
+    queryFn: () => fetchEvents() as Promise<EventRow[]>,
+    enabled: isManager,
+    cacheKey: `checkin-events.${user?.id ?? "anon"}`,
+    owner: user?.id ?? null,
+    maxAgeMs: CHECKIN_CACHE_MAX_AGE_MS,
+    revive: cacheReviver<EventRow[]>(checkInEventsCacheSchema),
+  });
+  const events = useMemo(() => eventsQ.data ?? [], [eventsQ.data]);
 
+  const boardQ = usePersistentQuery<Board>({
+    queryKey: ["checkin-board", user?.id ?? null, eventId],
+    queryFn: () => fetchBoard({ data: { event_id: eventId! } }) as Promise<Board>,
+    enabled: isManager && Boolean(eventId),
+    cacheKey: `checkin-board.${user?.id ?? "anon"}.${eventId ?? "none"}`,
+    owner: user?.id ?? null,
+    maxAgeMs: CHECKIN_CACHE_MAX_AGE_MS,
+    revive: cacheReviver<Board>(checkInBoardCacheSchema),
+  });
+  const board = boardQ.data ?? null;
+
+  /**
+   * The needs-attention list, memory-only and deliberately so: see
+   * `checkin-cache.ts`. A stale worklist sends a manager chasing check-ins
+   * somebody has already sorted out.
+   */
+  const uncoveredQ = useQuery({
+    queryKey: ["checkin-uncovered", user?.id ?? null],
+    queryFn: () => fetchUncovered() as Promise<UncoveredRow[]>,
+    enabled: isManager,
+  });
+  const uncovered = useMemo(() => uncoveredQ.data ?? [], [uncoveredQ.data]);
+
+  // Two loads, two failures, and they mean different things: no classes on the
+  // calendar is a reason to add one, and no roster means nobody is in the room.
+  // Both are only a FAILURE when there is nothing to show — with a copy on the
+  // device, a failed refresh is a staleness notice instead (see `StaleNotice`).
+  const eventsError =
+    eventsQ.isError && !eventsQ.data
+      ? describeLoadError(eventsQ.error, "Could not load the classes")
+      : null;
+  const boardError =
+    boardQ.isError && !boardQ.data
+      ? describeLoadError(boardQ.error, "Could not load the roster")
+      : null;
+  const loading = eventsQ.isLoading;
+
+  // The class the screen opens on: today's, or the nearest. In an effect rather
+  // than inside the fetch, because the list can now arrive from the device
+  // before any fetch has happened at all.
   useEffect(() => {
-    if (!isManager) return;
-    void loadEvents();
-  }, [isManager, loadEvents]);
+    if (!events.length) return;
+    setEventId((current) => current ?? pickDefaultEvent(events, new Date())?.id ?? null);
+  }, [events]);
 
-  const reloadBoard = useCallback(() => {
-    if (!eventId) return Promise.resolve();
-    return fetchBoard({ data: { event_id: eventId } })
-      .then((b) => {
-        setBoard(b as Board);
-        setBoardError(null);
-      })
-      .catch((e) => {
-        const message = describeLoadError(e, "Could not load the roster");
-        setBoardError(message);
-        toast.error(message);
-      });
-  }, [eventId, fetchBoard]);
-
-  const reloadUncovered = useCallback(() => {
-    return fetchUncovered()
-      .then((rows) => setUncovered(rows as UncoveredRow[]))
-      .catch(() => {
-        /* the needs-attention list is secondary; never block the door on it */
-      });
-  }, [fetchUncovered]);
-
-  useEffect(() => {
-    if (!isManager) return;
-    reloadBoard();
-  }, [isManager, reloadBoard]);
-
-  useEffect(() => {
-    if (!isManager) return;
-    reloadUncovered();
-  }, [isManager, reloadUncovered]);
+  const queryClient = useQueryClient();
+  /** Re-read the roster and the needs-attention list after a write. */
+  const refreshAfterWrite = useCallback(async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["checkin-board"] }),
+      queryClient.invalidateQueries({ queryKey: ["checkin-uncovered"] }),
+      // The class list carries each class's attendance count, so checking
+      // somebody in changes it too.
+      queryClient.invalidateQueries({ queryKey: ["checkin-events"] }),
+    ]);
+  }, [queryClient]);
 
   const selectedEvent = events.find((e) => e.id === eventId) ?? null;
   const isCancelled = board?.event.status === "cancelled";
@@ -220,7 +242,7 @@ function CheckInPage() {
         );
       }
       setSearch("");
-      await Promise.all([reloadBoard(), reloadUncovered()]);
+      await refreshAfterWrite();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Could not check them in");
     } finally {
@@ -243,7 +265,7 @@ function CheckInPage() {
             : `Removed ${name ?? "the check-in"}.`,
         );
       }
-      await Promise.all([reloadBoard(), reloadUncovered()]);
+      await refreshAfterWrite();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Could not undo that check-in");
     } finally {
@@ -266,7 +288,7 @@ function CheckInPage() {
         toast.success(left == null ? `Attached to ${plan}.` : `Attached to ${plan}. ${left} left.`);
         setOpenAttach(null);
       }
-      await Promise.all([reloadBoard(), reloadUncovered()]);
+      await refreshAfterWrite();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Could not attach that check-in");
     } finally {
@@ -331,7 +353,7 @@ function CheckInPage() {
             what="The class list"
             message={eventsError}
             hint="This is not the same as there being no classes on the calendar, so do not add one from here."
-            onRetry={() => void loadEvents()}
+            onRetry={() => void eventsQ.refetch()}
           />
         )}
 
@@ -346,6 +368,18 @@ function CheckInPage() {
         )}
       </div>
 
+      {/* The one thing a manager at the door must not be left to guess: whether
+          what they are reading is live. Shown only when this really IS the
+          stored copy and the refresh behind it failed — a successful refresh
+          replaces it silently, which is the ordinary case. */}
+      {boardQ.isError && boardQ.restoredAt !== null && (
+        <StaleNotice
+          what="roster"
+          savedAt={boardQ.restoredAt}
+          onRetry={() => void boardQ.refetch()}
+        />
+      )}
+
       {/* ---- Here now ---- */}
       <div className="space-y-2">
         <h2 className="text-xl font-bold">Here now{board ? ` (${board.checkins.length})` : ""}</h2>
@@ -354,7 +388,7 @@ function CheckInPage() {
             what="The roster"
             message={boardError}
             hint="Nobody is listed because it could not be read, not because the mat is empty."
-            onRetry={() => void reloadBoard()}
+            onRetry={() => void boardQ.refetch()}
           />
         )}
         <div className="overflow-x-auto rounded-lg border">

--- a/src/routes/_authenticated/manager.check-in.tsx
+++ b/src/routes/_authenticated/manager.check-in.tsx
@@ -372,6 +372,13 @@ function CheckInPage() {
           what they are reading is live. Shown only when this really IS the
           stored copy and the refresh behind it failed — a successful refresh
           replaces it silently, which is the ordinary case. */}
+      {eventsQ.isError && eventsQ.restoredAt !== null && (
+        <StaleNotice
+          what="class list"
+          savedAt={eventsQ.restoredAt}
+          onRetry={() => void eventsQ.refetch()}
+        />
+      )}
       {boardQ.isError && boardQ.restoredAt !== null && (
         <StaleNotice
           what="roster"

--- a/src/routes/_authenticated/manager.kb.tsx
+++ b/src/routes/_authenticated/manager.kb.tsx
@@ -71,6 +71,7 @@ import {
 import { kbMarkdownComponents, kbRemarkPlugins } from "@/lib/kb-markdown";
 import { useEditorDraft } from "@/hooks/use-editor-draft";
 import { DraftRestoreBanner } from "@/components/site/DraftRestoreBanner";
+import { SaveFailure } from "@/components/site/SaveFailure";
 import { useInvalidateKbReader } from "@/hooks/useKbArticle";
 import { articleVisibilities, visibilityAudience } from "@/lib/kb";
 import { discardUnsavedChanges, useConfirm } from "@/hooks/use-confirm";
@@ -293,6 +294,14 @@ function KnowledgeBaseManager() {
   const [saving, setSaving] = useState(false);
   const [promoting, setPromoting] = useState(false);
   const [busy, setBusy] = useState(false);
+  /**
+   * The last failed save, kept on screen rather than left to a toast.
+   *
+   * `SaveFailure`, for the reason written at the top of that component: a toast
+   * fades in four seconds and leaves an editor that looks exactly like one that
+   * saved. A manager who glanced away walks off believing a correction is live.
+   */
+  const [saveError, setSaveError] = useState<string | null>(null);
   const { confirm, confirmDialog } = useConfirm();
   // Called after every write here. The reader side caches articles and the
   // sidebar for minutes at a time, and this screen is the only thing that
@@ -428,6 +437,13 @@ function KnowledgeBaseManager() {
     shape: KB_DRAFT_SHAPE,
     enabled: Boolean(slug) && stored !== null,
   });
+
+  // Editing anything clears the last failure: the panel is about the save that
+  // was attempted, and leaving it up over changed text claims something about
+  // work it never saw.
+  useEffect(() => {
+    setSaveError(null);
+  }, [title, body, visibility, annotationsEnabled, section, navTitle, linkPath]);
 
   function restoreKbDraft() {
     const d = kbDraft.offered;
@@ -775,6 +791,7 @@ function KnowledgeBaseManager() {
   }
 
   async function onSave() {
+    setSaveError(null);
     const isLink = kind === "link";
     const targetSlug = (creating ? slug || slugFromTitle(isLink ? navTitle : title) : slug).trim();
     if (!targetSlug) {
@@ -940,7 +957,8 @@ function KnowledgeBaseManager() {
         toast.warning("Saved. The version list could not be refreshed, so reload to see it.");
       }
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Save failed");
+      if (stale(token)) return;
+      setSaveError(e instanceof Error && e.message ? e.message : "Save failed.");
     } finally {
       setSaving(false);
       // Clears a `busy` a load abandoned when this save overtook it. That load
@@ -1583,6 +1601,14 @@ function KnowledgeBaseManager() {
               savedAt={kbDraft.offeredAt}
               onRestore={restoreKbDraft}
               onDiscard={kbDraft.discard}
+            />
+          )}
+          {saveError && (
+            <SaveFailure
+              what={kind === "link" ? "link" : "article"}
+              message={saveError}
+              retrying={saving}
+              onRetry={() => void onSave()}
             />
           )}
           {sectionEdit ? (

--- a/src/routes/_authenticated/manager.kb.tsx
+++ b/src/routes/_authenticated/manager.kb.tsx
@@ -302,6 +302,17 @@ function KnowledgeBaseManager() {
    * saved. A manager who glanced away walks off believing a correction is live.
    */
   const [saveError, setSaveError] = useState<string | null>(null);
+  /**
+   * The fields "New article" / "New link" just seeded, so a draft of an entry
+   * that does not exist yet has something to be measured against.
+   *
+   * `stored` is the baseline for an entry that HAS been saved, and it is null
+   * while creating one — which is exactly the case that loses the most work, so
+   * it cannot simply be left unprotected. Measuring against a bare empty shape
+   * instead would not do: `startNew` presets a section and a position, so a
+   * form nobody has typed into yet would read as unsaved work.
+   */
+  const [newBaseline, setNewBaseline] = useState<KbDraftFields | null>(null);
   const { confirm, confirmDialog } = useConfirm();
   // Called after every write here. The reader side caches articles and the
   // sidebar for minutes at a time, and this screen is the only thing that
@@ -410,8 +421,9 @@ function KnowledgeBaseManager() {
   );
   const kbDraftBaseline = useMemo<KbDraftFields>(
     () =>
-      stored
-        ? {
+      !stored
+        ? (newBaseline ?? KB_DRAFT_SHAPE)
+        : {
             title: stored.title,
             body: stored.body_md,
             visibility: stored.visibility,
@@ -424,18 +436,22 @@ function KnowledgeBaseManager() {
             // about to happen — so its baseline is always empty and a note
             // somebody typed counts as unsaved work on its own.
             changeNote: "",
-          }
-        : KB_DRAFT_SHAPE,
-    [stored],
+          },
+    [stored, newBaseline],
   );
   const kbDraft = useEditorDraft<KbDraftFields>({
     kind: "kb-entry",
-    scope: slug || "new",
+    // A new entry has no slug yet, so it gets its own slot. Once it is saved
+    // the screen moves onto the real slug and this one is cleared.
+    scope: creating ? "new" : slug,
     owner: user?.id ?? null,
     value: kbDraftFields,
     baseline: kbDraftBaseline,
     shape: KB_DRAFT_SHAPE,
-    enabled: Boolean(slug) && stored !== null,
+    // Held back until there is a baseline to measure against: an offer weighed
+    // against nothing is an offer to restore a draft identical to what is
+    // already on screen.
+    enabled: creating ? newBaseline !== null : Boolean(slug) && stored !== null,
   });
 
   // Editing anything clears the last failure: the panel is about the save that
@@ -615,6 +631,7 @@ function KnowledgeBaseManager() {
     if (summary?.link_path) {
       claim();
       setCreating(false);
+      setNewBaseline(null);
       setSlug(next);
       setKind("link");
       setTitle("");
@@ -659,6 +676,7 @@ function KnowledgeBaseManager() {
       if (stale(token)) return;
 
       setCreating(false);
+      setNewBaseline(null);
       setSlug(next);
       setChangeNote("");
       setPreview(null);
@@ -751,6 +769,11 @@ function KnowledgeBaseManager() {
     const into = sections[0]?.slug ?? "";
     setSection(into);
     setPosition(nextPosition(siblingsOf(into)));
+    setNewBaseline({
+      ...KB_DRAFT_SHAPE,
+      section: into,
+      position: String(nextPosition(siblingsOf(into))),
+    });
     setFailed({ article: false, versions: false, feedback: false });
   }
 
@@ -921,6 +944,7 @@ function KnowledgeBaseManager() {
       // editor would put the screen out of step with itself.
       if (stale(token)) return;
       setCreating(false);
+      setNewBaseline(null);
       setSlug(targetSlug);
       setChangeNote("");
       setBaseVisibility(visibility);

--- a/src/routes/_authenticated/manager.kb.tsx
+++ b/src/routes/_authenticated/manager.kb.tsx
@@ -69,6 +69,8 @@ import {
   setCurrentArticleVersion,
 } from "@/lib/kb.functions";
 import { kbMarkdownComponents, kbRemarkPlugins } from "@/lib/kb-markdown";
+import { useEditorDraft } from "@/hooks/use-editor-draft";
+import { DraftRestoreBanner } from "@/components/site/DraftRestoreBanner";
 import { useInvalidateKbReader } from "@/hooks/useKbArticle";
 import { articleVisibilities, visibilityAudience } from "@/lib/kb";
 import { discardUnsavedChanges, useConfirm } from "@/hooks/use-confirm";
@@ -156,6 +158,35 @@ function containerOf(groups: NavGroup[], id: string): string | null {
   const slug = id.slice("entry:".length);
   return groups.find((g) => g.entries.some((e) => e.slug === slug))?.slug ?? null;
 }
+
+/**
+ * One entry's draft, flattened. `position` is a number on screen and a string
+ * here for the same reason every other field is a string or a boolean: the
+ * stored shape has to be readable by a later build without a migration.
+ */
+type KbDraftFields = {
+  title: string;
+  body: string;
+  visibility: string;
+  annotationsEnabled: boolean;
+  section: string;
+  position: string;
+  navTitle: string;
+  linkPath: string;
+  changeNote: string;
+};
+
+const KB_DRAFT_SHAPE: KbDraftFields = {
+  title: "",
+  body: "",
+  visibility: "members",
+  annotationsEnabled: true,
+  section: "",
+  position: "0",
+  navTitle: "",
+  linkPath: "",
+  changeNote: "",
+};
 
 function KnowledgeBaseManager() {
   const navigate = useNavigate();
@@ -330,6 +361,88 @@ function KnowledgeBaseManager() {
     link_path: linkPath,
   };
   const dirty = isArticleDirty(draft, stored);
+
+  /**
+   * The on-device safety net for whichever entry is open.
+   *
+   * An article is Markdown a manager can sit with for a long time, and until now
+   * it lived only in React state — so the installed app being reclaimed in the
+   * background took the lot, exactly as it did for a blog post. Flattened to
+   * strings and booleans because a draft has to survive being read back by a
+   * later build of the site (see `src/lib/editor-draft.ts`).
+   *
+   * Scoped by slug, so two entries never overwrite each other's draft, and held
+   * back until `stored` has loaded: comparing against a baseline that has not
+   * arrived would offer back a draft identical to the saved version.
+   */
+  const kbDraftFields = useMemo<KbDraftFields>(
+    () => ({
+      title,
+      body,
+      visibility,
+      annotationsEnabled,
+      section,
+      position: String(position),
+      navTitle,
+      linkPath,
+      changeNote,
+    }),
+    [
+      title,
+      body,
+      visibility,
+      annotationsEnabled,
+      section,
+      position,
+      navTitle,
+      linkPath,
+      changeNote,
+    ],
+  );
+  const kbDraftBaseline = useMemo<KbDraftFields>(
+    () =>
+      stored
+        ? {
+            title: stored.title,
+            body: stored.body_md,
+            visibility: stored.visibility,
+            annotationsEnabled: stored.annotations_enabled,
+            section: stored.section,
+            position: String(stored.position),
+            navTitle: stored.nav_title,
+            linkPath: stored.link_path,
+            // Never part of the saved version — it describes the save that is
+            // about to happen — so its baseline is always empty and a note
+            // somebody typed counts as unsaved work on its own.
+            changeNote: "",
+          }
+        : KB_DRAFT_SHAPE,
+    [stored],
+  );
+  const kbDraft = useEditorDraft<KbDraftFields>({
+    kind: "kb-entry",
+    scope: slug || "new",
+    owner: user?.id ?? null,
+    value: kbDraftFields,
+    baseline: kbDraftBaseline,
+    shape: KB_DRAFT_SHAPE,
+    enabled: Boolean(slug) && stored !== null,
+  });
+
+  function restoreKbDraft() {
+    const d = kbDraft.offered;
+    if (!d) return;
+    setTitle(d.title);
+    setBody(d.body);
+    setVisibility(d.visibility === "managers" ? "managers" : "members");
+    setAnnotationsEnabled(d.annotationsEnabled);
+    setSection(d.section);
+    setPosition(Number.isFinite(Number(d.position)) ? Number(d.position) : 0);
+    setNavTitle(d.navTitle);
+    setLinkPath(d.linkPath);
+    setChangeNote(d.changeNote);
+    kbDraft.restore();
+  }
   /**
    * The work the VISIBLE editor would lose, which is what every "discard your
    * unsaved changes?" prompt is really asking about.
@@ -807,6 +920,10 @@ function KnowledgeBaseManager() {
         link_path: isLink ? linkPath.trim() : "",
       });
       if (isLink) setLinkPath(linkPath.trim());
+      // The version is published, so there is nothing left to recover. `stored`
+      // moving to match would clear it anyway; doing it here as well covers the
+      // save that also changed the slug, whose draft is filed under the old one.
+      kbDraft.clear();
       try {
         const [rows, sectionRows, vs] = await Promise.all([
           fetchArticles(),
@@ -1457,6 +1574,17 @@ function KnowledgeBaseManager() {
         </aside>
 
         <div className="space-y-4">
+          {/* Above both editors rather than inside the article one: the offer is
+              about this slug, and it should be the first thing a manager sees on
+              a screen they have just come back to. */}
+          {kbDraft.offered && (
+            <DraftRestoreBanner
+              what={kbDraft.offered.linkPath ? "link" : "article"}
+              savedAt={kbDraft.offeredAt}
+              onRestore={restoreKbDraft}
+              onDiscard={kbDraft.discard}
+            />
+          )}
           {sectionEdit ? (
             /* A section, edited in the same window an article is, so titles,
                settings and deletion all live in one place and the list on the

--- a/src/routes/_authenticated/manager.waiver-template.tsx
+++ b/src/routes/_authenticated/manager.waiver-template.tsx
@@ -28,6 +28,7 @@ import {
   hasMediaAcknowledgement,
   isDirty,
   meaningfulAcks,
+  parseAcksJson,
   versionLabel,
 } from "@/lib/waiver-template-editor";
 import { MEDIA_ACK_ID } from "@/lib/waiver-acknowledgements";
@@ -109,23 +110,6 @@ type TemplateVersion = Awaited<ReturnType<typeof listWaiverTemplates>>[number];
 type TemplateDraftFields = { title: string; body: string; acksJson: string };
 
 const TEMPLATE_DRAFT_SHAPE: TemplateDraftFields = { title: "", body: "", acksJson: "[]" };
-
-/**
- * Read the acknowledgements back out of a restored draft.
- *
- * Falls back to what is already on screen rather than to an empty list: the
- * media consent row is required, and restoring a draft into no acknowledgements
- * at all would put the editor into a state it refuses to save from, with no
- * obvious way out.
- */
-function parseAcksJson(raw: string, fallback: AcknowledgementDef[]): AcknowledgementDef[] {
-  try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? (parsed as AcknowledgementDef[]) : fallback;
-  } catch {
-    return fallback;
-  }
-}
 
 function EditorPage() {
   const navigate = useNavigate();
@@ -391,21 +375,21 @@ function EditorPage() {
           </Button>
         </div>
 
-        {saveError && (
-          <SaveFailure
-            what="waiver template"
-            message={saveError}
-            retrying={saving}
-            onRetry={() => void onSave()}
-          />
-        )}
-
         {templateDraft.offered && (
           <DraftRestoreBanner
             what="waiver template"
             savedAt={templateDraft.offeredAt}
             onRestore={restoreTemplateDraft}
             onDiscard={templateDraft.discard}
+          />
+        )}
+
+        {saveError && (
+          <SaveFailure
+            what="waiver template"
+            message={saveError}
+            retrying={saving}
+            onRetry={() => void onSave()}
           />
         )}
 

--- a/src/routes/_authenticated/manager.waiver-template.tsx
+++ b/src/routes/_authenticated/manager.waiver-template.tsx
@@ -33,6 +33,7 @@ import {
 import { MEDIA_ACK_ID } from "@/lib/waiver-acknowledgements";
 import { useEditorDraft } from "@/hooks/use-editor-draft";
 import { DraftRestoreBanner } from "@/components/site/DraftRestoreBanner";
+import { SaveFailure } from "@/components/site/SaveFailure";
 
 function applyPlaceholders(body: string, values: Record<string, string>): string {
   return body.replace(/\{\{\s*([a-z_]+)\s*\}\}/gi, (_, k) => values[k] ?? `{{${k}}}`);
@@ -146,6 +147,12 @@ function EditorPage() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [promoting, setPromoting] = useState(false);
+  /**
+   * The last failed save, kept on screen rather than left to a toast. This is
+   * the document people sign, so "did that go through?" is not a question to
+   * leave somebody guessing at four seconds after the fact.
+   */
+  const [saveError, setSaveError] = useState<string | null>(null);
   const { confirm, confirmDialog } = useConfirm();
 
   const selected = templates.find((t) => t.id === selectedId) ?? null;
@@ -299,6 +306,13 @@ function EditorPage() {
 
   const preview = useMemo(() => applyPlaceholders(body, SAMPLE), [body]);
 
+  // Editing anything clears the last failure: the panel is about the save that
+  // was attempted, and leaving it up over changed text claims something about
+  // work it never saw.
+  useEffect(() => {
+    setSaveError(null);
+  }, [title, body, acks]);
+
   async function onSave() {
     // Belt and braces: the Save button is already disabled for this, but a
     // rejected server call after the fact is a worse experience than catching
@@ -310,6 +324,7 @@ function EditorPage() {
       );
       return;
     }
+    setSaveError(null);
     setSaving(true);
     try {
       const cleanAcks = meaningfulAcks(acks);
@@ -332,7 +347,7 @@ function EditorPage() {
         toast.warning("Saved. The version list could not be refreshed, so reload to see it.");
       }
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Save failed");
+      setSaveError(e instanceof Error && e.message ? e.message : "Save failed.");
     } finally {
       setSaving(false);
     }
@@ -375,6 +390,15 @@ function EditorPage() {
             <Link to="/account">Back to account</Link>
           </Button>
         </div>
+
+        {saveError && (
+          <SaveFailure
+            what="waiver template"
+            message={saveError}
+            retrying={saving}
+            onRetry={() => void onSave()}
+          />
+        )}
 
         {templateDraft.offered && (
           <DraftRestoreBanner

--- a/src/routes/_authenticated/manager.waiver-template.tsx
+++ b/src/routes/_authenticated/manager.waiver-template.tsx
@@ -31,6 +31,8 @@ import {
   versionLabel,
 } from "@/lib/waiver-template-editor";
 import { MEDIA_ACK_ID } from "@/lib/waiver-acknowledgements";
+import { useEditorDraft } from "@/hooks/use-editor-draft";
+import { DraftRestoreBanner } from "@/components/site/DraftRestoreBanner";
 
 function applyPlaceholders(body: string, values: Record<string, string>): string {
   return body.replace(/\{\{\s*([a-z_]+)\s*\}\}/gi, (_, k) => values[k] ?? `{{${k}}}`);
@@ -98,6 +100,31 @@ export const Route = createFileRoute("/_authenticated/manager/waiver-template")(
 });
 
 type TemplateVersion = Awaited<ReturnType<typeof listWaiverTemplates>>[number];
+
+/**
+ * The template draft, flattened for storage. The acknowledgements are a list of
+ * objects, so they travel as JSON in one string field.
+ */
+type TemplateDraftFields = { title: string; body: string; acksJson: string };
+
+const TEMPLATE_DRAFT_SHAPE: TemplateDraftFields = { title: "", body: "", acksJson: "[]" };
+
+/**
+ * Read the acknowledgements back out of a restored draft.
+ *
+ * Falls back to what is already on screen rather than to an empty list: the
+ * media consent row is required, and restoring a draft into no acknowledgements
+ * at all would put the editor into a state it refuses to save from, with no
+ * obvious way out.
+ */
+function parseAcksJson(raw: string, fallback: AcknowledgementDef[]): AcknowledgementDef[] {
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as AcknowledgementDef[]) : fallback;
+  } catch {
+    return fallback;
+  }
+}
 
 function EditorPage() {
   const navigate = useNavigate();
@@ -171,6 +198,53 @@ function EditorPage() {
   );
 
   const liveVersion = templates.find((t) => t.is_current)?.version ?? null;
+
+  /**
+   * The on-device safety net, the same one the blog composer and the knowledge
+   * base editor use. This is the document people sign, and rewriting it is a
+   * long sitting: losing it to a backgrounded app is the worst version of the
+   * problem, not the least serious one.
+   *
+   * The acknowledgements are a list of objects, so they travel as JSON in a
+   * single string field — everything a draft stores has to be a plain string or
+   * boolean so a later build can read it back (`src/lib/editor-draft.ts`).
+   *
+   * Scoped to the version being edited, and held back until one is open: with no
+   * baseline, an offer would be measured against nothing.
+   */
+  const templateDraftFields = useMemo<TemplateDraftFields>(
+    () => ({ title, body, acksJson: JSON.stringify(acks) }),
+    [title, body, acks],
+  );
+  const templateDraftBaseline = useMemo<TemplateDraftFields>(
+    () =>
+      selected
+        ? {
+            title: selected.title,
+            body: selected.body_md,
+            acksJson: JSON.stringify(selected.acknowledgements ?? []),
+          }
+        : TEMPLATE_DRAFT_SHAPE,
+    [selected],
+  );
+  const templateDraft = useEditorDraft<TemplateDraftFields>({
+    kind: "waiver-template",
+    scope: selectedId ?? "new",
+    owner: user?.id ?? null,
+    value: templateDraftFields,
+    baseline: templateDraftBaseline,
+    shape: TEMPLATE_DRAFT_SHAPE,
+    enabled: Boolean(selected),
+  });
+
+  function restoreTemplateDraft() {
+    const d = templateDraft.offered;
+    if (!d) return;
+    setTitle(d.title);
+    setBody(d.body);
+    setAcks(parseAcksJson(d.acksJson, acks));
+    templateDraft.restore();
+  }
 
   // Checked against the raw acks so clearing the media row's label trips this
   // immediately, before `meaningfulAcks` would silently drop the row on save.
@@ -246,6 +320,9 @@ function EditorPage() {
       // as "Save failed" for a version that had been written and made live —
       // whereupon the obvious response, saving again, files a duplicate.
       toast.success(`Saved version ${res.version}, now live`);
+      // Published, so there is nothing left to recover. The reload below opens
+      // the new version, whose own baseline then matches what is on screen.
+      templateDraft.clear();
       try {
         const rows = await fetchTemplates();
         setTemplates(rows);
@@ -298,6 +375,15 @@ function EditorPage() {
             <Link to="/account">Back to account</Link>
           </Button>
         </div>
+
+        {templateDraft.offered && (
+          <DraftRestoreBanner
+            what="waiver template"
+            savedAt={templateDraft.offeredAt}
+            onRestore={restoreTemplateDraft}
+            onDiscard={templateDraft.discard}
+          />
+        )}
 
         <div className="grid gap-6 lg:grid-cols-[1fr_260px]">
           <div className="space-y-4">

--- a/src/routes/app.tsx
+++ b/src/routes/app.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { supabase } from "@/integrations/supabase/client";
 import { AuthPending } from "@/components/site/AuthPending";
-import { MEMBER_HOME_PATH, resolveLaunchScreen } from "@/lib/pwa";
+import { MEMBER_HOME_PATH, resolveLaunchTarget } from "@/lib/pwa";
+import { readLastVisit } from "@/lib/last-visit";
 
 /**
  * The installed app's launch screen (`start_url` in the web manifest).
@@ -9,6 +10,12 @@ import { MEMBER_HOME_PATH, resolveLaunchScreen } from "@/lib/pwa";
  * It renders nothing of its own: it works out who is holding the phone and
  * forwards them to the screen they actually wanted, so a member taps the icon
  * and lands in their member area instead of on the marketing home page.
+ *
+ * When the app was open recently it forwards them back to the screen they were
+ * actually on, which is what makes a relaunch feel like a resume. The installed
+ * app has no resume of its own: a phone reclaiming it in the background means
+ * the next tap is a cold launch right here. `resolveLaunchTarget` owns the rule,
+ * including which paths must never be reopened.
  *
  * `ssr: false` because the answer depends on the Supabase session, which lives
  * in the browser. Rendering it on the server would only produce a guess that
@@ -27,11 +34,22 @@ export const Route = createFileRoute("/app")({
   pendingComponent: () => <AuthPending label="Opening UTS Jitsu" />,
   beforeLoad: async () => {
     const { data } = await supabase.auth.getSession();
-    const screen = resolveLaunchScreen({ hasSession: Boolean(data.session) });
+    const hasSession = Boolean(data.session);
+    const target = resolveLaunchTarget({
+      hasSession,
+      lastVisit: readLastVisit(data.session?.user?.id ?? null),
+      now: Date.now(),
+    });
 
     // `replace` so the launch route never sits in the back stack: pressing back
     // from the member area should leave the app, not bounce through here.
-    if (screen === "member") throw redirect({ to: MEMBER_HOME_PATH, replace: true });
+    //
+    // The recorded path goes through `href` rather than `to`: it is a string
+    // read back off the device, not one of the router's known route ids, and
+    // `resolveLaunchTarget` has already refused anything that is not a plain
+    // site-relative path.
+    if ("path" in target) throw redirect({ href: target.path, replace: true });
+    if (target.screen === "member") throw redirect({ to: MEMBER_HOME_PATH, replace: true });
     throw redirect({ to: "/", replace: true });
   },
   component: () => <AuthPending label="Opening UTS Jitsu" />,

--- a/src/routes/kb/$slug.tsx
+++ b/src/routes/kb/$slug.tsx
@@ -30,6 +30,7 @@ import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { KbArticleReader } from "@/components/site/KbArticleReader";
 import { Loading } from "@/components/site/Loading";
+import { StaleNotice } from "@/components/site/StaleNotice";
 import type { NewAnnotation } from "@/components/site/KbArticleReader";
 import { useKbNav } from "@/hooks/useKbNav";
 import { kbAnnotationsQueryKey, useKbArticle, useKbArticlePrefetch } from "@/hooks/useKbArticle";
@@ -262,7 +263,11 @@ function ArticlePage() {
     );
   }
 
-  if (articleQ.isError || !article || !viewer) {
+  // `!article` rather than `isError`: with the article kept on the device, a
+  // refresh that fails still has the text to show, and rendering "Not available"
+  // over a perfectly good copy would be the cache making things worse. A failed
+  // refresh becomes the notice above the article instead, further down.
+  if (!article || !viewer) {
     return (
       <section className="max-w-3xl">
         <h1 className="text-3xl font-bold">Not available</h1>
@@ -294,6 +299,18 @@ function ArticlePage() {
         section={crumbs?.section?.slug ? crumbs.section.title : null}
         title={article.title}
       />
+
+      {/* Only when BOTH are true: this is the stored copy, and the refresh
+          behind it failed. A successful refresh replaces the text silently,
+          which is the ordinary case and needs no announcement. */}
+      {articleQ.isError && articleQ.restoredAt !== null && (
+        <StaleNotice
+          className="mb-6"
+          what="article"
+          savedAt={articleQ.restoredAt}
+          onRetry={() => void articleQ.refetch()}
+        />
+      )}
 
       <header className="mb-8">
         <div className="flex flex-wrap items-center gap-2">

--- a/src/routes/kb/index.tsx
+++ b/src/routes/kb/index.tsx
@@ -8,6 +8,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowRight, Check, ExternalLink, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { LoadFailure } from "@/components/site/LoadFailure";
+import { StaleNotice } from "@/components/site/StaleNotice";
 import { Loading } from "@/components/site/Loading";
 import { useKbNav } from "@/hooks/useKbNav";
 import { useKbArticlePrefetch } from "@/hooks/useKbArticle";
@@ -21,7 +22,7 @@ export const Route = createFileRoute("/kb/")({
 });
 
 function KnowledgeBaseIndex() {
-  const { nav, loading, error, refetch } = useKbNav();
+  const { nav, loading, error, restoredAt, refetch } = useKbNav();
   // Every article here is one click away, so the fetch starts on the hover, the
   // keyboard focus or the touch that precedes the click.
   const prefetchArticle = useKbArticlePrefetch();
@@ -121,6 +122,9 @@ function KnowledgeBaseIndex() {
       {/* Before the empty state, and instead of it. "There is nothing here for
           you to read yet" is a claim about the club, and a member who is told
           it because a fetch failed has no reason to ever come back. */}
+      {/* `error` is only set when there is NO list to show: with the contents
+          kept on the device, a failed background refresh still has a perfectly
+          good one, and that is the notice below rather than this panel. */}
       {!loading && error && (
         <LoadFailure
           className="mt-10"
@@ -130,6 +134,10 @@ function KnowledgeBaseIndex() {
           onRetry={refetch}
         />
       )}
+
+      {!loading && restoredAt ? (
+        <StaleNotice className="mt-10" what="contents" savedAt={restoredAt} onRetry={refetch} />
+      ) : null}
 
       {!loading && !error && !nav.length && (
         <p className="mt-10 text-sm text-muted-foreground">


### PR DESCRIPTION
A manager wrote a blog post in the installed app, left it, and came back to an empty editor. This fixes that, the reloading that caused it, and the local caching around it.

## What changes for the people using the site

**Nobody loses what they typed.** The blog composer, the knowledge base editor and the waiver template editor now keep everything on the device as it is written. Coming back to a composer that was closed offers the work back, with the time it was kept from, and a choice to bring it back or discard it. It is always an offer, never a silent restore: somebody who abandoned a draft on purpose, or who has since edited the same post from a laptop, must not have this device's older copy pushed over what they meant to keep.

**The app stops re-fetching everything each time you come back to it.** Unlocking a phone, switching tabs, returning from another app: all of it looked like a sign-in and threw the whole screen away. That was the reload, and it is gone.

**Relaunching the installed app returns you to the screen you were on**, if it was open in the last day. A phone reclaiming the app in the background means the next tap on the icon is a cold launch, which used to land everyone on the member home page with nothing to say anything had been lost.

**The knowledge base can be read with no signal.** Articles and the sidebar are kept on the reader's own device, so opening the app paints what was there instead of a spinner, and a member on the mat can re-read an article they have opened before. If it cannot be refreshed, the article stays up with a line saying when it was fetched, rather than the page reporting itself unavailable.

**Check-in works at the door on a bad connection.** The class list and the roster are kept on the manager's phone for a day, and the screen says plainly when what is on it is not live. Checking somebody in still needs the network, since it spends a session and works out coverage server-side; offline check-in is not part of this.

**A failed save no longer disappears.** The three editors reported one with a toast, which fades in four seconds and leaves an editor that looks exactly like one that saved. It now stays on screen with the writing still in the form and a button that tries again.

### What a person will feel

- Managers see a new panel offering back unsaved work the first time they open an editor they had left. Nothing to set up.
- On a shared club laptop, signing out wipes everything this keeps on the device, so a draft or a cached roster never survives into the next person's session.
- A roster or an article kept on a device can be a little behind. Where that is possible, the screen says so.

## How it works

Three separate causes of the reloading, all the same mistake at different layers:

- **supabase-js re-announces the session on every visibility change.** `_onVisibilityChanged` runs `_recoverAndRefresh`, which emits a fresh `SIGNED_IN` whenever it finds a usable stored session. `__root.tsx` took that at face value and called `router.invalidate()` plus `queryClient.invalidateQueries()`. `resolveAuthRefresh` (`src/lib/auth-events.ts`) makes the rule about identity instead, and ignores the first event of a page's life so a cold start no longer fetches everything twice.
- **`useAuth` re-set its state from those announcements**, re-rendering most of the signed-in app for nothing. It now holds `session`/`user` steady while the person and their token are unchanged, and still moves on a real `USER_UPDATED`.
- **React Query ran on its own defaults** (`staleTime: 0`, `refetchOnWindowFocus: true`). Now 30s fresh, focus refetch off, reconnect refetch on, one retry instead of three. `defaultPreloadStaleTime` moves off 0, so a hover preload survives long enough for the tap to use it.

New seams, all pure and unit tested:

| Module | What it owns |
| --- | --- |
| `src/lib/local-cache.ts` | The only place this app writes to `localStorage`. Every entry is versioned, owner-scoped and dated. |
| `src/lib/editor-draft.ts` + `src/hooks/use-editor-draft.ts` | Unsaved work. Saves on a debounce **and** on `visibilitychange`/`pagehide`. |
| `src/hooks/use-persistent-query.ts` | A React Query seeded from the device during render and refreshed behind it. |
| `src/lib/kb-cache.ts`, `src/lib/checkin-cache.ts` | What each feature may keep, for how long, and the Zod shapes it is read back through. |
| `src/lib/pwa.ts` (`resolveLaunchTarget`), `src/lib/last-visit.ts` | Where a launch should go. |

Components: `DraftRestoreBanner`, `SaveFailure` (the sibling of `LoadFailure`), `StaleNotice`.

Included as a preparatory refactor: check-in's three hand-rolled `useState`/`useEffect` loads move onto React Query so they can use the same seam. Its post-write reloads become one `refreshAfterWrite`, which also refreshes the class list — checking somebody in changes its attendance counts, and that was never re-read before.

## Why `beforeunload` was not a safety net

It is what the blog composer had. iOS ignores it outright, and an installed app the operating system reclaims in the background is never asked to unload — it is killed and relaunched cold. So it covered the one case that was already survivable (closing a desktop tab) and none of the cases that actually lose work on a phone. `visibilitychange`/`pagehide` are the last events a page is guaranteed, which is where the save now happens.

## Storing data on a device, deliberately

`public/sw.js` refuses to cache HTML precisely so no signed-in page can be served to the next person on a shared device, and this must not quietly undo that. Every entry records the user id it was written for, signing out wipes everything belonging to whoever was signed in, and each feature sets its own expiry:

| What | How long | Why |
| --- | --- | --- |
| Knowledge base sidebar and articles | 7 days | The club's own handbooks. They change a few times a year. |
| Check-in class list and roster | 24 hours | Carries members' names and emails, and memberships are raised between classes. Older is a wrong answer, not a convenience. |
| Unsaved editor drafts | 14 days | Long enough to survive being forgotten about. |
| Where the app was | 24 hours | Beyond that the member area is the better answer. |
| The needs-attention check-in list | never | A worklist. A stale one sends a manager chasing check-ins somebody already fixed. |

Stored shapes are declared with Zod rather than hand-rolled type guards: `safeParse` is exactly the total function a cache needs when reading what an older build wrote, and a cast there would turn leftover storage into a white screen on launch. Warning codes stay `z.string()` on purpose — pinning the enum would empty every phone's cache the day a new code shipped.

The launch-resume path refuses anything that is not a plain site-relative path (a protocol-relative `//host` is another origin to a browser), the auth screens, and anything carrying a token in its path.

## Form reliability review

Asked for alongside this. Where it already holds: the five paths that can lose a stranger's only attempt — interest, contact, the waiver, email settings, raising a membership — all use `useResilientSubmit` + `SubmitStatus`.

Where it did not, and now does: the three long-form editors, via `SaveFailure`.

Where it deliberately does not, and why: comments, knowledge base annotations and the code of conduct already keep what was typed on a failure but do not retry. Retrying safely needs a `client_submission_id` and a partial unique index per table, the way `20260729020000_submission_idempotency.sql` did for the funnel — without one, a retried comment is a duplicate comment. **That is a migration, so it is left as a separate change to decide on rather than smuggled in here.** Same for the editors' "save as new version", which is not idempotent by nature: their retry is a button a person presses.

## Notes for review

- **No migration, no schema change, no new dependency.** `package.json` and `bun.lock` are untouched.
- One bug found on the way past: `/kb/<slug>` keyed its "Not available" branch on `isError`, so once an article could come off the device a failed *refresh* would have rendered "not available" over a perfectly good copy. It is keyed on having no article now, and that trap is written into `CLAUDE.md`'s UX bar.
- Docs updated in the same change: `docs/pwa.md` (the reload causes, the resume rule, everything kept on a device), `docs/blog.md`, `docs/knowledge-base.md`, `docs/check-in.md`, and three new rules on `CLAUDE.md`'s UX bar.
- 2512 tests pass (86 new), plus lint, typecheck and build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TA7m7vpgMFBFA6DnJypUkC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TA7m7vpgMFBFA6DnJypUkC)_