### PR TITLE
Let a manager set and correct when yearly cover starts

### DIFF
--- a/.claude/skills/uts-manager-agent/SKILL.md
+++ b/.claude/skills/uts-manager-agent/SKILL.md
@@ -128,11 +128,14 @@ invoice reconciles off a bank statement like any other.
 
 `params`: `user_id` (**required** — from `list_users`), `plan_code`
 (**required** — from `list_membership_plans`), `uts_student_number` (optional),
-`session_date` (optional `YYYY-MM-DD`, casual class only), `include_insurance`
-(optional, default false), `send_email` (optional, default true).
+`session_date` (optional `YYYY-MM-DD`, casual class only), `starts_on` (optional
+`YYYY-MM-DD`, yearly insurance only — see below), `include_insurance` (optional,
+default false), `send_email` (optional, default true).
 
 ```bash
 scripts/agent.sh create_membership '{"user_id":"<uuid>","plan_code":"2026-s2"}'
+# Cover that really started in February, recorded now, with no invoice email:
+scripts/agent.sh create_membership '{"user_id":"<uuid>","plan_code":"insurance_yearly","starts_on":"2026-02-01","send_email":false}'
 ```
 
 > **It is authorised straight away, and that is not the same as paid.** Whatever
@@ -165,19 +168,41 @@ scripts/agent.sh create_membership '{"user_id":"<uuid>","plan_code":"2026-s2"}'
 > unpaid invoice rather than creating a second one (and does not re-send the
 > email), so a call whose reply you never saw can simply be repeated. The free
 > trial is still once per person ever: a second one is `409 trial_already_used`.
+>
+> **`starts_on` says when the cover itself begins**, defaulting to today. Only a
+> plan that runs for a fixed number of days takes one — today that is the yearly
+> insurance — because its length is fixed while where it sits is a real choice.
+> That makes it the other half of a backfill: `send_email: false` stops the
+> invoice going out, `starts_on` puts the year of cover where it actually ran.
+> The end date follows from the plan's duration.
+>
+> Anything else is refused with `422 start_date_not_choosable` rather than
+> ignored: a **training period**'s dates belong to the plan and everyone who buys
+> it gets exactly those, and a **casual class or free trial** ends with its
+> classes rather than on a date (use `session_date` there — it dates the payment
+> reference, not the membership). Re-raising with a different `starts_on` moves
+> the reused invoice's window.
+>
+> A bundled `include_insurance` invoice always runs from **today**, never from
+> `starts_on`: it is a second plan being sold now. To backdate cover as well,
+> raise the insurance as its own `create_membership` call with its own
+> `starts_on`.
 
 ### `edit_invoice` — correct an invoice's details
 
 `params`: `id` (**required** — the invoice UUID from a list call) plus at least
 one editable field: `price_cents` (integer cents), `notes` (pass `null` to clear
 a mistaken note), `payment_reference`, `payment_method`
-(`bank_transfer | stripe | manual`), `status` (`pending | cancelled | expired`).
+(`bank_transfer | stripe | manual`), `status` (`pending | cancelled | expired`),
+`starts_on` (`YYYY-MM-DD`, yearly insurance only — see below).
 Any other key is rejected, naming itself in the error — so a typo like `price`
 doesn't get silently ignored. This includes the read-only fields a `list_*`
 call decorates an invoice with (`plan_code`, `plan_name`, `price`, `is_student`,
 `paid_at`, `starts_at`, `ends_at`, `created_at`, `member_name`,
 `member_email`): send only `id` plus the field(s) you're actually changing,
-never a listed invoice echoed back wholesale. `plan_name` already names the
+never a listed invoice echoed back wholesale. `starts_at` / `ends_at` move only
+through `starts_on`, which names a day and lets the plan place it — you never
+write the two instants yourself. `plan_name` already names the
 dated period an invoice is for (e.g. "Semester 2 2026", since each period is
 its own plan — see `list_membership_plans` below); it is not editable here
 (moving one person's dates is a plan correction, not an invoice edit).
@@ -229,6 +254,26 @@ audit log with who made it and each field's old and new value.
 >
 > Ask the manager before overriding. "The price is wrong" and "the price was
 > recorded wrong" are different problems, and only the second one is fixed here.
+
+> **`starts_on` corrects the day the cover began**, for a membership whose plan
+> runs a fixed number of days (the yearly insurance). It writes `starts_at` and
+> `ends_at` together: the window keeps the length it was sold at and moves as
+> one, so a correction can never lengthen or shorten somebody's cover. Both show
+> up in `changed` and `previous`, and in the audit log. Any other plan is refused
+> with `422 start_date_not_choosable` — a training period's dates belong to the
+> plan (correct them with `save_membership_plan`, which changes what activates
+> from then on, not anyone already on it), and a class-credit plan has no window
+> to move.
+>
+> It is deliberately **not** guarded by `confirm_paid_edit`. The dates say when
+> somebody is covered, not what they paid, and the correction is wanted most
+> often precisely because the money already landed. Still say what you moved:
+> shortening live cover is felt by the member even though nothing about the
+> invoice changed.
+
+```bash
+scripts/agent.sh edit_invoice '{"id":"<uuid>","starts_on":"2026-02-01"}'
+```
 
 ### `mark_invoice_paid` — record money that arrived
 
@@ -747,7 +792,7 @@ scripts/agent.sh list_kb_comments '{"slug":"our-history"}'
   correct to retry unchanged, and it carries a `Retry-After` header — obey it
   rather than retrying immediately. Nothing was filed. Retryable failures are 5xx;
   a 4xx means the request itself needs to change before it will ever succeed.
-- The manifest's `version` tells generations apart (currently `"13"`), and its
+- The manifest's `version` tells generations apart (currently `"14"`), and its
   `changes` array says what each version actually moved, newest first, with
   `breaking: true` on any version that turns calls which used to succeed into
   errors. **There is no way to pin an older version** — the contract is

--- a/docs/database.md
+++ b/docs/database.md
@@ -562,9 +562,10 @@ no pro rata, staying a member through the break).
 its own window with no second table to look up: `starts_on`/`ends_on` both set
 means a fixed date range (e.g. "Semester 2 2026", 20 Jul – 16 Dec — everyone who
 buys it gets exactly those dates, full price regardless of when in it they
-join; there is no pro rata); `duration_days` set means a rolling window from
-payment (yearly insurance, 365 days); neither set means the plan ends with its
-session credits instead of a date (trial, casual class). Three CHECK
+join; there is no pro rata); `duration_days` set means a rolling window from the
+day the membership starts (yearly insurance, 365 days — today unless a manager
+names another day, see `docs/memberships.md`); neither set means the plan ends
+with its session credits instead of a date (trial, casual class). Three CHECK
 constraints enforce this is mutually exclusive
 (`membership_plans_dates_paired`, `membership_plans_dates_order`,
 `membership_plans_dates_xor_duration`). Each training period the club sells is
@@ -606,7 +607,11 @@ cancellation and deletion — it is a label, not the access gate (see the
 name/email come from their profile (via `user_id`). For a dated plan,
 `starts_at`/`ends_at` are the plan's own dates (`starts_on` at 00:00 and
 `ends_on` at 23:59:59, both Australia/Sydney), computed once at activation and
-never touched again. `sessions_remaining` is set at activation and spent by a
+never touched again. For a rolling plan (yearly insurance) they are the only
+window a manager can move afterwards: `setMembershipStart` and the agent API's
+`edit_invoice` (`starts_on`) write the pair together, keeping the length the
+membership already has, so a correction re-places the cover without resizing it
+(`docs/memberships.md`). `sessions_remaining` is set at activation and spent by a
 **check-in** — see `session_checkins` below, the only writer that decrements it.
 **RLS:** users read own; managers read/update all; direct member INSERT is
 revoked (all inserts go through the service-role `startMembership` /

--- a/docs/database.md
+++ b/docs/database.md
@@ -564,7 +564,8 @@ means a fixed date range (e.g. "Semester 2 2026", 20 Jul – 16 Dec — everyone
 buys it gets exactly those dates, full price regardless of when in it they
 join; there is no pro rata); `duration_days` set means a rolling window from the
 day the membership starts (yearly insurance, 365 days — today unless a manager
-names another day, see `docs/memberships.md`); neither set means the plan ends
+names another day, and counted as calendar days in the club's timezone rather
+than as fixed milliseconds, see `docs/memberships.md`); neither set means the plan ends
 with its session credits instead of a date (trial, casual class). Three CHECK
 constraints enforce this is mutually exclusive
 (`membership_plans_dates_paired`, `membership_plans_dates_order`,

--- a/docs/manager-agent-api.md
+++ b/docs/manager-agent-api.md
@@ -59,6 +59,13 @@ An "invoice" is a `memberships` row — its price/reference/status _are_ the inv
   person + plan reuses their existing unpaid invoice rather than creating a
   second one, so a retry is safe; the free trial is still once per person ever
   (`409 trial_already_used`), and an unknown plan code is `404 plan_not_found`.
+  `starts_on` (default today) says when the membership itself runs from, and is
+  the other half of a backfill — `send_email: false` keeps the invoice quiet,
+  `starts_on` puts the cover where it actually ran. Only a plan whose start is a
+  real choice takes one (`planStartIsChoosable`, so the yearly insurance);
+  anything else is `422 start_date_not_choosable` rather than a date silently
+  dropped. A bundled insurance invoice always runs from today: it is a second
+  plan being sold now, not part of the backfill.
 - `mark_invoice_paid` — record a payment against an invoice, for money that never
   touches the club account (cash at the door). Dispatches to
   `recordMembershipPayment`, the same writer bank reconciliation uses, so a
@@ -80,7 +87,13 @@ An "invoice" is a `memberships` row — its price/reference/status _are_ the inv
   a reconciled invoice's amount is a record of money that moved, and the
   status it belongs to is already protected. `notes` and `status` stay freely
   editable (a note claims nothing about money; expiring a membership that ran
-  its course is ordinary). There is **no audit table** — if the log is not
+  its course is ordinary), and so is `starts_on`: it corrects the day a
+  membership began, writing `starts_at` **and** `ends_at` through
+  `rescheduleMembershipStart` so the window keeps the length it was sold at and
+  moves as one. It is unguarded on purpose — dates say when somebody is covered,
+  not what they paid, and the correction is wanted most often precisely because
+  the money already landed. Same `422 start_date_not_choosable` on a plan with no
+  start date to set, refused before anything is written. There is **no audit table** — if the log is not
   enough for the club's bookkeeping, that is a schema change and a product
   decision, not something to add quietly. Setting `status` to `cancelled` or
   `expired` also reconciles the person's `member` role (`syncMemberRole`), so
@@ -253,7 +266,7 @@ wrapper never needs hand-syncing beyond the human-readable docs above.
 changes**, not only when an action is added or removed. A guard that starts
 refusing a call that used to succeed, or a new field in a response, is exactly
 what a client needs the version to tell it about. The version is pinned by a
-test so the bump is a deliberate edit, and the current value is `"13"`.
+test so the bump is a deliberate edit, and the current value is `"14"`.
 
 **Responses carry `version` too**, not just the manifest, so a client that
 cached the manifest at the start of a long run can notice a bump per call

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -228,11 +228,24 @@ year of cover sits where it ran, and nobody is invoiced for it now.
   club time too, so the date typed and the date shown are the same date wherever
   the manager is.
 - **Correcting it moves the window, it does not resize it**
-  (`rescheduleMembershipStart`): the end date shifts by exactly as much as the
-  start, so the cover keeps the length it was sold at. Recomputing the end from
-  the plan's current `duration_days` would make this the one back door through
-  which a later plan edit re-dates a membership somebody already bought, which
-  is exactly what "Buying a dated plan" says never happens.
+  (`rescheduleMembershipStart`): the cover keeps the number of days it was sold,
+  ending at the time of day it already ended. Recomputing the end from the plan's
+  current `duration_days` would make this the one back door through which a later
+  plan edit re-dates a membership somebody already bought, which is exactly what
+  "Buying a dated plan" says never happens. The start snaps to the beginning of
+  the chosen day while the end keeps its time, so the rounding can only add
+  hours, never take them away: correcting a record must not quietly shorten
+  cover somebody is relying on.
+- **A rolling plan's length is counted in club days, not in milliseconds.**
+  Sydney's clocks move twice a year, so `start + days x 86,400,000` lands an
+  hour out either side of a change, and an hour before midnight prints as the
+  previous day. A year of cover starting 5 April 2026 read as ending 4 April
+  2027: a day short, on screen, in the club's own words. Both
+  `planMembershipWindow` and `rescheduleMembershipStart` add calendar days at
+  the same time of day instead. **Leap years are a different question and are
+  deliberately not adjusted**: a plan that sells 365 days sells 365 days, and
+  one of them may be 29 February. If the club ever means "the same date next
+  year", that is a change to what the plan sells, not to this arithmetic.
 - **A start date is refused, never ignored**, on a plan that has none. A date
   quietly dropped leaves an invoice that looks backdated and is not, and nothing
   downstream would ever show the difference.

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -19,7 +19,8 @@ plan's **kind** decides how it ends, and the manager screen asks for it as a
 single plain-language question ("what kind of plan is this?"): a **training
 period** runs between fixed dates (everyone who buys it gets exactly those
 dates, regardless of when in it they joined), **yearly insurance** runs N days
-from the moment it is raised, and a **casual class** or the **free trial**
+from the day it starts (today unless a manager says otherwise, see "Setting the
+day yearly cover starts"), and a **casual class** or the **free trial**
 ends with its session credits instead of on a date. There is no self-serve
 sign-up: a membership only exists because someone bought one, because a manager
 raised it for them, or because a manager approved a waiver and the club's free
@@ -32,7 +33,7 @@ trial was assigned automatically.
 | `trial_2_session`  | `trial`     | Free trial                 | ends with its credits               | Two free classes, ever, no expiry.                              |
 | `casual_session`   | `session`   | Casual class or class pack | ends with its credits               | One class, tied to a session date.                              |
 | `2026-s2`, …       | `period`    | Training period            | fixed dates (`starts_on`/`ends_on`) | Unlimited classes for that training period.                     |
-| `insurance_yearly` | `insurance` | Yearly insurance           | rolling (`duration_days`)           | Club affiliation & insurance, 12 months from when it is raised. |
+| `insurance_yearly` | `insurance` | Yearly insurance           | rolling (`duration_days`)           | Club affiliation & insurance, 12 months from the day it starts. |
 
 A plan that ends with its credits carries a `starts_at` for the record, but
 **nothing reads it as a limit**: at check-in a credit balance covers any class
@@ -205,6 +206,59 @@ there is no re-sync.
 late joiner who would rather pay for only what is left is pointed at the
 casual per-class rate instead — that is what it is for.
 
+## Setting the day yearly cover starts
+
+**The yearly insurance is the one plan whose start date is a question**, and a
+manager answers it twice: once when the membership is raised, and again
+afterwards if the answer turns out to be wrong. Everywhere else the date is
+settled by something else and is not offered at all — a training period runs the
+plan's own dates and everyone who buys it shares them, and a casual class or the
+free trial ends with its classes rather than on a date, so there is no window to
+place. `planStartIsChoosable` is that rule, read off the plan's own window rather
+than its `kind`, and both the screen and the API ask it.
+
+**It defaults to today**, which is right for a member paying at the counter. It
+matters for the other case: a manager writing down cover that really began in
+February. Together with `send_email: false` that is a complete backfill — the
+year of cover sits where it ran, and nobody is invoiced for it now.
+
+- **The date is a day, and the club's day.** 00:00 Australia/Sydney on whatever
+  is picked, so cover starts at the beginning of that day and can cover a class
+  somebody trained at that morning. The screens read the stored instants back in
+  club time too, so the date typed and the date shown are the same date wherever
+  the manager is.
+- **Correcting it moves the window, it does not resize it**
+  (`rescheduleMembershipStart`): the end date shifts by exactly as much as the
+  start, so the cover keeps the length it was sold at. Recomputing the end from
+  the plan's current `duration_days` would make this the one back door through
+  which a later plan edit re-dates a membership somebody already bought, which
+  is exactly what "Buying a dated plan" says never happens.
+- **A start date is refused, never ignored**, on a plan that has none. A date
+  quietly dropped leaves an invoice that looks backdated and is not, and nothing
+  downstream would ever show the difference.
+- **Correcting is not gated on payment.** The dates say when somebody is
+  covered, not what they paid, so they sit outside the paid-invoice guard that
+  protects price, reference and method. The correction is wanted most often
+  precisely because the money already landed: settled in March, recorded in
+  April, dated from the day the manager got to it.
+- **A bundled insurance invoice always runs from today**, whatever start date
+  the plan beside it was given. It is a second plan being sold now, and dating
+  it from a backfilled training period would hand out a year of cover that has
+  already half run out. Backdating cover means raising the insurance on its own.
+- **Re-raising the same plan with a different start date moves the invoice it
+  reuses.** Raising a membership twice resolves back to the same unpaid row
+  rather than making a second one, and nothing re-runs the dating on that path —
+  so without this a manager who re-raised the insurance with the right date
+  would be told it worked while the window stayed where it was.
+
+A manager sets it in **Add a membership** on a person's page, and corrects it
+with **Start date** on the membership row (both manager screens, since they
+share `MembershipRowActions`). The correction is deliberately not a hard
+confirm: it changes a record rather than doing anything to anybody, sends
+nothing, and setting the date back undoes it. What it does show, before the
+save, is the end date moving with the start. The agent equivalents are
+`create_membership`'s and `edit_invoice`'s `starts_on`.
+
 ## Staying a member through the break
 
 Nothing in the app closes a membership automatically when its `ends_at`
@@ -258,6 +312,10 @@ nothing and re-sends nothing. There is no **Activate** button any more, because
 there is nothing left for it to do: a membership is authorised from the moment it
 is raised. **Reopen** is the narrow leftover, putting a cancelled or expired
 membership back into service, and it says nothing about money either way.
+
+**Start date** appears only on a membership whose start is a real choice (the
+yearly insurance) and corrects the day its cover began, moving the end with it.
+See "Setting the day yearly cover starts".
 
 **Cancel** works from any state and is the ordinary tidy-up for somebody who said
 they would join and never paid. It keeps the row, its dates and its credits;
@@ -317,6 +375,9 @@ often writing down an enrolment that already happened rather than selling one:
 - **Insurance is their call.** A member with no current cover cannot decline it
   (see "Buying a dated plan"); a manager can, because an enrolment that really
   did happen without cover is history, not a sale.
+- **Yearly cover can be dated.** A member buying for themselves gets cover from
+  now, because that is when they are buying it; a manager can say when it
+  actually began. See "Setting the day yearly cover starts".
 
 `send_email: false` records the invoice without telling anyone about it, so
 backfilling last semester does not invoice the whole club for it. The free trial
@@ -453,6 +514,7 @@ things to somebody about to transfer money.
 | `/manager/memberships`            | `list_invoices` / `edit_invoice`                 | See and correct invoices.                      |
 | both membership screens           | `edit_invoice` (`status`) / `delete_invoice`     | Cancel from any state; delete a junk invoice.  |
 | `/manager/users/<id>`             | `create_membership`                              | Raise a membership for a person.               |
+| both membership screens           | `edit_invoice` (`starts_on`)                     | Correct the day yearly cover began.            |
 | `/manager/users/<id>` (check-ins) | none                                             | Move a check-in to another membership.         |
 
 Moving a check-in is the one row with no agent equivalent: the API has no

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -250,6 +250,18 @@ year of cover sits where it ran, and nobody is invoiced for it now.
   rather than making a second one, and nothing re-runs the dating on that path —
   so without this a manager who re-raised the insurance with the right date
   would be told it worked while the window stayed where it was.
+- **That is also why the Add a membership panel sends the date only when a
+  manager actually sets one.** The field is prefilled with today because today
+  is nearly always right, but sending that prefill on every raise would drag a
+  deliberately backdated invoice forward the next time somebody opened the panel
+  to fix a student number. Untouched means "no opinion", which for a membership
+  that does not exist yet is today anyway. Correcting one that does exist is the
+  Start date button on its row, where the field opens on the date it holds.
+- **Two spellings of one instant are not a change.** Postgres returns a
+  timestamp as `+00:00` where this code writes `Z`, so both the reuse move and
+  the agent's edit diff compare by instant (`sameInstant`). Comparing the
+  strings would write a move that never happened into the invoice audit log,
+  which is the club's only record of who changed what.
 
 A manager sets it in **Add a membership** on a person's page, and corrects it
 with **Start date** on the membership row (both manager screens, since they

--- a/src/components/site/AddMembershipCard.test.tsx
+++ b/src/components/site/AddMembershipCard.test.tsx
@@ -103,6 +103,41 @@ describe("AddMembershipCard start date", () => {
     expect(createMembership.mock.calls[0][0].data.starts_on).toBe("2026-02-01");
   });
 
+  // Abandoning an edit is the other direction of the same guard. The panel is
+  // one long-lived instance on the person's page, so without a reset a manager
+  // who typed a date, thought better of it and closed would come back to a field
+  // still holding it — and the next raise, for an unrelated reason, would move
+  // an existing invoice's window to a date nobody meant this time.
+  it("forgets a date that was typed and then abandoned", async () => {
+    const user = await openWithPlan("insurance_yearly");
+    const field = await screen.findByLabelText(/start date/i);
+    await user.clear(field);
+    await user.type(field, "2020-01-01");
+    await user.click(screen.getByRole("button", { name: /^close$/i }));
+
+    await user.click(screen.getByRole("button", { name: /add a membership/i }));
+    await user.selectOptions(await screen.findByLabelText(/^plan$/i), "insurance_yearly");
+    expect(await screen.findByLabelText(/start date/i)).not.toHaveValue("2020-01-01");
+    await user.click(screen.getByRole("button", { name: /^add membership$/i }));
+    await waitFor(() => expect(createMembership).toHaveBeenCalled());
+    expect(createMembership.mock.calls[0][0].data.starts_on).toBeNull();
+  });
+
+  // A date chosen for one plan is not an answer about another.
+  it("forgets a date after switching plans and back", async () => {
+    const user = await openWithPlan("insurance_yearly");
+    const field = await screen.findByLabelText(/start date/i);
+    await user.clear(field);
+    await user.type(field, "2020-01-01");
+    const plan = screen.getByLabelText(/^plan$/i);
+    await user.selectOptions(plan, "2026-s2");
+    await user.selectOptions(plan, "insurance_yearly");
+    expect(await screen.findByLabelText(/start date/i)).not.toHaveValue("2020-01-01");
+    await user.click(screen.getByRole("button", { name: /^add membership$/i }));
+    await waitFor(() => expect(createMembership).toHaveBeenCalled());
+    expect(createMembership.mock.calls[0][0].data.starts_on).toBeNull();
+  });
+
   // Nothing to place on a casual class or a training period, and the server
   // refuses a date there — so a stale value must never ride along.
   it("sends no start date for a plan that has none, even after picking one", async () => {

--- a/src/components/site/AddMembershipCard.test.tsx
+++ b/src/components/site/AddMembershipCard.test.tsx
@@ -1,0 +1,118 @@
+// Raising a membership for somebody, and the one field on this panel that can
+// change a record that already exists.
+//
+// The Start date is prefilled with today, which is right almost every time and
+// is also what makes it dangerous: re-raising a plan resolves back to the
+// person's existing unpaid invoice and MOVES its window to the date sent. A
+// panel that always sent its prefill would drag a deliberately backdated year of
+// cover forward to today the next time a manager opened it to fix a student
+// number. So an untouched field means "no opinion", and these pin that.
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createMembership = vi.fn();
+const listAllMembershipPlans = vi.fn();
+
+vi.mock("@tanstack/react-start", () => ({
+  useServerFn: (fn: unknown) => fn,
+}));
+
+vi.mock("@/lib/membership.functions", () => ({
+  createMembership: (...args: unknown[]) => createMembership(...args),
+  listAllMembershipPlans: (...args: unknown[]) => listAllMembershipPlans(...args),
+}));
+
+const { AddMembershipCard } = await import("./AddMembershipCard");
+
+/** The yearly insurance: a fixed length, and where it sits is a real choice. */
+const YEARLY = {
+  id: "plan-insurance",
+  code: "insurance_yearly",
+  name: "Yearly insurance",
+  kind: "insurance",
+  public_price_cents: 5000,
+  student_price_cents: null,
+  is_active: true,
+  starts_on: null,
+  ends_on: null,
+  duration_days: 365,
+  session_credits: null,
+  sort_order: 1,
+};
+
+/** A training period: its dates belong to the plan, so there is nothing to set. */
+const PERIOD = {
+  ...YEARLY,
+  id: "plan-period",
+  code: "2026-s2",
+  name: "Semester 2 2026",
+  kind: "period",
+  starts_on: "2026-07-20",
+  ends_on: "2026-11-22",
+  duration_days: null,
+  sort_order: 0,
+};
+
+async function openWithPlan(code: string) {
+  const user = userEvent.setup();
+  listAllMembershipPlans.mockResolvedValue([PERIOD, YEARLY]);
+  createMembership.mockResolvedValue({ ok: true, reference: "LEE1234" });
+  render(<AddMembershipCard userId="user-1" onAdded={vi.fn().mockResolvedValue(1)} />);
+  await user.click(screen.getByRole("button", { name: /add a membership/i }));
+  const plan = await screen.findByLabelText(/^plan$/i);
+  await user.selectOptions(plan, code);
+  return user;
+}
+
+describe("AddMembershipCard start date", () => {
+  // Cleared per test: every case below reads the FIRST call, and a mock carried
+  // over from the previous test would answer with that test's payload.
+  beforeEach(() => {
+    createMembership.mockClear();
+    listAllMembershipPlans.mockClear();
+  });
+
+  it("asks for a start date on the yearly cover", async () => {
+    await openWithPlan("insurance_yearly");
+    expect(await screen.findByLabelText(/start date/i)).toBeInTheDocument();
+  });
+
+  it("does not ask on a plan whose dates belong to the plan", async () => {
+    await openWithPlan("2026-s2");
+    expect(screen.queryByLabelText(/start date/i)).not.toBeInTheDocument();
+  });
+
+  // The prefill is a suggestion, not an answer. Sending it would move an
+  // existing unpaid invoice's window with nothing on screen to say so.
+  it("sends no start date while the manager has not set one", async () => {
+    const user = await openWithPlan("insurance_yearly");
+    await screen.findByLabelText(/start date/i);
+    await user.click(screen.getByRole("button", { name: /^add membership$/i }));
+    await waitFor(() => expect(createMembership).toHaveBeenCalled());
+    expect(createMembership.mock.calls[0][0].data.starts_on).toBeNull();
+  });
+
+  it("sends the day the manager actually picked", async () => {
+    const user = await openWithPlan("insurance_yearly");
+    const field = await screen.findByLabelText(/start date/i);
+    await user.clear(field);
+    await user.type(field, "2026-02-01");
+    await user.click(screen.getByRole("button", { name: /^add membership$/i }));
+    await waitFor(() => expect(createMembership).toHaveBeenCalled());
+    expect(createMembership.mock.calls[0][0].data.starts_on).toBe("2026-02-01");
+  });
+
+  // Nothing to place on a casual class or a training period, and the server
+  // refuses a date there — so a stale value must never ride along.
+  it("sends no start date for a plan that has none, even after picking one", async () => {
+    const user = await openWithPlan("insurance_yearly");
+    const field = await screen.findByLabelText(/start date/i);
+    await user.clear(field);
+    await user.type(field, "2026-02-01");
+    await user.selectOptions(screen.getByLabelText(/^plan$/i), "2026-s2");
+    await user.click(screen.getByRole("button", { name: /^add membership$/i }));
+    await waitFor(() => expect(createMembership).toHaveBeenCalled());
+    expect(createMembership.mock.calls[0][0].data.starts_on).toBeNull();
+  });
+});

--- a/src/components/site/AddMembershipCard.tsx
+++ b/src/components/site/AddMembershipCard.tsx
@@ -50,7 +50,16 @@ export function AddMembershipCard({
   const [sessionDate, setSessionDate] = useState("");
   // Prefilled with today rather than left blank, because today is the answer
   // almost every time and an empty date field asks a question nobody had.
+  //
+  // `startsOnSet` is what makes the prefill safe. Re-raising the same plan
+  // resolves back to the existing unpaid invoice and MOVES its window to the
+  // date sent, so a card that always sent its default would silently drag a
+  // deliberately backdated invoice forward to today the next time a manager
+  // opened this panel to fix something else. Untouched means "no opinion", which
+  // for a new membership is today anyway. Correcting one that already exists is
+  // the Start date button on its row, where the field opens on the date it holds.
   const [startsOn, setStartsOn] = useState(() => clubToday());
+  const [startsOnSet, setStartsOnSet] = useState(false);
   const [includeInsurance, setIncludeInsurance] = useState(false);
   const [sendEmail, setSendEmail] = useState(true);
   const [open, setOpen] = useState(false);
@@ -89,7 +98,7 @@ export function AddMembershipCard({
             // Sent only where it means something: the server refuses a start
             // date on a plan that has none, and sending today's date for every
             // casual class would turn that guard into a wall.
-            starts_on: startIsChoosable ? startsOn || null : null,
+            starts_on: startIsChoosable && startsOnSet ? startsOn || null : null,
             include_insurance: includeInsurance,
             send_email: sendEmail,
           },
@@ -104,6 +113,7 @@ export function AddMembershipCard({
       setPlanCode("");
       setSessionDate("");
       setStartsOn(clubToday());
+      setStartsOnSet(false);
       await onAdded();
     }
   }
@@ -225,7 +235,10 @@ export function AddMembershipCard({
                 id="add-starts-on"
                 type="date"
                 value={startsOn}
-                onChange={(e) => setStartsOn(e.target.value)}
+                onChange={(e) => {
+                  setStartsOn(e.target.value);
+                  setStartsOnSet(true);
+                }}
               />
               <p className="text-xs text-muted-foreground">
                 Defaults to today. Set it back when you are writing down cover that really began

--- a/src/components/site/AddMembershipCard.tsx
+++ b/src/components/site/AddMembershipCard.tsx
@@ -27,7 +27,7 @@ import { Label } from "@/components/ui/label";
 import { SubmitStatus } from "@/components/site/SubmitStatus";
 import { INTAKE_SUBMIT } from "@/lib/submit-resilience";
 import { useResilientSubmit } from "@/hooks/use-resilient-submit";
-import { formatCents, sellablePlans } from "@/lib/validation";
+import { clubToday, formatCents, planStartIsChoosable, sellablePlans } from "@/lib/validation";
 import { createMembership, listAllMembershipPlans } from "@/lib/membership.functions";
 
 type Plan = Awaited<ReturnType<typeof listAllMembershipPlans>>[number];
@@ -48,6 +48,9 @@ export function AddMembershipCard({
   const [planCode, setPlanCode] = useState("");
   const [studentNumber, setStudentNumber] = useState("");
   const [sessionDate, setSessionDate] = useState("");
+  // Prefilled with today rather than left blank, because today is the answer
+  // almost every time and an empty date field asks a question nobody had.
+  const [startsOn, setStartsOn] = useState(() => clubToday());
   const [includeInsurance, setIncludeInsurance] = useState(false);
   const [sendEmail, setSendEmail] = useState(true);
   const [open, setOpen] = useState(false);
@@ -66,6 +69,11 @@ export function AddMembershipCard({
   const onSaleCodes = new Set(onSale.map((p) => p.code));
   const retired = (plans ?? []).filter((p) => !onSaleCodes.has(p.code));
   const chosen = (plans ?? []).find((p) => p.code === planCode) ?? null;
+  // The same question the server asks, asked of the plan's own window rather
+  // than of its kind, so the field appears exactly where a date would change
+  // something. A training period's dates belong to the plan, and a class-credit
+  // plan has no window to place.
+  const startIsChoosable = chosen ? planStartIsChoosable(chosen) : false;
 
   async function submit() {
     if (!planCode) return;
@@ -78,6 +86,10 @@ export function AddMembershipCard({
             plan_code: planCode,
             uts_student_number: studentNumber.trim() || null,
             session_date: sessionDate || null,
+            // Sent only where it means something: the server refuses a start
+            // date on a plan that has none, and sending today's date for every
+            // casual class would turn that guard into a wall.
+            starts_on: startIsChoosable ? startsOn || null : null,
             include_insurance: includeInsurance,
             send_email: sendEmail,
           },
@@ -91,6 +103,7 @@ export function AddMembershipCard({
       // (a training period and a casual class) is a normal afternoon.
       setPlanCode("");
       setSessionDate("");
+      setStartsOn(clubToday());
       await onAdded();
     }
   }
@@ -198,6 +211,25 @@ export function AddMembershipCard({
               />
               <p className="text-xs text-muted-foreground">
                 Defaults to today, so each drop-in payment reconciles to its own class.
+              </p>
+            </div>
+          )}
+
+          {/* Only a plan that runs for a fixed number of days has a start to
+              place: the yearly insurance. Everyone who buys a training period
+              gets its dates, and a class-credit plan ends with its classes. */}
+          {startIsChoosable && (
+            <div className="space-y-2">
+              <Label htmlFor="add-starts-on">Start date</Label>
+              <Input
+                id="add-starts-on"
+                type="date"
+                value={startsOn}
+                onChange={(e) => setStartsOn(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Defaults to today. Set it back when you are writing down cover that really began
+                earlier; it runs {chosen?.duration_days ?? 365} days from whatever you pick.
               </p>
             </div>
           )}

--- a/src/components/site/AddMembershipCard.tsx
+++ b/src/components/site/AddMembershipCard.tsx
@@ -60,6 +60,17 @@ export function AddMembershipCard({
   // the Start date button on its row, where the field opens on the date it holds.
   const [startsOn, setStartsOn] = useState(() => clubToday());
   const [startsOnSet, setStartsOnSet] = useState(false);
+
+  // Abandoning an edit has to put the date back to "no opinion" too, or the
+  // guard only holds in one direction: a manager who typed February, thought
+  // better of it and closed the panel would come back to a field still showing
+  // February and still marked as set, and the next unrelated raise would carry
+  // it. Same for switching plans — a date chosen for one plan is not an answer
+  // about another.
+  function forgetStartDate() {
+    setStartsOn(clubToday());
+    setStartsOnSet(false);
+  }
   const [includeInsurance, setIncludeInsurance] = useState(false);
   const [sendEmail, setSendEmail] = useState(true);
   const [open, setOpen] = useState(false);
@@ -112,8 +123,7 @@ export function AddMembershipCard({
       // (a training period and a casual class) is a normal afternoon.
       setPlanCode("");
       setSessionDate("");
-      setStartsOn(clubToday());
-      setStartsOnSet(false);
+      forgetStartDate();
       await onAdded();
     }
   }
@@ -136,7 +146,14 @@ export function AddMembershipCard({
             a price stays pending until you press Activate; a free plan starts straight away.
           </p>
         </div>
-        <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            setOpen(false);
+            forgetStartDate();
+          }}
+        >
           Close
         </Button>
       </div>
@@ -171,7 +188,10 @@ export function AddMembershipCard({
               id="add-plan"
               className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm"
               value={planCode}
-              onChange={(e) => setPlanCode(e.target.value)}
+              onChange={(e) => {
+                setPlanCode(e.target.value);
+                forgetStartDate();
+              }}
             >
               <option value="">Choose a plan...</option>
               {onSale.length > 0 && (

--- a/src/components/site/MembershipRowActions.test.tsx
+++ b/src/components/site/MembershipRowActions.test.tsx
@@ -221,6 +221,17 @@ describe("MembershipRowActions", () => {
     expect(setMembershipStart).not.toHaveBeenCalled();
   });
 
+  // A Save button that silently does nothing is a dead end. Clearing the field
+  // to retype is the ordinary way to reach that state.
+  it("says why Save is unavailable when the date is cleared", async () => {
+    const user = userEvent.setup();
+    renderRow(COVER);
+    await user.click(screen.getByRole("button", { name: /start date/i }));
+    await user.clear(await screen.findByLabelText(/start date/i));
+    expect(screen.getByRole("button", { name: /save start date/i })).toBeDisabled();
+    expect(screen.getByText(/pick a day to save/i)).toBeInTheDocument();
+  });
+
   it("saves the day, and lets the server place it", async () => {
     const user = userEvent.setup();
     setMembershipStart.mockResolvedValueOnce({ ok: true });

--- a/src/components/site/MembershipRowActions.test.tsx
+++ b/src/components/site/MembershipRowActions.test.tsx
@@ -13,6 +13,7 @@ import { describe, expect, it, vi } from "vitest";
 const setMembershipStatus = vi.fn();
 const deleteMembership = vi.fn();
 const markMembershipPaid = vi.fn();
+const setMembershipStart = vi.fn();
 
 vi.mock("@tanstack/react-start", () => ({
   useServerFn: (fn: unknown) => fn,
@@ -22,6 +23,7 @@ vi.mock("@/lib/membership.functions", () => ({
   setMembershipStatus: (...args: unknown[]) => setMembershipStatus(...args),
   deleteMembership: (...args: unknown[]) => deleteMembership(...args),
   markMembershipPaid: (...args: unknown[]) => markMembershipPaid(...args),
+  setMembershipStart: (...args: unknown[]) => setMembershipStart(...args),
 }));
 
 const { MembershipRowActions } = await import("./MembershipRowActions");
@@ -35,6 +37,19 @@ const JUNK: Row = {
   price_cents: 44500,
   checkin_count: 0,
   plan_name: "Semester 2 2026",
+  starts_at: "2026-07-19T14:00:00.000Z",
+  ends_at: "2026-11-22T12:59:59.000Z",
+  // A training period: its dates belong to the plan, so there is no start date
+  // on this row to move.
+  plan_window: { starts_on: "2026-07-20", ends_on: "2026-11-22", duration_days: null },
+};
+
+/** The yearly insurance: fixed length, and where it sits is a real choice. */
+const COVER: Partial<Row> = {
+  plan_name: "Yearly insurance",
+  starts_at: "2026-05-01T00:00:00.000Z",
+  ends_at: "2027-05-01T00:00:00.000Z",
+  plan_window: { starts_on: null, ends_on: null, duration_days: 365 },
 };
 
 function renderRow(overrides: Partial<Row> = {}, onChanged = vi.fn().mockResolvedValue(1)) {
@@ -165,6 +180,78 @@ describe("MembershipRowActions", () => {
       }),
     );
     expect(onChanged).toHaveBeenCalled();
+  });
+
+  // ---- The start date ----
+  //
+  // Offered only where it means something, and it shows the end date moving
+  // with it: the one thing a manager could reasonably fear here is silently
+  // buying somebody a longer or shorter year.
+  it("offers a start date on the yearly cover and not on a training period", () => {
+    renderRow(COVER);
+    expect(screen.getByRole("button", { name: /start date/i })).toBeEnabled();
+  });
+
+  it("does not offer one on a plan whose dates belong to the plan", () => {
+    renderRow();
+    expect(screen.queryByRole("button", { name: /start date/i })).not.toBeInTheDocument();
+  });
+
+  it("does not offer one when the plan could not be read", () => {
+    renderRow({ ...COVER, plan_window: null });
+    expect(screen.queryByRole("button", { name: /start date/i })).not.toBeInTheDocument();
+  });
+
+  it("opens on the day it already starts, not on today", async () => {
+    const user = userEvent.setup();
+    renderRow(COVER);
+    await user.click(screen.getByRole("button", { name: /start date/i }));
+    expect(await screen.findByLabelText(/start date/i)).toHaveValue("2026-05-01");
+  });
+
+  it("shows the end date moving with the start before anything is saved", async () => {
+    const user = userEvent.setup();
+    renderRow(COVER);
+    await user.click(screen.getByRole("button", { name: /start date/i }));
+    const field = await screen.findByLabelText(/start date/i);
+    await user.clear(field);
+    await user.type(field, "2026-02-01");
+    // Still 365 days, moved: 1 Feb 2026 to 1 Feb 2027, read in club time.
+    expect(await screen.findByText(/Runs 01\/02\/2026 to 01\/02\/2027/)).toBeInTheDocument();
+    expect(setMembershipStart).not.toHaveBeenCalled();
+  });
+
+  it("saves the day, and lets the server place it", async () => {
+    const user = userEvent.setup();
+    setMembershipStart.mockResolvedValueOnce({ ok: true });
+    const { onChanged } = renderRow(COVER);
+
+    await user.click(screen.getByRole("button", { name: /start date/i }));
+    const field = await screen.findByLabelText(/start date/i);
+    await user.clear(field);
+    await user.type(field, "2026-02-01");
+    await user.click(screen.getByRole("button", { name: /save start date/i }));
+
+    await waitFor(() =>
+      expect(setMembershipStart).toHaveBeenCalledWith({
+        data: { id: "mem-1", starts_on: "2026-02-01" },
+      }),
+    );
+    expect(onChanged).toHaveBeenCalled();
+  });
+
+  // Same rule as every other write on this row: a failure stays on screen with
+  // the button still in it, never a toast that fades.
+  it("keeps a failed start-date save on screen with a way forward", async () => {
+    const user = userEvent.setup();
+    setMembershipStart.mockRejectedValueOnce(new Error("Yearly insurance has no start date"));
+    renderRow(COVER);
+
+    await user.click(screen.getByRole("button", { name: /start date/i }));
+    await user.click(screen.getByRole("button", { name: /save start date/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/no start date/i);
+    expect(screen.getByRole("button", { name: /try again/i })).toBeEnabled();
   });
 
   it("keeps the failure on screen with the button still there", async () => {

--- a/src/components/site/MembershipRowActions.tsx
+++ b/src/components/site/MembershipRowActions.tsx
@@ -304,9 +304,12 @@ export function MembershipRowActions({
             <p className="text-sm text-muted-foreground">
               {preview
                 ? `Runs ${clubDayLabel(preview.starts_at)} to ${clubDayLabel(preview.ends_at)}.`
-                : `Currently ${clubDayLabel(membership.starts_at)} to ${clubDayLabel(
-                    membership.ends_at,
-                  )}.`}
+                : // Save is disabled while there is no day to save. Saying so
+                  // beats a button that silently does nothing when somebody
+                  // clears the field to retype it.
+                  `Pick a day to save. It currently runs ${clubDayLabel(
+                    membership.starts_at,
+                  )} to ${clubDayLabel(membership.ends_at)}.`}
             </p>
           </div>
           {dating?.error && (
@@ -321,6 +324,13 @@ export function MembershipRowActions({
             <Button variant="outline" disabled={dating?.busy} onClick={() => setDating(null)}>
               Go back
             </Button>
+            {/* The spinner is the only thing that changes while this saves, and
+                a spinner says nothing to a screen reader. */}
+            {dating?.busy && (
+              <span className="sr-only" role="status">
+                Saving the start date...
+              </span>
+            )}
             <Button disabled={dating?.busy || !preview} onClick={() => void saveStart()}>
               {dating?.busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {dating?.error ? "Try again" : "Save start date"}

--- a/src/components/site/MembershipRowActions.tsx
+++ b/src/components/site/MembershipRowActions.tsx
@@ -13,6 +13,13 @@
 // cancelled or expired membership back into service — and it says nothing about
 // money.
 //
+// Start date is the odd one out and is deliberately not a confirm: it corrects a
+// record rather than doing anything to anybody, nothing is sent, and setting the
+// date back undoes it. It only appears where the start is a real choice
+// (`planStartIsChoosable`, so the yearly insurance), and it shows the end date
+// moving with it, because the one thing a manager could reasonably fear here is
+// silently buying somebody a longer or shorter year.
+//
 // The confirms say what will happen in words before the click, because both
 // outward-facing actions here are ones somebody feels: marking paid emails a
 // receipt and makes the row permanent, deleting cannot be undone. A failure
@@ -20,8 +27,18 @@
 // that auto-dismisses on a phone.
 import { useState } from "react";
 import { useServerFn } from "@tanstack/react-start";
-import { Check, Loader2, RotateCcw, Trash2, Undo2 } from "lucide-react";
+import { CalendarDays, Check, Loader2, RotateCcw, Trash2, Undo2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -35,14 +52,20 @@ import {
 import {
   deleteMembership,
   markMembershipPaid,
+  setMembershipStart,
   setMembershipStatus,
 } from "@/lib/membership.functions";
 import {
+  clubToday,
   formatCents,
   isUnpaid,
   membershipDeleteMessage,
+  planStartIsChoosable,
+  rescheduleMembershipStart,
   whyMembershipCannotBeDeleted,
 } from "@/lib/validation";
+import type { PlanWindow } from "@/lib/validation";
+import { formatDateOnly } from "@/lib/dates";
 
 /** The fields both screens' membership rows carry, and all the guard needs. */
 export type MembershipActionRow = {
@@ -54,6 +77,15 @@ export type MembershipActionRow = {
   price_cents: number;
   checkin_count: number;
   plan_name: string | null;
+  /** When this membership runs from, and to. Both move together, or neither. */
+  starts_at: string | null;
+  ends_at: string | null;
+  /**
+   * The plan's own window, not a derived flag: whether the start date can be
+   * moved is one rule (`planStartIsChoosable`), asked here of the same three
+   * values the server asks it of.
+   */
+  plan_window: PlanWindow | null;
 };
 
 type Pending = {
@@ -61,6 +93,14 @@ type Pending = {
   error: string | null;
   busy: boolean;
 };
+
+/** The start-date form while it is open: what has been typed, and how it went. */
+type Dating = { startsOn: string; error: string | null; busy: boolean };
+
+/** An instant as the day it falls on where the club is, or "no end date". */
+function clubDayLabel(iso: string | null): string {
+  return iso ? formatDateOnly(clubToday(new Date(iso))) : "no end date";
+}
 
 export function MembershipRowActions({
   membership,
@@ -73,7 +113,9 @@ export function MembershipRowActions({
   const setStatus = useServerFn(setMembershipStatus);
   const remove = useServerFn(deleteMembership);
   const markPaid = useServerFn(markMembershipPaid);
+  const setStart = useServerFn(setMembershipStart);
   const [pending, setPending] = useState<Pending | null>(null);
+  const [dating, setDating] = useState<Dating | null>(null);
 
   // Computed here from the same pure rule the server enforces, so the button and
   // the refusal can never disagree about why. The server still re-checks: this
@@ -84,6 +126,36 @@ export function MembershipRowActions({
   // `isUnpaid` already knows a free membership owes nothing.
   const owesMoney = isUnpaid(membership);
   const isClosed = membership.status === "cancelled" || membership.status === "expired";
+
+  // Only a plan whose length is fixed but whose position is not — the yearly
+  // insurance. A membership whose plan could not be read shows no button rather
+  // than a button that will be refused.
+  const canDate = membership.plan_window ? planStartIsChoosable(membership.plan_window) : false;
+  // What the row would end up holding, worked out with the rule the server uses,
+  // so the preview and the write cannot disagree about the new end date.
+  const preview =
+    dating?.startsOn && /^\d{4}-\d{2}-\d{2}$/.test(dating.startsOn)
+      ? rescheduleMembershipStart(membership, dating.startsOn)
+      : null;
+
+  async function saveStart() {
+    if (!dating) return;
+    setDating({ ...dating, error: null, busy: true });
+    try {
+      await setStart({ data: { id: membership.id, starts_on: dating.startsOn } });
+    } catch (e) {
+      setDating({
+        ...dating,
+        busy: false,
+        error: e instanceof Error ? e.message : "That did not go through. Try again.",
+      });
+      return;
+    }
+    // Same reasoning as `run` below: the write has landed, so a failed refresh is
+    // a stale table rather than a failed correction.
+    await onChanged().catch(() => {});
+    setDating(null);
+  }
 
   async function run(kind: Pending["kind"]) {
     setPending({ kind, error: null, busy: true });
@@ -157,6 +229,26 @@ export function MembershipRowActions({
             <RotateCcw className="mr-1 h-3 w-3" /> Reopen
           </Button>
         )}
+        {canDate && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() =>
+              setDating({
+                // Prefilled with the day it currently starts, so the field opens
+                // on the answer it already holds rather than on today, which
+                // would invite a manager to overwrite a date that was right.
+                startsOn: membership.starts_at
+                  ? clubToday(new Date(membership.starts_at))
+                  : clubToday(),
+                error: null,
+                busy: false,
+              })
+            }
+          >
+            <CalendarDays className="mr-1 h-3 w-3" /> Start date
+          </Button>
+        )}
         {membership.status !== "cancelled" && (
           <Button
             size="sm"
@@ -180,6 +272,62 @@ export function MembershipRowActions({
         </Button>
         {!canDelete && <span className="sr-only">{membershipDeleteMessage(blockers)}</span>}
       </div>
+
+      <Dialog
+        open={Boolean(dating)}
+        onOpenChange={(open) => {
+          if (!open && !dating?.busy) setDating(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>When does {membership.plan_name ?? "this membership"} start?</DialogTitle>
+            <DialogDescription>
+              Set this back to the day the cover really began. It runs for the same length either
+              way, so the end date moves with it, and nothing is emailed.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor={`start-date-${membership.id}`}>Start date</Label>
+            <Input
+              id={`start-date-${membership.id}`}
+              type="date"
+              value={dating?.startsOn ?? ""}
+              onChange={(e) =>
+                setDating((d) => (d ? { ...d, startsOn: e.target.value, error: null } : d))
+              }
+            />
+            {/* Read in the CLUB's timezone, not the reader's. A window stored as
+                13:00 UTC is 1 February in Sydney and 31 January in London, and
+                the date somebody just typed changing under them as they read it
+                back is the one thing this line must never do. */}
+            <p className="text-sm text-muted-foreground">
+              {preview
+                ? `Runs ${clubDayLabel(preview.starts_at)} to ${clubDayLabel(preview.ends_at)}.`
+                : `Currently ${clubDayLabel(membership.starts_at)} to ${clubDayLabel(
+                    membership.ends_at,
+                  )}.`}
+            </p>
+          </div>
+          {dating?.error && (
+            <p
+              role="alert"
+              className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            >
+              {dating.error}
+            </p>
+          )}
+          <DialogFooter>
+            <Button variant="outline" disabled={dating?.busy} onClick={() => setDating(null)}>
+              Go back
+            </Button>
+            <Button disabled={dating?.busy || !preview} onClick={() => void saveStart()}>
+              {dating?.busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {dating?.error ? "Try again" : "Save start date"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <AlertDialog
         open={Boolean(pending)}

--- a/src/lib/club-user.functions.ts
+++ b/src/lib/club-user.functions.ts
@@ -73,7 +73,7 @@ export const getClubUser = createServerFn({ method: "POST" })
         .eq("user_id", data.userId)
         .order("created_at", { ascending: false })
         .limit(MEMBERSHIPS_LIMIT),
-      admin.from("membership_plans").select("id, name, kind"),
+      admin.from("membership_plans").select("id, name, kind, starts_on, ends_on, duration_days"),
       admin.from("user_roles").select("user_id, role").eq("user_id", data.userId),
       userEmails(admin, [data.userId]),
       admin
@@ -304,6 +304,19 @@ export const getClubUser = createServerFn({ method: "POST" })
         // What the status is called depends on it: a plan sold as a number of
         // classes is "used up" when it ends, not "expired".
         kind: planById.get(m.plan_id)?.kind ?? null,
+        // The plan's own window, so the row can ask whether this membership's
+        // start date is a real choice with the same rule the server enforces
+        // (`planStartIsChoosable`) rather than re-deriving it from `kind`.
+        plan_window: (() => {
+          const plan = planById.get(m.plan_id);
+          return plan
+            ? {
+                starts_on: plan.starts_on,
+                ends_on: plan.ends_on,
+                duration_days: plan.duration_days,
+              }
+            : null;
+        })(),
         status: m.status,
         price_cents: m.price_cents,
         payment_reference: m.payment_reference,

--- a/src/lib/manager-agent.test.ts
+++ b/src/lib/manager-agent.test.ts
@@ -219,6 +219,23 @@ describe("buildInvoicePatch", () => {
     expect("notes" in untouched).toBe(false);
   });
 
+  // A start date is named as a DAY and placed by the plan. The caller never
+  // hands over instants, so the two columns cannot be pulled apart into a
+  // window no plan sells.
+  it("writes the resolved window, and never takes starts_at/ends_at from input", () => {
+    const patch = buildInvoicePatch({ id, starts_on: "2026-02-01" });
+    expect(patch).toEqual({});
+    const withWindow = buildInvoicePatch(
+      { id, starts_on: "2026-02-01" },
+      { starts_at: "2026-01-31T13:00:00.000Z", ends_at: "2027-01-31T13:00:00.000Z" },
+    );
+    expect(withWindow).toEqual({
+      starts_at: "2026-01-31T13:00:00.000Z",
+      ends_at: "2027-01-31T13:00:00.000Z",
+    });
+    expect("starts_on" in withWindow).toBe(false);
+  });
+
   it("only ever writes whitelisted columns", () => {
     const patch = buildInvoicePatch({
       id,
@@ -278,6 +295,15 @@ describe("reconciledEditBlockers", () => {
     // and the one status with consequences ("active") is refused by the schema.
     expect(RECONCILED_GUARDED_FIELDS).not.toContain("status");
     expect(RECONCILED_GUARDED_FIELDS).not.toContain("notes");
+  });
+
+  // The correction is wanted most often BECAUSE the money already landed: a
+  // year of cover settled in March and recorded in April. Guarding the dates
+  // would refuse the edit they exist for.
+  it("leaves the cover dates alone on a paid invoice: they are not a money record", () => {
+    expect(reconciledEditBlockers(paid, ["starts_at", "ends_at"], undefined)).toEqual([]);
+    expect(RECONCILED_GUARDED_FIELDS).not.toContain("starts_at");
+    expect(RECONCILED_GUARDED_FIELDS).not.toContain("ends_at");
   });
 
   it("does not block anything on an unpaid invoice, or when the caller confirms", () => {
@@ -452,7 +478,7 @@ describe("AGENT_MANIFEST", () => {
   // Round 2 of the dev probes noted that the manifest still said "1" after the
   // behaviour changed, leaving a client no way to tell the generations apart.
   it("advertises a version a client can branch on", () => {
-    expect(AGENT_MANIFEST.version).toBe("13");
+    expect(AGENT_MANIFEST.version).toBe("14");
   });
 
   // The changelog is only worth having if it cannot fall behind the version it

--- a/src/lib/manager-agent.ts
+++ b/src/lib/manager-agent.ts
@@ -141,7 +141,7 @@ export const AGENT_MANIFEST: {
   service: "uts-jitsu-manager-agent",
   // Bumped when the behaviour a client can rely on changes, not just the action
   // list. See `changes` for what each version actually moved.
-  version: "13",
+  version: "14",
   // What changed in each version, newest first.
   //
   // A bare version number tells a client THAT something moved, never what — and
@@ -154,6 +154,19 @@ export const AGENT_MANIFEST: {
   // moves between versions is the behaviour INSIDE an action — a new refusal, a
   // new response field — which is what these notes name.
   changes: [
+    {
+      version: "14",
+      // Additive: one new optional param on each of two actions, and two fields
+      // that were always in the response are now editable. Nothing that worked
+      // before fails or means anything different.
+      breaking: false,
+      notes: [
+        "create_membership takes starts_on: the day the membership itself runs from, defaulting to today. Only a plan that runs for a fixed number of days takes one, which today means the yearly insurance, so it is what backdating somebody's cover to when it really began needs. Sending it for a training period (whose dates belong to the plan and are shared by everyone who buys it) or for a class-credit plan (which ends with its classes, not on a date) is refused with 422 start_date_not_choosable rather than ignored.",
+        "edit_invoice takes starts_on too, for correcting that day afterwards. It writes starts_at AND ends_at: the window keeps the length it was sold at and moves as one, so a correction can never lengthen or shorten somebody's cover. Both appear in `changed` and `previous`, and in the audit log, like any other edit. Same 422 start_date_not_choosable on a plan with no start date to set.",
+        "starts_at / ends_at are deliberately NOT guarded by confirm_paid_edit. They record when somebody is covered, not what they paid, and the correction is most often wanted precisely because the money has already landed.",
+        "Re-raising the same person and plan with create_membership still reuses their existing unpaid invoice, and now moves that invoice's window when the starts_on you send differs from the one it holds.",
+      ],
+    },
     {
       version: "13",
       // Additive: a new response field and a new piece of markdown syntax.
@@ -380,10 +393,16 @@ export const AGENT_MANIFEST: {
             "YYYY-MM-DD, for a casual class only, so the payment reconciles to that session. Defaults to today; ignored by every other plan kind.",
         },
         {
+          name: "starts_on",
+          required: false,
+          description:
+            "YYYY-MM-DD, the day the membership runs from. Defaults to today. Only a plan that runs for a fixed number of days takes one (the yearly insurance): its length is fixed but where it sits is a real choice, which is what backdating cover to when it actually began needs. The end date follows from the plan's duration. Refused with 422 start_date_not_choosable on a training period (its dates belong to the plan and everyone who buys it shares them) or a class-credit plan (it ends with its classes, not on a date).",
+        },
+        {
           name: "include_insurance",
           required: false,
           description:
-            "Bundle yearly insurance as a second invoice on the same payment reference (default false). A member buying for themselves cannot decline this without current cover; a manager can, because recording an enrolment that really happened without cover is history, not a sale.",
+            "Bundle yearly insurance as a second invoice on the same payment reference (default false). A member buying for themselves cannot decline this without current cover; a manager can, because recording an enrolment that really happened without cover is history, not a sale. A bundled insurance invoice always runs from today, never from starts_on: it is a second plan being sold now.",
         },
         {
           name: "send_email",
@@ -417,6 +436,12 @@ export const AGENT_MANIFEST: {
           description: "bank_transfer | stripe | manual.",
         },
         { name: "status", required: false, description: "pending | cancelled | expired." },
+        {
+          name: "starts_on",
+          required: false,
+          description:
+            "YYYY-MM-DD, the day this membership runs from. Writes starts_at AND ends_at: the window keeps the length it was sold at and moves as one, so a correction cannot lengthen or shorten the cover. Only on a plan whose start is a real choice (the yearly insurance) - anything else is refused with 422 start_date_not_choosable. Not guarded by confirm_paid_edit: dates say when somebody is covered, not what they paid.",
+        },
         {
           name: "confirm_paid_edit",
           required: false,
@@ -940,30 +965,50 @@ export function bearerToken(header: string | null): string | null {
   return m ? m[1].trim() : null;
 }
 
-/** The membership columns `edit_invoice` may write (documented in the manifest). */
+/**
+ * The membership columns `edit_invoice` may write (documented in the manifest).
+ *
+ * `starts_at` / `ends_at` are here for the diff and the audit trail, not as
+ * fields a caller names: the API takes a `starts_on` DAY and resolves the pair
+ * itself, so the two always move together and a window can never be hand-built
+ * into a shape no plan sells.
+ */
 export const INVOICE_EDITABLE_FIELDS = [
   "price_cents",
   "notes",
   "payment_reference",
   "payment_method",
   "status",
+  "starts_at",
+  "ends_at",
 ] as const;
 
 /**
  * Turn a validated edit_invoice input into a DB patch containing only the fields
  * the caller actually supplied (so unspecified columns are never overwritten).
  *
- * Takes a Partial rather than a whole `EditInvoiceInput`: this reads the five
+ * Takes a Partial rather than a whole `EditInvoiceInput`: this reads the named
  * editable fields and nothing else, so requiring `id` or the `confirm_paid_edit`
  * flag in the signature would only be asking callers for values it ignores.
+ *
+ * `window` is the resolved answer to the input's `starts_on` — the caller works
+ * it out from the plan (which decides whether that plan has a start date to set
+ * at all) and hands the pair in, so this stays a pure field-by-field copy.
  */
-export function buildInvoicePatch(input: Partial<EditInvoiceInput>): Partial<MembershipRow> {
+export function buildInvoicePatch(
+  input: Partial<EditInvoiceInput>,
+  window?: { starts_at: string; ends_at: string | null },
+): Partial<MembershipRow> {
   const patch: Partial<MembershipRow> = {};
   if (input.price_cents !== undefined) patch.price_cents = input.price_cents;
   if (input.notes !== undefined) patch.notes = input.notes;
   if (input.payment_reference !== undefined) patch.payment_reference = input.payment_reference;
   if (input.payment_method !== undefined) patch.payment_method = input.payment_method;
   if (input.status !== undefined) patch.status = input.status;
+  if (window) {
+    patch.starts_at = window.starts_at;
+    patch.ends_at = window.ends_at;
+  }
   return patch;
 }
 
@@ -980,6 +1025,12 @@ export type InvoiceEditableField = (typeof INVOICE_EDITABLE_FIELDS)[number];
  * ran its course is an ordinary lifecycle move, not a rewrite of the payment,
  * and the one status that has consequences ("active") is already refused by the
  * schema. `notes` is free text about the invoice, never a claim about money.
+ *
+ * Nor are `starts_at` / `ends_at`. They say when somebody is covered, not what
+ * they paid, and the case for correcting them is at its strongest AFTER the
+ * money landed: a year of insurance settled in March, recorded in April, and
+ * dated from the day the manager got to it. Guarding them would refuse the very
+ * edit they exist for.
  */
 export const RECONCILED_GUARDED_FIELDS: readonly InvoiceEditableField[] = [
   "price_cents",

--- a/src/lib/manager-agent.ts
+++ b/src/lib/manager-agent.ts
@@ -7,7 +7,7 @@
 //
 // Keep AGENT_MANIFEST, managerAgentActions (validation.ts), the route dispatch,
 // and the skill (.claude/skills/uts-manager-agent/) in lockstep. See docs/manager-agent-api.md.
-import { formatCents } from "@/lib/validation";
+import { formatCents, sameInstant } from "@/lib/validation";
 import type { EditInvoiceInput } from "@/lib/validation";
 import type { MembershipPlanRow, MembershipRow } from "@/lib/membership-types";
 import { versionLabel } from "@/lib/waiver-template-editor";
@@ -1038,6 +1038,17 @@ export const RECONCILED_GUARDED_FIELDS: readonly InvoiceEditableField[] = [
   "payment_method",
 ];
 
+/**
+ * The editable columns holding a timestamp, where one instant has more than one
+ * spelling. See `sameInstant`.
+ */
+const INSTANT_FIELDS = new Set<InvoiceEditableField>(["starts_at", "ends_at"]);
+
+/** A field value as a timestamp, or null when it is not a string to parse. */
+function asInstant(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
 /** What an edit would actually change, and what those fields hold right now. */
 export type InvoiceEditDiff = {
   /** Editable fields whose value would genuinely move (a no-op edit is empty). */
@@ -1062,6 +1073,12 @@ export function diffInvoicePatch(
     const before = existing[field] ?? null;
     const after = patch[field] ?? null;
     if (before === after) continue;
+    // The two date columns are the only ones where equal values can be spelled
+    // differently: the row was read back from Postgres as `+00:00` and the patch
+    // was written by JS as `Z`. A string compare would call every resubmitted
+    // start date a change, putting a move that never happened into the club's
+    // only record of who edited an invoice.
+    if (INSTANT_FIELDS.has(field) && sameInstant(asInstant(before), asInstant(after))) continue;
     changed.push(field);
     previous[field] = before;
   }

--- a/src/lib/membership.functions.test.ts
+++ b/src/lib/membership.functions.test.ts
@@ -1047,8 +1047,8 @@ describe("enrolMember with a start date", () => {
         status: "active",
         paid_at: null,
         price_cents: 0,
-        starts_at: "2026-05-01T00:00:00.000Z",
-        ends_at: "2027-05-01T00:00:00.000Z",
+        starts_at: "2026-05-01T00:00:00+00:00",
+        ends_at: "2027-05-01T00:00:00+00:00",
       }),
     );
     await enrolFrom(fake, INSURANCE_PLAN, "2026-02-01");
@@ -1060,6 +1060,9 @@ describe("enrolMember with a start date", () => {
     });
   });
 
+  // Spelled as PostgREST returns a TIMESTAMPTZ, not as JS writes one: the same
+  // instant in two spellings is exactly what a string compare gets wrong, and a
+  // fixture in the write format would pass with the guard deleted.
   it("writes nothing when the reused invoice already starts on that day", async () => {
     const fake = fakeEnrolAdmin(
       ok({
@@ -1068,8 +1071,8 @@ describe("enrolMember with a start date", () => {
         status: "active",
         paid_at: null,
         price_cents: 0,
-        starts_at: "2026-01-31T13:00:00.000Z",
-        ends_at: "2027-01-31T13:00:00.000Z",
+        starts_at: "2026-01-31T13:00:00+00:00",
+        ends_at: "2027-01-31T13:00:00+00:00",
       }),
     );
     await enrolFrom(fake, INSURANCE_PLAN, "2026-02-01");

--- a/src/lib/membership.functions.test.ts
+++ b/src/lib/membership.functions.test.ts
@@ -1047,8 +1047,10 @@ describe("enrolMember with a start date", () => {
         status: "active",
         paid_at: null,
         price_cents: 0,
-        starts_at: "2026-05-01T00:00:00+00:00",
-        ends_at: "2027-05-01T00:00:00+00:00",
+        // Club midnight to club midnight, spelled as PostgREST renders a
+        // TIMESTAMPTZ: 00:00 on 1 May in Sydney is 14:00 the day before in UTC.
+        starts_at: "2026-04-30T14:00:00+00:00",
+        ends_at: "2027-04-30T14:00:00+00:00",
       }),
     );
     await enrolFrom(fake, INSURANCE_PLAN, "2026-02-01");

--- a/src/lib/membership.functions.test.ts
+++ b/src/lib/membership.functions.test.ts
@@ -871,7 +871,29 @@ function fakeEnrolAdmin(existing: Result) {
       },
       update: (patch: unknown) => {
         updates.push(patch);
-        return { eq: () => Promise.resolve(ok(null)) };
+        // Two callers, two shapes: syncMemberRole awaits `.eq(...)` directly,
+        // while the reuse path that moves a start date reads the moved row back
+        // with `.eq(...).select("*").single()`. A thenable carrying `select`
+        // serves both without the fake having to guess which one is calling.
+        return {
+          eq: () => {
+            const p = Promise.resolve(ok(null)) as Promise<Result> & {
+              select?: () => { single: () => Promise<Result> };
+            };
+            p.select = () => ({
+              single: () =>
+                Promise.resolve(
+                  ok({
+                    id: "mem-1",
+                    user_id: "user-1",
+                    price_cents: 0,
+                    ...(patch as Record<string, unknown>),
+                  }),
+                ),
+            });
+            return p;
+          },
+        };
       },
       upsert: () => Promise.resolve(ok(null)),
       delete: () => ({ eq: () => ({ eq: () => Promise.resolve(ok(null)) }) }),
@@ -937,6 +959,120 @@ describe("enrolMember on a free plan", () => {
       ok({ id: "mem-1", user_id: "user-1", status: "active", paid_at: null, price_cents: 0 }),
     );
     await enrol(fake);
+    expect(fake.updates).toEqual([]);
+  });
+});
+
+// ---- Setting the day a membership starts ----
+//
+// The yearly insurance is the one plan whose start is a real choice: it runs a
+// fixed number of days from wherever it is placed. A manager writing down cover
+// that began in February needs to say so, and the two ways that can go wrong are
+// a date silently ignored (the invoice looks backdated and is not) and a date
+// accepted on a plan whose dates belong to everyone who buys it.
+
+const INSURANCE_PLAN = {
+  id: "plan-insurance",
+  code: "insurance_yearly",
+  name: "Yearly insurance",
+  kind: "insurance",
+  is_active: true,
+  session_credits: null,
+  public_price_cents: 0,
+  student_price_cents: null,
+  starts_on: null,
+  ends_on: null,
+  duration_days: 365,
+};
+
+async function enrolFrom(
+  fake: ReturnType<typeof fakeEnrolAdmin>,
+  plan: unknown,
+  startsOn?: string,
+) {
+  const { enrolMember } = await import("./membership.functions");
+  return enrolMember(fake.admin as never, {
+    userId: "user-1",
+    plan: plan as never,
+    utsStudentNumber: null,
+    insurancePlan: null,
+    startsOn,
+  });
+}
+
+describe("enrolMember with a start date", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // 00:00 Sydney on 1 February is 13:00 UTC on 31 January (AEDT, +11), and the
+  // year of cover is measured from there rather than from the moment a manager
+  // happened to type it in.
+  it("dates a rolling plan from the start of the chosen club day", async () => {
+    const fake = fakeEnrolAdmin(ok(null));
+    await enrolFrom(fake, INSURANCE_PLAN, "2026-02-01");
+    expect(fake.inserts[0]).toMatchObject({
+      starts_at: "2026-01-31T13:00:00.000Z",
+      ends_at: "2027-01-31T13:00:00.000Z",
+    });
+  });
+
+  it("still runs from today when no start date is given", async () => {
+    const fake = fakeEnrolAdmin(ok(null));
+    const before = Date.now();
+    await enrolFrom(fake, INSURANCE_PLAN);
+    const starts = new Date((fake.inserts[0] as { starts_at: string }).starts_at).getTime();
+    expect(starts).toBeGreaterThanOrEqual(before - 1000);
+  });
+
+  // Refused, not ignored. A dropped date reads as a backdated enrolment that
+  // never happened, and nothing later would show the difference.
+  it("refuses a start date on a plan whose dates belong to the plan", async () => {
+    const fake = fakeEnrolAdmin(ok(null));
+    await expect(enrolFrom(fake, FREE_PLAN, "2026-02-01")).rejects.toThrow(/no start date to set/);
+    expect(fake.inserts).toEqual([]);
+  });
+
+  // The reuse path has no second `authorisedFields` in it, so without this a
+  // manager who re-raised the insurance with the right date would be told it
+  // worked while the window sat where it was.
+  it("moves an existing unpaid invoice's window when the start date differs", async () => {
+    const fake = fakeEnrolAdmin(
+      ok({
+        id: "mem-1",
+        user_id: "user-1",
+        status: "active",
+        paid_at: null,
+        price_cents: 0,
+        starts_at: "2026-05-01T00:00:00.000Z",
+        ends_at: "2027-05-01T00:00:00.000Z",
+      }),
+    );
+    await enrolFrom(fake, INSURANCE_PLAN, "2026-02-01");
+    expect(fake.inserts).toEqual([]);
+    expect(fake.updates[0]).toMatchObject({
+      starts_at: "2026-01-31T13:00:00.000Z",
+      // Moved, not resized: still 365 days, as sold.
+      ends_at: "2027-01-31T13:00:00.000Z",
+    });
+  });
+
+  it("writes nothing when the reused invoice already starts on that day", async () => {
+    const fake = fakeEnrolAdmin(
+      ok({
+        id: "mem-1",
+        user_id: "user-1",
+        status: "active",
+        paid_at: null,
+        price_cents: 0,
+        starts_at: "2026-01-31T13:00:00.000Z",
+        ends_at: "2027-01-31T13:00:00.000Z",
+      }),
+    );
+    await enrolFrom(fake, INSURANCE_PLAN, "2026-02-01");
     expect(fake.updates).toEqual([]);
   });
 });

--- a/src/lib/membership.functions.ts
+++ b/src/lib/membership.functions.ts
@@ -21,6 +21,7 @@ import {
   planStartIsChoosable,
   profileFullName,
   rescheduleMembershipStart,
+  sameInstant,
   saveClubSettingsSchema,
   savePlanSchema,
   sellablePlans,
@@ -928,8 +929,11 @@ export async function enrolMember(
     // with the right start date would be told it worked while the window sat
     // where it was. Moved by the same rule a later correction uses, so the two
     // paths cannot give the same request two different answers.
+    // By instant, not by string: the row came back from Postgres spelled
+    // `+00:00` and `rescheduleMembershipStart` writes `Z`, so a string compare
+    // would never match and every re-raise would write the window it already had.
     const wanted = effectiveFrom ? rescheduleMembershipStart(inserted, startsOn!) : null;
-    if (wanted && wanted.starts_at !== inserted.starts_at) {
+    if (wanted && !sameInstant(wanted.starts_at, inserted.starts_at)) {
       const { data: moved, error: mvErr } = await admin
         .from("memberships")
         .update(wanted)

--- a/src/lib/membership.functions.ts
+++ b/src/lib/membership.functions.ts
@@ -1549,8 +1549,19 @@ export const setMembershipStart = createServerFn({ method: "POST" })
     if (!membership) throw new Error("Membership not found.");
 
     const patch = await resolveMembershipStartPatch(admin, membership, data.starts_on);
-    const { error: uErr } = await admin.from("memberships").update(patch).eq("id", data.id);
+    // Read the row back rather than trusting the absence of an error. An UPDATE
+    // matching nothing is not a failure in Postgres, so a membership deleted
+    // between the read above and this write would leave the manager looking at a
+    // dialog that closed on "saved" over a correction that went nowhere.
+    const { data: moved, error: uErr } = await admin
+      .from("memberships")
+      .update(patch)
+      .eq("id", data.id)
+      .select("id")
+      .maybeSingle();
     if (uErr) throw new Error(uErr.message);
+    if (!moved)
+      throw new Error("That membership is no longer there. Refresh the page and check it again.");
     return { ok: true as const, id: data.id, ...patch };
   });
 

--- a/src/lib/membership.functions.ts
+++ b/src/lib/membership.functions.ts
@@ -2,6 +2,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { requireSupabaseAuth } from "@/integrations/supabase/auth-middleware";
 import {
   buildPaymentReference,
+  clubDayStart,
   computeMembershipPrice,
   createMembershipSchema,
   deleteMembershipSchema,
@@ -17,11 +18,15 @@ import {
   greetingName,
   nameWithPreferred,
   planMembershipWindow,
+  planStartIsChoosable,
   profileFullName,
+  rescheduleMembershipStart,
   saveClubSettingsSchema,
   savePlanSchema,
   sellablePlans,
+  setMembershipStartSchema,
   setMembershipStatusSchema,
+  startDateNotChoosableMessage,
   startMembershipSchema,
   whyMembershipCannotBeDeleted,
 } from "@/lib/validation";
@@ -233,6 +238,17 @@ function projectMembership(m: MembershipRow, plan?: MembershipPlanRow) {
     plan_code: plan?.code ?? null,
     plan_name: plan?.name ?? null,
     kind: plan?.kind ?? null,
+    // The plan's own window, handed over whole rather than as a derived flag, so
+    // a screen asks `planStartIsChoosable` the same question the server asks
+    // instead of re-deriving it from `kind` and drifting the day one plan is set
+    // up a shape `kind` does not describe (the database still allows that).
+    plan_window: plan
+      ? {
+          starts_on: plan.starts_on,
+          ends_on: plan.ends_on,
+          duration_days: plan.duration_days,
+        }
+      : null,
     status: m.status,
     is_student: m.is_student,
     price_cents: m.price_cents,
@@ -809,11 +825,25 @@ export async function enrolMember(
     /** The casual class this is for; ignored by every other plan kind. */
     sessionDate?: string | null;
     insurancePlan: MembershipPlanRow | null;
+    /**
+     * The day (YYYY-MM-DD, club time) this membership runs from, when that is
+     * not today. Only a plan whose start is a real choice takes one — see
+     * `planStartIsChoosable` — and anything else is refused rather than
+     * ignored, because a silently dropped date reads as a backdated enrolment
+     * that never happened.
+     */
+    startsOn?: string | null;
     /** False records the invoice without telling them about it. */
     sendEmail?: boolean;
   },
 ): Promise<{ ok: true; authorised: true; reference: string | null }> {
   const { userId, plan, insurancePlan } = input;
+
+  // Resolved before anything is written: a refusal has to land before the
+  // invoice exists, not halfway through raising one.
+  const startsOn = input.startsOn || null;
+  if (startsOn && !planStartIsChoosable(plan)) throw new MembershipStartNotChoosableError(plan);
+  const effectiveFrom = startsOn ? clubDayStart(startsOn) : undefined;
 
   // Student status is derived server-side from the number's presence, so the
   // number is the single source of truth: a non-empty UTS student number gets
@@ -893,6 +923,22 @@ export async function enrolMember(
   let inserted: MembershipRow;
   if (existingUnpaid) {
     inserted = existingUnpaid;
+    // Reuse must not swallow a start date. Nothing re-runs `authorisedFields` on
+    // a reused row, so a manager who raised the insurance and then re-raised it
+    // with the right start date would be told it worked while the window sat
+    // where it was. Moved by the same rule a later correction uses, so the two
+    // paths cannot give the same request two different answers.
+    const wanted = effectiveFrom ? rescheduleMembershipStart(inserted, startsOn!) : null;
+    if (wanted && wanted.starts_at !== inserted.starts_at) {
+      const { data: moved, error: mvErr } = await admin
+        .from("memberships")
+        .update(wanted)
+        .eq("id", inserted.id)
+        .select("*")
+        .single();
+      if (mvErr || !moved) throw new Error(mvErr?.message || "Could not set the start date.");
+      inserted = moved;
+    }
   } else {
     const insert = {
       user_id: userId,
@@ -900,7 +946,11 @@ export async function enrolMember(
       // Authorised on the spot. Raising a membership IS the authorisation: the
       // invoice goes out and they can be checked in from that moment, with the
       // money outstanding until somebody records it.
-      ...authorisedFields(plan),
+      //
+      // `effectiveFrom` moves only THIS row. A bundled insurance invoice is a
+      // second plan being sold now, and dating it from a backfilled training
+      // period would hand out cover for a year that has already half run out.
+      ...authorisedFields(plan, effectiveFrom),
       is_student: isStudent,
       uts_student_number: utsStudentNumber,
       price_cents: price,
@@ -1432,6 +1482,75 @@ export const setMembershipStatus = createServerFn({ method: "POST" })
   });
 
 /**
+ * Resolve the window a membership should hold once its start date is corrected,
+ * or say why this membership has no start date to correct.
+ *
+ * Shared by the manager screen's server function and the agent's `edit_invoice`
+ * so both refuse the same plans, in the same words, and land the same two
+ * columns. The rule itself is pure (`rescheduleMembershipStart`): the window
+ * keeps its length and moves as one, so no correction can lengthen cover.
+ */
+export async function resolveMembershipStartPatch(
+  admin: MembershipClient,
+  membership: MembershipRow,
+  startsOn: string,
+): Promise<{ starts_at: string; ends_at: string | null }> {
+  // Both outcomes stop the edit, and they are different problems: a failed read
+  // must not be reported as "this plan has no start date", which would send a
+  // manager off to argue with a rule that never applied.
+  const { data: plan, error } = await admin
+    .from("membership_plans")
+    .select("*")
+    .eq("id", membership.plan_id)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!plan) throw new Error("Plan not found.");
+  if (!planStartIsChoosable(plan)) throw new MembershipStartNotChoosableError(plan);
+  return rescheduleMembershipStart(membership, startsOn);
+}
+
+/**
+ * The refusal a plan with no movable start gives back. A distinct class rather
+ * than a bare Error so the agent API can answer it as a 422 the caller can act
+ * on, instead of the 500 an unrecognised throw becomes.
+ */
+export class MembershipStartNotChoosableError extends Error {
+  constructor(readonly plan: MembershipPlanRow) {
+    super(startDateNotChoosableMessage(plan));
+    this.name = "MembershipStartNotChoosableError";
+  }
+}
+
+// ---- Manager: correct the day a membership starts ----
+//
+// The counterpart to setting it when the membership is raised, for the ordinary
+// case of a manager writing down an enrolment after the fact: the cover really
+// began in February, and the row says today. It says nothing about money and
+// sends nothing — a date correction is a records fix, not news — and it is
+// reversible by setting the date back, which is why the screen asks for it
+// without a hard confirm.
+export const setMembershipStart = createServerFn({ method: "POST" })
+  .middleware([requireSupabaseAuth])
+  .inputValidator((d: unknown) => setMembershipStartSchema.parse(d))
+  .handler(async ({ data, context }) => {
+    await requireManager(context);
+    const admin = await adminClient();
+
+    const { data: membership, error } = await admin
+      .from("memberships")
+      .select("*")
+      .eq("id", data.id)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!membership) throw new Error("Membership not found.");
+
+    const patch = await resolveMembershipStartPatch(admin, membership, data.starts_on);
+    const { error: uErr } = await admin.from("memberships").update(patch).eq("id", data.id);
+    if (uErr) throw new Error(uErr.message);
+    return { ok: true as const, id: data.id, ...patch };
+  });
+
+/**
  * Delete a membership outright, or refuse and say what would have to change.
  *
  * Shared by the manager screens and the agent's `delete_invoice`, so both
@@ -1567,6 +1686,7 @@ export async function createMembershipForUser(
     plan,
     utsStudentNumber: input.uts_student_number ?? null,
     sessionDate: input.session_date,
+    startsOn: input.starts_on,
     insurancePlan: input.include_insurance ? insurancePlan : null,
     sendEmail: input.send_email,
   });

--- a/src/lib/membership.test.ts
+++ b/src/lib/membership.test.ts
@@ -29,6 +29,7 @@ import {
   rescheduleMembershipStart,
   sanitizeSurname,
   savePlanSchema,
+  sameInstant,
   sellablePlans,
   sellableWindowNotifications,
   startDateNotChoosableMessage,
@@ -681,6 +682,34 @@ describe("rescheduleMembershipStart", () => {
       "2026-02-01",
     );
     expect(w.ends_at).toBeNull();
+  });
+});
+
+describe("sameInstant", () => {
+  // The whole point: Postgres hands a TIMESTAMPTZ back as `+00:00` with no
+  // fractional part, this code writes `Z` with one, and a string compare between
+  // them reports a move that never happened -- into the invoice audit log, which
+  // is the club's only record of who changed what.
+  it("reads the two spellings of one instant as equal", () => {
+    expect(sameInstant("2026-05-01T00:00:00+00:00", "2026-05-01T00:00:00.000Z")).toBe(true);
+  });
+
+  it("still tells two different instants apart", () => {
+    expect(sameInstant("2026-05-01T00:00:00+00:00", "2026-05-02T00:00:00.000Z")).toBe(false);
+  });
+
+  it("treats two nulls as equal and one null as a change", () => {
+    expect(sameInstant(null, null)).toBe(true);
+    expect(sameInstant(null, "2026-05-01T00:00:00.000Z")).toBe(false);
+    expect(sameInstant("2026-05-01T00:00:00.000Z", null)).toBe(false);
+  });
+
+  // An unparseable value is not quietly "the same as everything": NaN compares
+  // equal to nothing, and saying two unreadable dates match would hide the
+  // corruption rather than surface it.
+  it("does not call an unreadable timestamp equal to anything", () => {
+    expect(sameInstant("not a date", "2026-05-01T00:00:00.000Z")).toBe(false);
+    expect(sameInstant("not a date", "not a date")).toBe(true);
   });
 });
 

--- a/src/lib/membership.test.ts
+++ b/src/lib/membership.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { CLUB_TIME_ZONE, zonedWallTimeToUtc } from "./calendar";
 import {
   buildPaymentReference,
   clubPaymentDetailsSchema,
@@ -600,6 +601,26 @@ describe("planMembershipWindow", () => {
     expect(w.ends_at).toBe("2027-05-01T00:00:00.000Z");
   });
 
+  // Counted as calendar days at the same time of day, not as a fixed number of
+  // milliseconds. 00:00 on 5 April 2026 is AEDT (+11) — the clocks go back that
+  // very morning — and 00:00 on 5 April 2027 is AEST (+10), so the two are 365
+  // days and one hour apart. Fixed-ms arithmetic lands at 23:00 on the 4th, and
+  // an hour before midnight prints as the PREVIOUS DAY on every screen that
+  // shows it: a year of cover reading as a day short.
+  it("keeps a rolling plan on the same clock time across a daylight-saving change", () => {
+    const start = zonedWallTimeToUtc("2026-04-05", "00:00", CLUB_TIME_ZONE).toISOString();
+    const w = planMembershipWindow({ starts_on: null, ends_on: null, duration_days: 365 }, start);
+    expect(w.ends_at).toBe(zonedWallTimeToUtc("2027-04-05", "00:00", CLUB_TIME_ZONE).toISOString());
+  });
+
+  // A leap year is a different question and deliberately NOT adjusted: a plan
+  // that sells 365 days sells 365 days, and one of them may be 29 February.
+  it("counts 365 days through a leap year rather than landing on the same date", () => {
+    const start = zonedWallTimeToUtc("2027-03-01", "00:00", CLUB_TIME_ZONE).toISOString();
+    const w = planMembershipWindow({ starts_on: null, ends_on: null, duration_days: 365 }, start);
+    expect(w.ends_at).toBe(zonedWallTimeToUtc("2028-02-29", "00:00", CLUB_TIME_ZONE).toISOString());
+  });
+
   // Undated plans (the free trial, casual classes) run from the START OF THE
   // CLUB DAY, so the row reads as "granted on this day" rather than at some
   // arbitrary instant. Nothing enforces it -- a credit balance is not date-gated
@@ -665,13 +686,65 @@ describe("rescheduleMembershipStart", () => {
   // The whole rule: a correction moves the window, it does not resize it. A
   // recompute from the plan's CURRENT duration would make this the one back door
   // through which a later plan edit re-dates a membership somebody already
-  // bought.
-  it("moves the end by exactly as much as the start, keeping the length sold", () => {
-    const before = { starts_at: "2026-05-01T00:00:00.000Z", ends_at: "2027-05-01T00:00:00.000Z" };
+  // bought. The length carried over is a count of club DAYS, so the pinned value
+  // here is the day count, not a millisecond span — those two differ by an hour
+  // whenever the move crosses one of Sydney's clock changes, which is the whole
+  // reason this counts days.
+  it("carries the day count over rather than recomputing it from the plan", () => {
+    const before = {
+      starts_at: zonedWallTimeToUtc("2026-05-01", "00:00", CLUB_TIME_ZONE).toISOString(),
+      ends_at: zonedWallTimeToUtc("2027-05-01", "00:00", CLUB_TIME_ZONE).toISOString(),
+    };
     const after = rescheduleMembershipStart(before, "2026-02-01");
+    expect(after.starts_at).toBe(
+      zonedWallTimeToUtc("2026-02-01", "00:00", CLUB_TIME_ZONE).toISOString(),
+    );
+    expect(after.ends_at).toBe(
+      zonedWallTimeToUtc("2027-02-01", "00:00", CLUB_TIME_ZONE).toISOString(),
+    );
+  });
+
+  // The start is snapped to the BEGINNING of the chosen day while the end keeps
+  // the time of day it already had, so the rounding can only ever add hours,
+  // never take them away. Correcting a record must not quietly shorten cover
+  // somebody is relying on.
+  it("never shortens the cover it is moving", () => {
+    const before = {
+      starts_at: zonedWallTimeToUtc("2026-05-01", "14:32", CLUB_TIME_ZONE).toISOString(),
+      ends_at: zonedWallTimeToUtc("2027-05-01", "14:32", CLUB_TIME_ZONE).toISOString(),
+    };
     const length = (w: { starts_at: string; ends_at: string | null }) =>
       new Date(w.ends_at!).getTime() - new Date(w.starts_at).getTime();
-    expect(length(after)).toBe(length(before));
+    for (const day of ["2026-02-01", "2026-04-05", "2026-10-04", "2027-01-01"]) {
+      expect(length(rescheduleMembershipStart(before, day))).toBeGreaterThanOrEqual(length(before));
+    }
+  });
+
+  // The same reason `planMembershipWindow` counts days: dragging a fixed
+  // millisecond length across a clock change lands an hour out, and an hour
+  // before midnight is the previous day everywhere it is printed.
+  it("keeps the day count when the correction crosses a daylight-saving change", () => {
+    const w = rescheduleMembershipStart(
+      {
+        starts_at: zonedWallTimeToUtc("2026-01-05", "00:00", CLUB_TIME_ZONE).toISOString(),
+        ends_at: zonedWallTimeToUtc("2027-01-05", "00:00", CLUB_TIME_ZONE).toISOString(),
+      },
+      "2026-04-05",
+    );
+    expect(w.ends_at).toBe(zonedWallTimeToUtc("2027-04-05", "00:00", CLUB_TIME_ZONE).toISOString());
+  });
+
+  // A membership someone bought at 14:32 keeps ending at 14:32: the correction
+  // moves the window, it does not quietly re-grain it to midnight.
+  it("keeps the end's time of day on a window that did not start at midnight", () => {
+    const w = rescheduleMembershipStart(
+      {
+        starts_at: zonedWallTimeToUtc("2026-05-01", "14:32", CLUB_TIME_ZONE).toISOString(),
+        ends_at: zonedWallTimeToUtc("2027-05-01", "14:32", CLUB_TIME_ZONE).toISOString(),
+      },
+      "2026-02-01",
+    );
+    expect(w.ends_at).toBe(zonedWallTimeToUtc("2027-02-01", "14:32", CLUB_TIME_ZONE).toISOString());
   });
 
   // A plan that ends with its classes has no end to move, and inventing one

--- a/src/lib/membership.test.ts
+++ b/src/lib/membership.test.ts
@@ -25,10 +25,13 @@ import {
   planTypePatch,
   strandedPlanFields,
   planMembershipWindow,
+  planStartIsChoosable,
+  rescheduleMembershipStart,
   sanitizeSurname,
   savePlanSchema,
   sellablePlans,
   sellableWindowNotifications,
+  startDateNotChoosableMessage,
   sessionDateTag,
   stableCode,
   startMembershipSchema,
@@ -606,6 +609,101 @@ describe("planMembershipWindow", () => {
     const w = planMembershipWindow({ starts_on: null, ends_on: null, duration_days: null }, NOW);
     expect(w.starts_at).toBe("2026-04-30T14:00:00.000Z");
     expect(w.ends_at).toBeNull();
+  });
+});
+
+// ---- Setting and correcting the day a membership starts ----
+//
+// A start date is only a real question on a plan whose LENGTH is fixed but whose
+// POSITION is not, which today is the yearly insurance. The two mistakes worth
+// pinning are letting it loose on the other kinds -- a training period's dates
+// belong to the plan and everyone who buys it shares them -- and letting a
+// correction change how long somebody is covered for.
+
+describe("planStartIsChoosable", () => {
+  it("says yes to a rolling plan: its length is fixed, where it sits is not", () => {
+    expect(planStartIsChoosable({ starts_on: null, ends_on: null, duration_days: 365 })).toBe(true);
+  });
+
+  it("says no to a dated plan, whose dates everyone who buys it shares", () => {
+    expect(
+      planStartIsChoosable({ starts_on: "2026-07-20", ends_on: "2026-11-22", duration_days: null }),
+    ).toBe(false);
+  });
+
+  it("says no to a plan that ends with its classes rather than on a date", () => {
+    expect(planStartIsChoosable({ starts_on: null, ends_on: null, duration_days: null })).toBe(
+      false,
+    );
+  });
+
+  // The database still permits a shape the plan editor refuses. Dates win in
+  // `planMembershipWindow`, so they have to win here too -- otherwise the screen
+  // offers a start date the window would then ignore.
+  it("says no when a plan carries dates AND a duration, matching planMembershipWindow", () => {
+    expect(
+      planStartIsChoosable({ starts_on: "2026-07-20", ends_on: "2026-11-22", duration_days: 365 }),
+    ).toBe(false);
+  });
+
+  it("says no to a duration of zero days, which is not a plan that runs", () => {
+    expect(planStartIsChoosable({ starts_on: null, ends_on: null, duration_days: 0 })).toBe(false);
+  });
+});
+
+describe("rescheduleMembershipStart", () => {
+  // AEST (+10) in July: 00:00 on the 20th is 14:00 UTC the day before.
+  it("starts at 00:00 in the club's own timezone on the chosen day", () => {
+    const w = rescheduleMembershipStart(
+      { starts_at: "2026-05-01T00:00:00.000Z", ends_at: "2027-05-01T00:00:00.000Z" },
+      "2026-07-20",
+    );
+    expect(w.starts_at).toBe("2026-07-19T14:00:00.000Z");
+  });
+
+  // The whole rule: a correction moves the window, it does not resize it. A
+  // recompute from the plan's CURRENT duration would make this the one back door
+  // through which a later plan edit re-dates a membership somebody already
+  // bought.
+  it("moves the end by exactly as much as the start, keeping the length sold", () => {
+    const before = { starts_at: "2026-05-01T00:00:00.000Z", ends_at: "2027-05-01T00:00:00.000Z" };
+    const after = rescheduleMembershipStart(before, "2026-02-01");
+    const length = (w: { starts_at: string; ends_at: string | null }) =>
+      new Date(w.ends_at!).getTime() - new Date(w.starts_at).getTime();
+    expect(length(after)).toBe(length(before));
+  });
+
+  // A plan that ends with its classes has no end to move, and inventing one
+  // would date-gate a credit balance that deliberately is not.
+  it("leaves a null end date null", () => {
+    const w = rescheduleMembershipStart(
+      { starts_at: "2026-05-01T00:00:00.000Z", ends_at: null },
+      "2026-02-01",
+    );
+    expect(w.ends_at).toBeNull();
+  });
+});
+
+describe("startDateNotChoosableMessage", () => {
+  it("names the plan and why a training period has no start date to set", () => {
+    const msg = startDateNotChoosableMessage({
+      name: "Semester 2 2026",
+      starts_on: "2026-07-20",
+      ends_on: "2026-11-22",
+      duration_days: null,
+    });
+    expect(msg).toContain("Semester 2 2026");
+    expect(msg).toContain("fixed dates");
+  });
+
+  it("says a class-credit plan ends with its classes instead", () => {
+    const msg = startDateNotChoosableMessage({
+      name: "Casual class",
+      starts_on: null,
+      ends_on: null,
+      duration_days: null,
+    });
+    expect(msg).toContain("ends with its classes");
   });
 });
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1524,6 +1524,26 @@ export function rescheduleMembershipStart(
 }
 
 /**
+ * Whether two timestamps name the same instant, however they are spelled.
+ *
+ * Postgres hands a TIMESTAMPTZ back as `2026-05-01T00:00:00+00:00` while this
+ * code writes `2026-05-01T00:00:00.000Z`, and comparing those as strings reports
+ * a change that never happened. That is not cosmetic here: it is a phantom line
+ * in the invoice audit log, which is the club's only record of who moved what,
+ * and a write on every re-raise that should have been a no-op. The same trap has
+ * already cost this repo the waiver idempotency path once
+ * (`docs/manager-agent-api.md`) and is why `diffOccurrences` in `calendar.ts`
+ * compares by `getTime()` too.
+ */
+export function sameInstant(a: string | null, b: string | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const ta = new Date(a).getTime();
+  const tb = new Date(b).getTime();
+  return Number.isFinite(ta) && ta === tb;
+}
+
+/**
  * Why a plan refuses a start date, in the words a manager or an agent reads.
  * One message for both callers, so the manager screen and the API cannot
  * explain the same refusal differently.

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -18,7 +18,7 @@ import { beltSizes, giSizes } from "./kit-sizes";
 // must cover that evening's class, not cut off at UTC midnight), so this
 // module needs the same zoned-time helpers the calendar uses. `calendar.ts` is
 // the same kind of module as this one (pure, no server imports).
-import { CLUB_TIME_ZONE, clubLocalDate, zonedWallTimeToUtc } from "./calendar";
+import { CLUB_TIME_ZONE, clubLocalDate, tzOffsetMinutes, zonedWallTimeToUtc } from "./calendar";
 import { formatDate, formatDateOnly } from "./dates";
 
 // ---- Pure helpers ----
@@ -1417,6 +1417,13 @@ function addCalendarDays(dateStr: string, days: number): string {
   return `${String(dt.getUTCFullYear()).padStart(4, "0")}-${String(dt.getUTCMonth() + 1).padStart(2, "0")}-${String(dt.getUTCDate()).padStart(2, "0")}`;
 }
 
+/** The club's own calendar date and clock time at an instant. */
+function clubWallTime(instant: Date): { date: string; time: string } {
+  const shifted = new Date(instant.getTime() + tzOffsetMinutes(instant, CLUB_TIME_ZONE) * 60000);
+  const iso = shifted.toISOString();
+  return { date: iso.slice(0, 10), time: iso.slice(11, 16) };
+}
+
 /**
  * The absolute instants a plan's membership runs for, resolved from the plan
  * alone — no second table to look up, and no branch on the plan's `kind`:
@@ -1451,8 +1458,19 @@ export function planMembershipWindow(
     return { starts_at, ends_at };
   }
   if (plan.duration_days) {
-    const ends_at = new Date(
-      new Date(now).getTime() + plan.duration_days * 86_400_000,
+    // Counted as CALENDAR days in the club's timezone, at the same time of day,
+    // not as a fixed number of milliseconds. Sydney's clocks move twice a year,
+    // so `now + days * 86_400_000` lands an hour out either side of a change —
+    // and when the start is a club midnight, an hour before midnight is the
+    // PREVIOUS DAY. A year of cover bought on 5 April 2026 then read as ending
+    // on 4 April 2027: a day short, on screen, in the club's own words. Leap
+    // years are untouched by this and are not the same question: a plan that
+    // sells 365 days sells 365 days, and one of them may be 29 February.
+    const { date, time } = clubWallTime(new Date(now));
+    const ends_at = zonedWallTimeToUtc(
+      addCalendarDays(date, plan.duration_days),
+      time,
+      CLUB_TIME_ZONE,
     ).toISOString();
     return { starts_at: now, ends_at };
   }
@@ -1498,14 +1516,19 @@ export function clubToday(now: Date = new Date()): string {
 
 /**
  * Move an existing membership's window so it begins at 00:00 club time on
- * `startsOn`, **keeping the length it already has**.
+ * `startsOn`, **keeping the length it already has** — the same number of club
+ * days, ending at the same time of day.
  *
- * Correcting a start date is not re-buying the plan, so the end date is shifted
- * by exactly the same amount rather than recomputed from the plan's current
- * `duration_days`. A membership is given its dates once, at the moment it is
- * raised, and a later plan edit never re-syncs it (see docs/memberships.md) —
- * recomputing here would make a start-date correction the one back door that
- * does, silently handing somebody a longer or shorter year than they bought.
+ * Correcting a start date is not re-buying the plan, so the length is carried
+ * over rather than recomputed from the plan's current `duration_days`. A
+ * membership is given its dates once, at the moment it is raised, and a later
+ * plan edit never re-syncs it (see docs/memberships.md) — recomputing here would
+ * make a start-date correction the one back door that does, silently handing
+ * somebody a longer or shorter year than they bought.
+ *
+ * Days rather than milliseconds, for the reason in `planMembershipWindow`: a
+ * fixed millisecond length dragged across one of Sydney's clock changes lands an
+ * hour off, and an hour before midnight is the previous day on screen.
  *
  * A null `ends_at` stays null: nothing to move, and inventing an end for a plan
  * that runs on credits would date-gate a balance that is deliberately not.
@@ -1516,11 +1539,23 @@ export function rescheduleMembershipStart(
 ): { starts_at: string; ends_at: string | null } {
   const starts_at = clubDayStart(startsOn);
   if (!window.ends_at || !window.starts_at) return { starts_at, ends_at: window.ends_at };
-  const lengthMs = new Date(window.ends_at).getTime() - new Date(window.starts_at).getTime();
+  const from = clubWallTime(new Date(window.starts_at));
+  const to = clubWallTime(new Date(window.ends_at));
+  const days = Math.round((dayNumber(to.date) - dayNumber(from.date)) / 86_400_000);
   return {
     starts_at,
-    ends_at: new Date(new Date(starts_at).getTime() + lengthMs).toISOString(),
+    ends_at: zonedWallTimeToUtc(
+      addCalendarDays(startsOn, days),
+      to.time,
+      CLUB_TIME_ZONE,
+    ).toISOString(),
   };
+}
+
+/** A YYYY-MM-DD as a plain day index, for counting days between two dates. */
+function dayNumber(dateStr: string): number {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return Date.UTC(y, m - 1, d);
 }
 
 /**

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1465,6 +1465,78 @@ export function planMembershipWindow(
 }
 
 /**
+ * Whether the day a membership STARTS is a real choice on this plan, and so
+ * whether a manager may set it when raising one or correct it afterwards.
+ *
+ * Only a rolling plan (`duration_days`, which today is the yearly insurance)
+ * qualifies, and the reason is what the other two kinds mean. A dated plan's
+ * window belongs to the plan, not the member — everyone who buys this training
+ * period gets exactly its dates, and a per-member start would quietly reinvent
+ * the pro rata this club does not do. A credit plan has no window to move: it
+ * ends with its classes, its `starts_at` is a record of the day it was granted,
+ * and nothing reads it as a limit (`docs/check-in.md`).
+ *
+ * A rolling plan is the opposite of both: its length is fixed but its position
+ * is not, so "when does their year of cover run from" is a question with no
+ * answer until somebody gives one. Today defaults it; a manager writing down an
+ * enrolment that already happened says when it really started.
+ */
+export function planStartIsChoosable(plan: PlanWindow): boolean {
+  if (plan.starts_on && plan.ends_on) return false;
+  return Boolean(plan.duration_days && plan.duration_days > 0);
+}
+
+/** The instant 00:00 in the club's own timezone on `date` (YYYY-MM-DD). */
+export function clubDayStart(date: string): string {
+  return zonedWallTimeToUtc(date, "00:00", CLUB_TIME_ZONE).toISOString();
+}
+
+/** Today's date (YYYY-MM-DD) where the club is, whatever timezone the reader is in. */
+export function clubToday(now: Date = new Date()): string {
+  return clubLocalDate(now, CLUB_TIME_ZONE);
+}
+
+/**
+ * Move an existing membership's window so it begins at 00:00 club time on
+ * `startsOn`, **keeping the length it already has**.
+ *
+ * Correcting a start date is not re-buying the plan, so the end date is shifted
+ * by exactly the same amount rather than recomputed from the plan's current
+ * `duration_days`. A membership is given its dates once, at the moment it is
+ * raised, and a later plan edit never re-syncs it (see docs/memberships.md) —
+ * recomputing here would make a start-date correction the one back door that
+ * does, silently handing somebody a longer or shorter year than they bought.
+ *
+ * A null `ends_at` stays null: nothing to move, and inventing an end for a plan
+ * that runs on credits would date-gate a balance that is deliberately not.
+ */
+export function rescheduleMembershipStart(
+  window: { starts_at: string | null; ends_at: string | null },
+  startsOn: string,
+): { starts_at: string; ends_at: string | null } {
+  const starts_at = clubDayStart(startsOn);
+  if (!window.ends_at || !window.starts_at) return { starts_at, ends_at: window.ends_at };
+  const lengthMs = new Date(window.ends_at).getTime() - new Date(window.starts_at).getTime();
+  return {
+    starts_at,
+    ends_at: new Date(new Date(starts_at).getTime() + lengthMs).toISOString(),
+  };
+}
+
+/**
+ * Why a plan refuses a start date, in the words a manager or an agent reads.
+ * One message for both callers, so the manager screen and the API cannot
+ * explain the same refusal differently.
+ */
+export function startDateNotChoosableMessage(plan: { name: string } & PlanWindow): string {
+  const reason =
+    plan.starts_on && plan.ends_on
+      ? "runs between fixed dates that everyone who buys it shares"
+      : "ends with its classes rather than on a date";
+  return `${plan.name} ${reason}, so it has no start date to set. Only a plan that runs for a fixed number of days, like the yearly insurance, does.`;
+}
+
+/**
  * The plans a member may buy right now: an undated plan (trial, casual,
  * insurance) is always sellable while active; a dated plan drops off on its
  * own once its `ends_on` has passed, with no manager step required to retire
@@ -2241,6 +2313,19 @@ export const setMembershipStatusSchema = z.object({
 });
 export type SetMembershipStatusInput = z.infer<typeof setMembershipStatusSchema>;
 
+// ---- Manager: correct the day a membership starts ----
+//
+// Only meaningful where the start is a real choice (`planStartIsChoosable`), so
+// in practice the yearly insurance. The server refuses anything else rather than
+// ignoring the date, and moves `ends_at` with `starts_at` so the cover keeps the
+// length it was sold at (`rescheduleMembershipStart`).
+
+export const setMembershipStartSchema = z.object({
+  id: z.string().uuid(),
+  starts_on: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+export type SetMembershipStartInput = z.infer<typeof setMembershipStartSchema>;
+
 // ---- Manager: record a payment ----
 //
 // The counterpart to bank reconciliation, for money that never touches the club
@@ -2278,6 +2363,15 @@ export const createMembershipSchema = z.object({
   plan_code: z.string().trim().min(1).max(64),
   uts_student_number: z.string().trim().max(32).nullable().optional(),
   session_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .nullable()
+    .optional(),
+  // The day the membership itself runs from, for a plan whose start is a real
+  // choice (`planStartIsChoosable` — the yearly insurance). Absent means today.
+  // Refused rather than ignored on any other plan: an agent told "ignored" would
+  // read a 200 as proof it had backdated somebody's training period.
+  starts_on: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/)
     .nullable()
@@ -2369,6 +2463,15 @@ export const editInvoiceSchema = z
     payment_reference: z.string().trim().min(1).max(64).optional(),
     payment_method: z.enum(invoicePaymentMethods).optional(),
     status: z.enum(["pending", "cancelled", "expired"]).optional(),
+    // The day this membership runs from, for a plan whose start is a real
+    // choice (`planStartIsChoosable`). Writes `starts_at` AND `ends_at`: the
+    // window keeps the length it has and moves as one, so a correction can
+    // never quietly lengthen somebody's cover. Not nullable — a membership
+    // always starts on some day, so there is nothing to clear it to.
+    starts_on: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .optional(),
     // `.default(false)` to match confirm_duplicate on paperWaiverUploadSchema:
     // two structurally identical confirmation flags should not parse to
     // different types (`boolean | undefined` vs `boolean`) for no reason.
@@ -2381,7 +2484,8 @@ export const editInvoiceSchema = z
       d.notes !== undefined ||
       d.payment_reference !== undefined ||
       d.payment_method !== undefined ||
-      d.status !== undefined,
+      d.status !== undefined ||
+      d.starts_on !== undefined,
     { message: "Provide at least one invoice field to edit." },
   );
 export type EditInvoiceInput = z.infer<typeof editInvoiceSchema>;

--- a/src/routes/api/manager/agent.test.ts
+++ b/src/routes/api/manager/agent.test.ts
@@ -126,6 +126,31 @@ function fakeAdminForEditInvoice(
   };
 }
 
+/**
+ * The reads `create_membership` walks before it can refuse a start date: the
+ * plan named by `plan_code`, and the insurance catalogue `resolveInsuranceCover`
+ * checks on the way past. Nothing else is reached, because the refusal lands
+ * before a single write.
+ */
+function fakeAdminForCreateMembership(plan: Record<string, unknown>) {
+  return {
+    from: (table: string) => {
+      if (table === "membership_plans") {
+        return {
+          select: () => ({
+            eq: (col: string) =>
+              col === "code"
+                ? { maybeSingle: () => Promise.resolve(ok(plan)) }
+                : // resolveInsuranceCover awaits the kind filter directly.
+                  Promise.resolve(ok([])),
+          }),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+}
+
 let currentAdmin: unknown;
 vi.mock("@/integrations/supabase/client.server", () => ({
   get supabaseAdmin() {
@@ -480,8 +505,11 @@ describe("manager agent route", () => {
       ...ROW,
       id: INVOICE_ID,
       paid_at: null,
-      starts_at: "2026-05-01T00:00:00+00:00",
-      ends_at: "2027-05-01T00:00:00+00:00",
+      // A real backdated year of cover: club midnight to club midnight, spelled
+      // the way PostgREST renders a TIMESTAMPTZ. 00:00 on 1 May in Sydney is
+      // 14:00 the day before in UTC (AEST, +10).
+      starts_at: "2026-04-30T14:00:00+00:00",
+      ends_at: "2027-04-30T14:00:00+00:00",
     };
 
     it("moves both ends of the window, and reports both as changed", async () => {
@@ -500,8 +528,8 @@ describe("manager agent route", () => {
       });
       expect(body.result.changed).toEqual(["starts_at", "ends_at"]);
       expect(body.result.previous).toEqual({
-        starts_at: "2026-05-01T00:00:00+00:00",
-        ends_at: "2027-05-01T00:00:00+00:00",
+        starts_at: "2026-04-30T14:00:00+00:00",
+        ends_at: "2027-04-30T14:00:00+00:00",
       });
     });
 
@@ -566,6 +594,39 @@ describe("manager agent route", () => {
       // current value does.
       expect((await res.json()).result.changed).toEqual([]);
     });
+  });
+
+  // The refusal has to reach a caller as a 422 it can act on, not the 500 an
+  // unrecognised throw becomes — and it has to say the same thing edit_invoice
+  // says, since it is the same rule about the same plan.
+  it("refuses create_membership's start date on a plan that has none, as a 422", async () => {
+    currentAdmin = fakeAdminForCreateMembership({
+      id: "plan-period",
+      code: "2026-s2",
+      name: "Semester 2 2026",
+      kind: "period",
+      starts_on: "2026-07-20",
+      ends_on: "2026-11-22",
+      duration_days: null,
+      session_credits: null,
+      public_price_cents: 24500,
+      student_price_cents: null,
+      is_active: true,
+      sort_order: 0,
+    });
+    const res = await post({
+      action: "create_membership",
+      params: {
+        user_id: "22222222-2222-4222-8222-222222222222",
+        plan_code: "2026-s2",
+        starts_on: "2026-02-01",
+      },
+    });
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error.code).toBe("start_date_not_choosable");
+    expect(body.error.message).toContain("Semester 2 2026");
+    expect(body.error.details.plan_kind).toBe("period");
   });
 
   it("reports a missing invoice as not_found rather than a guard failure", async () => {

--- a/src/routes/api/manager/agent.test.ts
+++ b/src/routes/api/manager/agent.test.ts
@@ -472,12 +472,16 @@ describe("manager agent route", () => {
       ends_on: null,
       duration_days: 365,
     };
+    // Spelled the way PostgREST renders a TIMESTAMPTZ (`+00:00`, no fractional
+    // part), NOT the way JS writes one. A fixture in the write format hides the
+    // one bug these tests exist to catch: the same instant compared as two
+    // different strings, reported as an edit that never happened.
     const COVER = {
       ...ROW,
       id: INVOICE_ID,
       paid_at: null,
-      starts_at: "2026-05-01T00:00:00.000Z",
-      ends_at: "2027-05-01T00:00:00.000Z",
+      starts_at: "2026-05-01T00:00:00+00:00",
+      ends_at: "2027-05-01T00:00:00+00:00",
     };
 
     it("moves both ends of the window, and reports both as changed", async () => {
@@ -496,8 +500,8 @@ describe("manager agent route", () => {
       });
       expect(body.result.changed).toEqual(["starts_at", "ends_at"]);
       expect(body.result.previous).toEqual({
-        starts_at: "2026-05-01T00:00:00.000Z",
-        ends_at: "2027-05-01T00:00:00.000Z",
+        starts_at: "2026-05-01T00:00:00+00:00",
+        ends_at: "2027-05-01T00:00:00+00:00",
       });
     });
 
@@ -542,9 +546,11 @@ describe("manager agent route", () => {
       expect((await res.json()).result.changed).toEqual(["starts_at", "ends_at"]);
     });
 
+    // The same instant, spelled as Postgres returns it. A string compare would
+    // call this an edit and write a move that never happened into the audit log.
     it("treats the day it already starts on as no edit at all", async () => {
       const fake = fakeAdminForEditInvoice(
-        { ...COVER, starts_at: "2026-01-31T13:00:00.000Z", ends_at: "2027-01-31T13:00:00.000Z" },
+        { ...COVER, starts_at: "2026-01-31T13:00:00+00:00", ends_at: "2027-01-31T13:00:00+00:00" },
         undefined,
         YEARLY,
       );
@@ -554,6 +560,10 @@ describe("manager agent route", () => {
         params: { id: INVOICE_ID, starts_on: "2026-02-01" },
       });
       expect(res.status).toBe(200);
+      // `changed` empty is the assertion that matters: it is what the audit log
+      // records, and a move that never happened must not appear in it. The patch
+      // itself still carries the field, exactly as a price resubmitted at its
+      // current value does.
       expect((await res.json()).result.changed).toEqual([]);
     });
   });

--- a/src/routes/api/manager/agent.test.ts
+++ b/src/routes/api/manager/agent.test.ts
@@ -72,6 +72,10 @@ function fakeAdminForListInvoices(rows: (typeof ROW)[], total: number) {
 function fakeAdminForEditInvoice(
   existing: Record<string, unknown> | null,
   atWriteTime?: Record<string, unknown> | null,
+  // The plan behind the invoice. It decides one thing on its own: whether this
+  // membership has a start date to set at all, which is a property of the plan's
+  // window and not of the row being edited.
+  plan: Record<string, unknown> = { id: "plan-1", code: "trial" },
 ) {
   const updates: Record<string, unknown>[] = [];
   const current = atWriteTime === undefined ? existing : atWriteTime;
@@ -111,7 +115,7 @@ function fakeAdminForEditInvoice(
           return {
             select: () => ({
               eq: () => ({
-                maybeSingle: () => Promise.resolve(ok({ id: "plan-1", code: "trial" })),
+                maybeSingle: () => Promise.resolve(ok(plan)),
               }),
             }),
           };
@@ -451,6 +455,107 @@ describe("manager agent route", () => {
     });
     expect(res.status).toBe(409);
     expect((await res.json()).error.code).toBe("invoice_changed");
+  });
+
+  // ---- Correcting the day a membership starts ----
+  //
+  // The manager's counterpart is the Start date button on the membership row;
+  // both land the same two columns through the same rule, so cover cannot be
+  // lengthened by correcting when it began.
+  describe("edit_invoice starts_on", () => {
+    const YEARLY = {
+      id: "plan-1",
+      code: "insurance_yearly",
+      name: "Yearly insurance",
+      kind: "insurance",
+      starts_on: null,
+      ends_on: null,
+      duration_days: 365,
+    };
+    const COVER = {
+      ...ROW,
+      id: INVOICE_ID,
+      paid_at: null,
+      starts_at: "2026-05-01T00:00:00.000Z",
+      ends_at: "2027-05-01T00:00:00.000Z",
+    };
+
+    it("moves both ends of the window, and reports both as changed", async () => {
+      const fake = fakeAdminForEditInvoice(COVER, undefined, YEARLY);
+      currentAdmin = fake.db;
+      const res = await post({
+        action: "edit_invoice",
+        params: { id: INVOICE_ID, starts_on: "2026-02-01" },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // 00:00 Sydney on 1 February, and 365 days later: the length it was sold at.
+      expect(fake.updates[0]).toEqual({
+        starts_at: "2026-01-31T13:00:00.000Z",
+        ends_at: "2027-01-31T13:00:00.000Z",
+      });
+      expect(body.result.changed).toEqual(["starts_at", "ends_at"]);
+      expect(body.result.previous).toEqual({
+        starts_at: "2026-05-01T00:00:00.000Z",
+        ends_at: "2027-05-01T00:00:00.000Z",
+      });
+    });
+
+    // Not ignored: an agent told "ok" would report a training period as
+    // backdated when nothing moved.
+    it("refuses a plan whose dates belong to the plan, and writes nothing", async () => {
+      const fake = fakeAdminForEditInvoice(COVER, undefined, {
+        id: "plan-1",
+        name: "Semester 2 2026",
+        kind: "period",
+        starts_on: "2026-07-20",
+        ends_on: "2026-11-22",
+        duration_days: null,
+      });
+      currentAdmin = fake.db;
+      const res = await post({
+        action: "edit_invoice",
+        params: { id: INVOICE_ID, starts_on: "2026-02-01" },
+      });
+      expect(res.status).toBe(422);
+      const body = await res.json();
+      expect(body.error.code).toBe("start_date_not_choosable");
+      expect(body.error.message).toContain("Semester 2 2026");
+      expect(fake.updates).toHaveLength(0);
+    });
+
+    // The case this exists for: cover settled in March, recorded in April, dated
+    // from the day the manager got to it. Guarding the dates behind
+    // confirm_paid_edit would refuse exactly that.
+    it("corrects a PAID invoice's dates without confirm_paid_edit", async () => {
+      const fake = fakeAdminForEditInvoice(
+        { ...COVER, paid_at: "2026-05-02T00:00:00.000Z" },
+        undefined,
+        YEARLY,
+      );
+      currentAdmin = fake.db;
+      const res = await post({
+        action: "edit_invoice",
+        params: { id: INVOICE_ID, starts_on: "2026-02-01" },
+      });
+      expect(res.status).toBe(200);
+      expect((await res.json()).result.changed).toEqual(["starts_at", "ends_at"]);
+    });
+
+    it("treats the day it already starts on as no edit at all", async () => {
+      const fake = fakeAdminForEditInvoice(
+        { ...COVER, starts_at: "2026-01-31T13:00:00.000Z", ends_at: "2027-01-31T13:00:00.000Z" },
+        undefined,
+        YEARLY,
+      );
+      currentAdmin = fake.db;
+      const res = await post({
+        action: "edit_invoice",
+        params: { id: INVOICE_ID, starts_on: "2026-02-01" },
+      });
+      expect(res.status).toBe(200);
+      expect((await res.json()).result.changed).toEqual([]);
+    });
   });
 
   it("reports a missing invoice as not_found rather than a guard failure", async () => {

--- a/src/routes/api/manager/agent.ts
+++ b/src/routes/api/manager/agent.ts
@@ -87,8 +87,10 @@ import {
 import {
   createMembershipForUser,
   deleteMembershipRow,
+  MembershipStartNotChoosableError,
   recordMembershipPayment,
   listMembershipPlanRows,
+  resolveMembershipStartPatch,
   saveMembershipPlanRow,
   syncMemberRole,
 } from "@/lib/membership.functions";
@@ -458,7 +460,24 @@ async function handleEditInvoice(params: unknown, actingAs: string) {
   if (findErr) throw new AgentError(500, "db_error", findErr.message);
   if (!existing) throw new AgentError(404, "not_found", "Invoice not found.");
 
-  const patch = buildInvoicePatch(input);
+  // Resolved before the patch is built, so a plan with no start date to set
+  // refuses the WHOLE edit rather than writing its other fields first. The plan
+  // is what decides, and reading it is also what stops a caller hand-building a
+  // window: they name a day, the plan's own rule places it.
+  let window: { starts_at: string; ends_at: string | null } | undefined;
+  if (input.starts_on !== undefined) {
+    try {
+      window = await resolveMembershipStartPatch(db, existing as MembershipRow, input.starts_on);
+    } catch (e) {
+      if (e instanceof MembershipStartNotChoosableError)
+        throw new AgentError(422, "start_date_not_choosable", e.message, {
+          plan_kind: e.plan.kind,
+        });
+      throw new AgentError(500, "db_error", e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  const patch = buildInvoicePatch(input, window);
   // What this edit would actually move, measured against the row as it stands.
   // Submitting a field with the value it already has is not an edit: it neither
   // trips the guard below nor gets recorded as a change that happened.
@@ -647,6 +666,11 @@ async function handleCreateMembership(params: unknown) {
   try {
     return await createMembershipForUser(db, input);
   } catch (e) {
+    // A start date on a plan that has none is the caller's mistake and is worth
+    // naming: the alternative reading, that we backdated the enrolment and said
+    // nothing, is the one that would go unnoticed.
+    if (e instanceof MembershipStartNotChoosableError)
+      throw new AgentError(422, "start_date_not_choosable", e.message, { plan_kind: e.plan.kind });
     // The two refusals a caller can act on — an unknown plan code, and the free
     // trial already being used — are the caller's mistakes, not server faults,
     // and a 500 would tell them to retry something that can never succeed.


### PR DESCRIPTION
## What changes for people

**For a manager.** Yearly insurance now asks when it starts, and it defaults to today.

- **Raising one** (Add a membership, on a person's page): a **Start date** field appears when the plan is the yearly insurance, prefilled with today. Leave it alone for someone paying at the counter; set it back when you are writing down cover that really began weeks ago. Combined with the existing "don't email them" tick box, that is a complete backfill: the year of cover sits where it actually ran, and nobody gets an invoice for it now.
- **Correcting one afterwards** (a **Start date** button on the membership row, on both `/manager/memberships` and a person's page): change the day and the end date moves with it, shown on screen before you save. No confirm dialog, because nothing is sent and setting the date back undoes it.

**For a member.** No new field, no extra step, no email. One thing does change for them, and it is a fix: a year of cover now always ends on the calendar day it should (see the date arithmetic below).

**For an agent** driving the manager API: `create_membership` and `edit_invoice` both take `starts_on`. Manifest version is now `14`.

## Decisions worth a look

- **Only the yearly insurance takes a start date**, and the other plans refuse it rather than ignoring it. A training period runs the plan's own dates and everyone who buys it gets exactly those, so a per-member start would quietly reinvent the pro rata the club does not do. A casual class or the free trial ends with its classes, so there is no window to place. A date silently dropped would leave an invoice that looks backdated and is not, with nothing downstream to show the difference.
- **A rolling plan's length is counted in club days, not milliseconds.** This is a bug fix that predates the feature but is surfaced by it. The end was `start + days × 86,400,000`, and Sydney's clocks move twice a year, so that lands an hour out either side of a change — and when the start is a club midnight, an hour before midnight is the *previous day*. A year of cover starting 5 April 2026 read as ending 4 April 2027: a day short, on screen, in the club's own words. Both the raise and the correction now add calendar days at the same time of day. **Leap years are deliberately left alone**: a plan that sells 365 days sells 365 days, and one of them may be 29 February. If the club means "the same date next year", that is a change to what the plan sells, not to this arithmetic — worth deciding separately.
- **A correction moves the window, it never resizes it.** The cover keeps the number of days it was sold, ending at the time of day it already ended. Recomputing the end from the plan's current duration would have made this the one back door through which a later plan edit re-dates a membership somebody already bought. The start snaps to the beginning of the chosen day while the end keeps its time, so the rounding can only add hours, never take them away: correcting a record must not quietly shorten cover somebody is relying on.
- **Correcting is not gated on payment.** The dates say when somebody is covered, not what they paid, so they sit outside the guard that protects price, reference and payment method on a paid invoice. The correction is wanted most often precisely because the money already landed: settled in March, recorded in April, dated from the day the manager got to it.
- **A bundled insurance invoice still runs from today**, whatever start date the plan beside it was given: it is a second plan being sold now, and dating it from a backfilled training period would hand out a year of cover that has already half run out.
- **Re-raising a membership with a different start date moves the invoice it reuses**, and the Add panel therefore sends the date only when a manager actually sets one — including forgetting a date that was typed and then abandoned. A panel that always sent its "today" prefill would drag a deliberately backdated invoice forward the next time somebody opened it to fix a student number.

## Anything anyone will feel

Nothing goes out and nothing breaks mid-rollout. Two things to know: shortening live cover by correcting its start is felt by the member even though the invoice itself did not change, so the dialog states the new end date before the save and the agent skill tells an agent to report what it moved. And the date-arithmetic fix moves the end instant of *future* yearly memberships by up to an hour; memberships already in the database are untouched.

## Commits

1. The feature.
2. Fixes from a first review: Postgres spells a timestamp `+00:00` where this code writes `Z`, so two comparisons read one instant as two different values (a pointless write on every re-raise, and a phantom entry in the invoice audit log). `sameInstant` is the rule, and both fixtures that hid it now carry the spelling Postgres actually returns.
3. Fixes from three independent reviews: the calendar-day arithmetic above; the Add panel keeping an abandoned start date across Close/reopen and across switching plans; `setMembershipStart` reporting success when its UPDATE matched no row; and the row dialog explaining a disabled Save and announcing its busy state.

## Checks

`bun run lint`, `bun run typecheck`, `bun run test` (2583 passing) and `bun run build` all green locally. New coverage includes the DST boundary on both the raise and the correction, the never-shortens property, the leap-year behaviour pinned as intended rather than accidental, `create_membership`'s `422` at the HTTP dispatch, and the Add panel's abandoned-date cases. Every review finding is pinned by a test that fails without its fix.

Docs updated in the same change: `docs/memberships.md` (new "Setting the day yearly cover starts"), `docs/database.md`, `docs/manager-agent-api.md` and the manager agent skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EMFguCEgGRw1E9FQd1nFh