### PR TITLE
Add the guardian link so a parent can hold several kids' records

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -186,9 +186,16 @@ top-up, so a repeat offers "Stop repeating" instead. Cancel keeps the record.
    (see "Security headers" in `CLAUDE.md`). It keeps its own
    `Cache-Control: private, max-age=300`, which is what a polling calendar client
    wants.
-5. **"Member" means paid.** Members-only visibility keys off an active, non-trial
-   membership with a price above zero (mirroring `deriveLifecycleStatus`), via the
-   `has_active_paid_membership` helper used in RLS.
+5. **"Member" means paid, and it counts a parent's children.** Members-only
+   visibility keys off an active, non-trial membership with a price above zero,
+   via the `has_active_paid_membership` helper used in RLS. That helper answers
+   yes for the person **or any of their dependants**
+   (`profiles.guardian_user_id`), so a parent who does not train still gets the
+   class times their child's membership pays for. It therefore **no longer
+   mirrors `deriveLifecycleStatus`**, which still counts only a person's own
+   memberships: a guardian sees the members-only calendar without the funnel
+   calling them a member. See `docs/memberships.md`, "Staying a member through
+   the break".
 6. **A generated date is a copy of the entry**, including who can see it and the
    invite-only badge. Nothing about a repeat is hardcoded.
 7. **Times.** A repeat's time of day is local to the club (Australia/Sydney); every

--- a/docs/database.md
+++ b/docs/database.md
@@ -647,8 +647,13 @@ members-only entries and get them in their personal calendar feed. See
 
 **`has_active_paid_membership(_user_id uuid) → boolean`** — SECURITY DEFINER SQL
 helper (`SET search_path = ''`) used by the events RLS policy: true when the
-person has an `active` membership whose plan `kind <> 'trial'` and whose
-`price_cents > 0`, mirroring `deriveLifecycleStatus`. EXECUTE is revoked from
+person **or any of their dependants** (`profiles.guardian_user_id`) has an
+`active` membership whose plan `kind <> 'trial'` and whose `price_cents > 0`.
+The dependant half is what gets a parent who does not train into the
+members-only calendar their child's membership pays for
+(`20260827000000_household_guardian_link.sql`), and it is why this **no longer
+mirrors `deriveLifecycleStatus`**, which still counts only a person's own
+memberships. EXECUTE is revoked from
 PUBLIC/anon and granted to `authenticated` (it is evaluated inside RLS as the
 querying role) + `service_role`. It is acknowledged in
 `supabase/lint/advisors-allowlist.txt` for the same reason as `has_role`.

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -311,11 +311,13 @@ cent. `docs/blog.md` has always said so; this file disagreed with it.
 
 **The helper also answers for a person's dependants.** A parent who does not
 train holds no membership of their own, so without that they would be shut out
-of the class calendar they are paying for. See `docs/waivers.md` on household
-accounts. It is the one place the "an active paid membership" rule reaches past
-the person being asked about, and it is deliberately NOT mirrored in
-`deriveLifecycleStatus` or `syncMemberRole` — a guardian is not themself a
-member, and the funnel phase should not say they are.
+of the class calendar they are paying for. It is the one place the "an active
+paid membership" rule reaches past the person being asked about, and it is
+deliberately NOT mirrored in `deriveLifecycleStatus` or `syncMemberRole` — a
+guardian is not themself a member, and the funnel phase should not say they are.
+
+Nobody has a dependant yet: `profiles.guardian_user_id` exists but nothing
+writes it, so today this sentence describes a rule with no rows to apply it to.
 
 That helper's **name is now a leftover**: it never read `paid_at`, and since
 `active` means authorised rather than paid, what it actually asks is "do they

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -299,9 +299,23 @@ hand.
 
 **Members-only access is not gated on the `member` role.** It is gated live by
 the `has_active_paid_membership` SQL helper — an active, non-`trial`,
-`price_cents > 0` membership — which the RLS policies on the calendar and blog
-comments call directly. So the moment a membership is cancelled, access closes,
-with no role change involved.
+`price_cents > 0` membership — which the `calendar_events` RLS policy calls
+directly. So the moment a membership is cancelled, access closes, with no role
+change involved.
+
+**It is the calendar, and only the calendar.** This paragraph used to say the
+blog comment policy called the helper too. It never has: `Signed-in non-blocked
+users can comment` checks identity and block status and nothing else, so any
+signed-in person may comment whether or not they have ever paid the club a
+cent. `docs/blog.md` has always said so; this file disagreed with it.
+
+**The helper also answers for a person's dependants.** A parent who does not
+train holds no membership of their own, so without that they would be shut out
+of the class calendar they are paying for. See `docs/waivers.md` on household
+accounts. It is the one place the "an active paid membership" rule reaches past
+the person being asked about, and it is deliberately NOT mirrored in
+`deriveLifecycleStatus` or `syncMemberRole` — a guardian is not themself a
+member, and the funnel phase should not say they are.
 
 That helper's **name is now a leftover**: it never read `paid_at`, and since
 `active` means authorised rather than paid, what it actually asks is "do they

--- a/supabase/migrations/20260827000000_household_guardian_link.sql
+++ b/supabase/migrations/20260827000000_household_guardian_link.sql
@@ -33,8 +33,19 @@
 -- ---------- the guardian link ----------
 
 ALTER TABLE public.profiles
-  ADD COLUMN IF NOT EXISTS guardian_user_id UUID
-    REFERENCES public.profiles(user_id) ON DELETE RESTRICT;
+  ADD COLUMN IF NOT EXISTS guardian_user_id UUID;
+
+-- The foreign key is added separately and re-asserted, NOT inlined above.
+-- `ADD COLUMN IF NOT EXISTS ... REFERENCES ...` skips the whole clause when the
+-- column already exists, so a first attempt that half-applied through Lovable's
+-- SQL editor would leave a column with no referential integrity and report
+-- success. Same reasoning as the CHECK and the index below.
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_guardian_user_id_fkey;
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_guardian_user_id_fkey
+    FOREIGN KEY (guardian_user_id) REFERENCES public.profiles(user_id)
+    ON DELETE RESTRICT;
 
 COMMENT ON COLUMN public.profiles.guardian_user_id IS
   'The account holder responsible for this person. NOT NULL means they are a '
@@ -49,7 +60,8 @@ COMMENT ON COLUMN public.profiles.guardian_user_id IS
 -- books must fail LOUDLY rather than take those children's waivers, memberships
 -- and attendance with it. The knock-on is intended: deleting a parent's auth
 -- user is now refused until a manager has dealt with the children first.
--- docs/erasing-personal-data.md picks this up (issue #107).
+-- Nothing documents that remedy yet: #107 adds it to
+-- docs/erasing-personal-data.md, which today says nothing about the case.
 
 -- Nobody is their own guardian. One level only — that a dependant may not
 -- itself BE a guardian is enforced in the server function that creates one, not
@@ -75,10 +87,16 @@ CREATE INDEX IF NOT EXISTS profiles_guardian_user_id_idx
 -- locked out of the members-only calendar and blog while paying for a child who
 -- was not. They need the class times more than the child does.
 --
--- This is the ONLY change needed for that, because four surfaces already call
--- this one function: the members-only calendar policy (20260802000000), the
--- blog comment gate, src/lib/calendar.functions.ts and the subscribable ICS feed
+-- This is the ONLY change needed for that, because all THREE callers of this
+-- function go through it: the members-only calendar_events SELECT policy
+-- (20260802000000), src/lib/calendar.functions.ts and the subscribable ICS feed
 -- at src/routes/api/calendar/$token.ts.
+--
+-- All three are the calendar, and that is the whole of what this buys. The blog
+-- does NOT gate on membership: `Signed-in non-blocked users can comment`
+-- (20260802000000) checks identity and block status only, so any signed-in
+-- person could already comment and a guardian gains nothing there.
+-- docs/memberships.md claimed otherwise and is corrected in this change.
 --
 -- The caller-scoping guard from 20260820000000_scope_role_helpers_to_caller.sql
 -- is UNCHANGED and still load-bearing. The question this answers is still "about
@@ -127,6 +145,15 @@ $$;
 -- already is. Same belt-and-braces as 20260820000000.
 REVOKE EXECUTE ON FUNCTION public.has_active_paid_membership(UUID) FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.has_active_paid_membership(UUID) TO authenticated, service_role;
+
+-- ⚠️ This deliberately diverges from deriveLifecycleStatus (src/lib/validation.ts)
+-- and syncMemberRole (src/lib/membership.functions.ts), which still count only a
+-- person's OWN memberships. So once dependants exist, a guardian holds live
+-- members-only access while the manager directory and the agent API's list_users
+-- still label them `lead` or `lapsed` with no `member` role. That is a real
+-- inconsistency and it is not reachable yet: nobody has a guardian until #105
+-- creates the first one. #107 reconciles the two, and until then this comment is
+-- the record that the gap is known rather than missed.
 
 -- No grant changes anywhere else, so supabase/lint/client-grants-expected.txt
 -- needs no edit: profiles holds nothing for anon or authenticated (everything

--- a/supabase/migrations/20260827000000_household_guardian_link.sql
+++ b/supabase/migrations/20260827000000_household_guardian_link.sql
@@ -26,9 +26,16 @@
 --      shouldCreateUser: false). That is application behaviour, not schema —
 --      nothing here depends on the address's shape.
 --
--- NOTHING READS THIS COLUMN YET. This migration is deliberately alone in its
--- pull request (docs/database-changes.md): additive schema goes live before the
--- code that needs it, so the currently-deployed app keeps working in the gap.
+-- NO APPLICATION CODE READS THIS COLUMN YET, and no row can carry a non-null
+-- value until #105 creates the first dependant, so applying this changes nothing
+-- anybody can observe. Be precise about that rather than claiming more: the
+-- helper rewritten at the bottom of THIS file does read guardian_user_id, on
+-- every authenticated calendar access, from the moment this is applied. It is a
+-- no-op because the column is empty, not because nothing consults it.
+--
+-- The migration is still deliberately alone in its pull request
+-- (docs/database-changes.md): additive schema goes live before the code that
+-- needs it, so the currently-deployed app keeps working in the gap.
 
 -- ---------- the guardian link ----------
 
@@ -157,7 +164,10 @@ GRANT EXECUTE ON FUNCTION public.has_active_paid_membership(UUID) TO authenticat
 
 -- No grant changes anywhere else, so supabase/lint/client-grants-expected.txt
 -- needs no edit: profiles holds nothing for anon or authenticated (everything
--- goes through service-role server functions), and the two RLS policies that
--- call the function above call it unchanged.
+-- goes through service-role server functions), and the ONE RLS policy that
+-- calls the function above -- `Paid members can read members-only events` on
+-- calendar_events -- calls it unchanged. (That policy has been dropped and
+-- re-created twice under the same name, by 20260730113925 and 20260802000000,
+-- which makes it look like several in a grep. It is one.)
 
 NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260827000000_household_guardian_link.sql
+++ b/supabase/migrations/20260827000000_household_guardian_link.sql
@@ -1,0 +1,136 @@
+-- Household: a person can be a DEPENDANT of another person.
+--
+-- The club takes children, and a parent has one email address. Until now the
+-- site made that impossible to record: a person IS an email (docs/waivers.md
+-- rule 1, enforced by auth's unique email), so a second child signed on the
+-- same parent address resolved to the FIRST child's person record. The second
+-- waiver filed against the wrong child, approving it overwrote that child's
+-- name, date of birth and medical notes, and the second child never got a free
+-- trial. Silently, with no error on any screen. See issue #102.
+--
+-- The fix keeps a dependant an ORDINARY person: an ordinary auth.users row and
+-- an ordinary profiles row. That is the whole point of this shape — every table
+-- that keys on a person (waivers, memberships, session_checkins, notifications,
+-- code_of_conduct_acceptances, user_roles, and the storage.objects waiver-PDF
+-- policies) keeps working untouched, because a child is a person like any other.
+-- Only two things mark them:
+--
+--   1. guardian_user_id below, the ONLY discriminator. It lives in `public` so
+--      RLS and every server function ask the question directly, rather than
+--      sniffing an email string to decide.
+--   2. Their auth.users row carries a reserved, non-deliverable address and a
+--      permanent ban. auth.users.email is unique and Supabase will not create a
+--      user without one, so a dependant gets a generated address in a subdomain
+--      the club never routes mail for. Never printed, never sent to, and the
+--      ban means it can never sign in even if guessed (/auth already passes
+--      shouldCreateUser: false). That is application behaviour, not schema —
+--      nothing here depends on the address's shape.
+--
+-- NOTHING READS THIS COLUMN YET. This migration is deliberately alone in its
+-- pull request (docs/database-changes.md): additive schema goes live before the
+-- code that needs it, so the currently-deployed app keeps working in the gap.
+
+-- ---------- the guardian link ----------
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS guardian_user_id UUID
+    REFERENCES public.profiles(user_id) ON DELETE RESTRICT;
+
+COMMENT ON COLUMN public.profiles.guardian_user_id IS
+  'The account holder responsible for this person. NOT NULL means they are a '
+  'dependant: no login of their own, and every email about them goes to the '
+  'guardian instead. NULL means an ordinary account holder, which is everyone '
+  'who existed before this column. Compare guardian_name/guardian_email, which '
+  'are contact details promoted from a waiver and name nobody in particular; '
+  'this is a real person record in this table.';
+
+-- RESTRICT, deliberately, and NOT the CASCADE that profiles.user_id itself uses
+-- against auth.users. A parent deleted while their children are still on the
+-- books must fail LOUDLY rather than take those children's waivers, memberships
+-- and attendance with it. The knock-on is intended: deleting a parent's auth
+-- user is now refused until a manager has dealt with the children first.
+-- docs/erasing-personal-data.md picks this up (issue #107).
+
+-- Nobody is their own guardian. One level only — that a dependant may not
+-- itself BE a guardian is enforced in the server function that creates one, not
+-- here: a depth check would need a trigger, and the rule is cheap to hold at the
+-- single call site that writes this column.
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_guardian_not_self;
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_guardian_not_self
+    CHECK (guardian_user_id IS NULL OR guardian_user_id <> user_id);
+
+-- Partial: the overwhelming majority of rows are account holders and will never
+-- match, so the index only carries the dependants. Supports "who are this
+-- person's children", which the account page, the manager household card and
+-- the helper below all ask.
+CREATE INDEX IF NOT EXISTS profiles_guardian_user_id_idx
+  ON public.profiles (guardian_user_id)
+  WHERE guardian_user_id IS NOT NULL;
+
+-- ---------- members-only access reaches a parent through their child ----------
+--
+-- A parent who does not train holds no membership, so before this they were
+-- locked out of the members-only calendar and blog while paying for a child who
+-- was not. They need the class times more than the child does.
+--
+-- This is the ONLY change needed for that, because four surfaces already call
+-- this one function: the members-only calendar policy (20260802000000), the
+-- blog comment gate, src/lib/calendar.functions.ts and the subscribable ICS feed
+-- at src/routes/api/calendar/$token.ts.
+--
+-- The caller-scoping guard from 20260820000000_scope_role_helpers_to_caller.sql
+-- is UNCHANGED and still load-bearing. The question this answers is still "about
+-- MYSELF" — a signed-in person may not ask it about anyone else — it is only the
+-- ANSWER that now consults rows belonging to people they are responsible for.
+-- Service-role callers still have a NULL auth.uid() and may still ask about
+-- anybody, which the digest, the agent API and the calendar feed all rely on.
+--
+-- Still SELECT EXISTS(...), so still never NULL: that is a documented contract
+-- (CLAUDE.md's RPC-nullability note and src/lib/supabase-rpc.ts) and the reason
+-- this function needs no wrapper. Still SET search_path = '' for advisor
+-- function_search_path_mutable.
+CREATE OR REPLACE FUNCTION public.has_active_paid_membership(_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    (
+      (SELECT auth.uid()) IS NULL
+      OR _user_id = (SELECT auth.uid())
+    )
+    AND EXISTS (
+      SELECT 1
+      FROM public.memberships m
+      JOIN public.membership_plans p ON p.id = m.plan_id
+      WHERE m.status = 'active'
+        AND p.kind <> 'trial'
+        AND m.price_cents > 0
+        AND (
+          m.user_id = _user_id
+          -- ...or the membership belongs to one of their dependants.
+          OR m.user_id IN (
+            SELECT d.user_id
+            FROM public.profiles d
+            WHERE d.guardian_user_id = _user_id
+          )
+        )
+    )
+$$;
+
+-- CREATE OR REPLACE keeps the existing ACL, so these restate intent next to the
+-- code they protect and make a from-scratch replay land where the live database
+-- already is. Same belt-and-braces as 20260820000000.
+REVOKE EXECUTE ON FUNCTION public.has_active_paid_membership(UUID) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.has_active_paid_membership(UUID) TO authenticated, service_role;
+
+-- No grant changes anywhere else, so supabase/lint/client-grants-expected.txt
+-- needs no edit: profiles holds nothing for anon or authenticated (everything
+-- goes through service-role server functions), and the two RLS policies that
+-- call the function above call it unchanged.
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Closes #103. First of five under #102.

**Schema only. No application code reads the new column yet**, and no row can carry a non-null value until #105 creates the first dependant. Precisely: the helper rewritten at the bottom of the file *does* read `guardian_user_id`, on every authenticated calendar access, from the moment this is applied — it is a no-op because the column is empty, not because nothing consults it. That distinction is the whole safety argument, so it is stated in the file rather than glossed.

## ⚠️ SQL waiting to be applied — approving this PR approves the schema change

Per `docs/database-changes.md`: there is one database and no staging tier, so applying **is** a production change and nothing runs until you approve. In full, `supabase/migrations/20260827000000_household_guardian_link.sql` does four things:

1. **Adds `profiles.guardian_user_id UUID REFERENCES public.profiles(user_id) ON DELETE RESTRICT`**, nullable, with a `COMMENT`. Every existing row keeps `NULL` and is therefore an ordinary account holder — no backfill, no behaviour change for anyone on file today.
2. **Adds `CHECK (guardian_user_id IS NULL OR guardian_user_id <> user_id)`** so nobody is their own guardian.
3. **Adds a partial index** on the column, `WHERE guardian_user_id IS NOT NULL`.
4. **Replaces `public.has_active_paid_membership(UUID)`** so it also matches a membership held by one of the person's dependants. Body only — same signature, same grants, still `SECURITY DEFINER`, still `SET search_path = ''`, still `SELECT EXISTS(...)` so still never NULL.

No `DROP`, no `TRUNCATE`, no rename, no grant change.

## Why

The club takes children, and a parent has one email address. The site made that impossible to record, and did so destructively rather than by refusing. A person *is* an email (`docs/waivers.md` rule 1, enforced by auth's unique email), so a second child signed on the same parent address resolved to the **first** child's person record: the waiver filed against the wrong child, approving it overwrote that child's name, date of birth and medical notes, and the second child never got a free trial. No error, on any screen. #102 has the full account.

`guardian_user_id` is the only discriminator, and it keeps a dependant an **ordinary person** — an ordinary auth user, an ordinary profile. That is what lets `waivers`, `memberships`, `session_checkins`, `notifications`, `code_of_conduct_acceptances`, `user_roles` and the `storage.objects` waiver-PDF policies all keep working untouched.

**`ON DELETE RESTRICT`, deliberately, and not the `CASCADE` that `profiles.user_id` itself uses against `auth.users`.** Deleting a parent while their children are on the books must fail loudly rather than take those children's waivers, memberships and attendance with it.

**The helper rewrite is the members-only access decision.** A parent who does not train holds no membership, so they were locked out of the class calendar their child's membership pays for. There is **one** RLS policy and two server-side callers, and all three are the calendar. The caller-scoping guard from `20260820000000_scope_role_helpers_to_caller.sql` is **unchanged**: the question is still "about myself", it is only the answer that now consults rows belonging to people I am responsible for.

## What a member or manager sees differently today

**Nothing.** No row has a guardian, so the helper returns the same answer for every existing person.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (153 files, 2583 tests) and `bun run build` green. **CI, e2e and Supabase lint all green** — the last replays every migration from scratch and runs the Advisors plus the client-grants checker.

The SQL was applied to a real Postgres 16 with the client roles, an `auth.uid()` stand-in and the tables it touches:

| Check | Result |
| --- | --- |
| Parent with no membership, child holds a paid one | covered ✅ |
| Unrelated person with no membership | not covered ✅ |
| Signed-in parent asking about a stranger | refused ✅ |
| Setting yourself as your own guardian | rejected by the check ✅ |
| Deleting a parent who still has a child | refused, and the whole statement rolls back atomically ✅ |
| Applying the file twice, and onto a half-applied state | converges to identical `\d profiles` ✅ |
| Function ACL after the replace | `authenticated`, `service_role` only ✅ |
| `TRUNCATE public.profiles` without `CASCADE` | succeeds — Postgres exempts self-referencing FKs ✅ |

**No-regression proof.** Every existing row has `guardian_user_id IS NULL`, so `d.guardian_user_id = _user_id` is `NULL` (never `TRUE`) for *any* input including `NULL` itself, and the added `OR` branch can never fire. Checked empirically as well: old and new bodies side by side over 200 profiles × 500 mixed memberships × three caller shapes — **0 mismatches in 600 comparisons**.

## Known and accepted

- **~30% heavier per call** (285ms → 370ms over 20k rows), because `SECURITY DEFINER` functions are never inlined and the RLS filter is per-row. That per-row pattern **pre-dates this PR**; this compounds it mildly. Both app callers invoke the RPC once on the service-role client and filter in application code, so only a direct browser query against `calendar_events` would exercise the hot path. Worth revisiting only if that ever happens at scale. Postgres already hashes the uncorrelated `IN (subquery)` into a hashed SubPlan, so a `JOIN`/`EXISTS` rewrite would buy nothing.
- **The partial index will not appear in `EXPLAIN` for a while** — a seq scan is correctly cheaper until roughly 50k profiles.
- **The `CHECK` blocks direct self-reference only**, not a longer cycle. "One level" is enforced at the single server call site in #105, per #102's sharp-edges list. Deliberate, and noted here because the schema is frozen in production before that code exists.
- **A guardian will read as `lead`/`lapsed` in `/manager/users`** while holding live members-only access, because `deriveLifecycleStatus` and `syncMemberRole` still count only a person's own memberships. Not reachable until #105, and #107 reconciles it. Confirmed **not** a check-in risk: coverage resolves strictly against the person's own `memberships` rows, so a guardian at the door correctly shows "No cover".

## Deliberately not in this PR

- **No `client-grants-expected.txt` edit** — a new column inherits the table ACL, and `profiles` holds nothing for `anon`/`authenticated` (`20260728150000`). Same reasoning as `20260806000000_profile_kit_sizes.sql` and `20260806020000_profile_martial_arts_experience.sql`.
- **No `docs/database.md` profiles-column entry** — `docs/database-changes.md` aligns the schema reference in the code PR that introduces the usage (#104). `gi_size`, `belt_size` and `martial_arts_experience` all landed that way.
- **No `schema-contract.test.ts` pin** — `types.ts` is generated from the live schema, so the column cannot be pinned until it is applied and Lovable regenerates. (`RequireColumns` is a subset check, so nothing goes red meanwhile.)

## After approval, before merge

Apply → record in `supabase_migrations.schema_migrations` (version `20260827000000`, name `household_guardian_link`) → verify against `information_schema.columns` and `pg_proc` → `NOTIFY pgrst, 'reload schema'` → merge. #104 does not start until that column exists in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzoqG3im9Qj3ygymp6qWan