### PR TITLE
Restore the household migration and its docs, dropped by a Lovable merge

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -186,9 +186,16 @@ top-up, so a repeat offers "Stop repeating" instead. Cancel keeps the record.
    (see "Security headers" in `CLAUDE.md`). It keeps its own
    `Cache-Control: private, max-age=300`, which is what a polling calendar client
    wants.
-5. **"Member" means paid.** Members-only visibility keys off an active, non-trial
-   membership with a price above zero (mirroring `deriveLifecycleStatus`), via the
-   `has_active_paid_membership` helper used in RLS.
+5. **"Member" means paid, and it counts a parent's children.** Members-only
+   visibility keys off an active, non-trial membership with a price above zero,
+   via the `has_active_paid_membership` helper used in RLS. That helper answers
+   yes for the person **or any of their dependants**
+   (`profiles.guardian_user_id`), so a parent who does not train still gets the
+   class times their child's membership pays for. It therefore **no longer
+   mirrors `deriveLifecycleStatus`**, which still counts only a person's own
+   memberships: a guardian sees the members-only calendar without the funnel
+   calling them a member. See `docs/memberships.md`, "Staying a member through
+   the break".
 6. **A generated date is a copy of the entry**, including who can see it and the
    invite-only badge. Nothing about a repeat is hardcoded.
 7. **Times.** A repeat's time of day is local to the club (Australia/Sydney); every

--- a/docs/database.md
+++ b/docs/database.md
@@ -647,8 +647,13 @@ members-only entries and get them in their personal calendar feed. See
 
 **`has_active_paid_membership(_user_id uuid) → boolean`** — SECURITY DEFINER SQL
 helper (`SET search_path = ''`) used by the events RLS policy: true when the
-person has an `active` membership whose plan `kind <> 'trial'` and whose
-`price_cents > 0`, mirroring `deriveLifecycleStatus`. EXECUTE is revoked from
+person **or any of their dependants** (`profiles.guardian_user_id`) has an
+`active` membership whose plan `kind <> 'trial'` and whose `price_cents > 0`.
+The dependant half is what gets a parent who does not train into the
+members-only calendar their child's membership pays for
+(`20260827000000_household_guardian_link.sql`), and it is why this **no longer
+mirrors `deriveLifecycleStatus`**, which still counts only a person's own
+memberships. EXECUTE is revoked from
 PUBLIC/anon and granted to `authenticated` (it is evaluated inside RLS as the
 querying role) + `service_role`. It is acknowledged in
 `supabase/lint/advisors-allowlist.txt` for the same reason as `has_role`.

--- a/docs/memberships.md
+++ b/docs/memberships.md
@@ -299,9 +299,25 @@ hand.
 
 **Members-only access is not gated on the `member` role.** It is gated live by
 the `has_active_paid_membership` SQL helper — an active, non-`trial`,
-`price_cents > 0` membership — which the RLS policies on the calendar and blog
-comments call directly. So the moment a membership is cancelled, access closes,
-with no role change involved.
+`price_cents > 0` membership — which the `calendar_events` RLS policy calls
+directly. So the moment a membership is cancelled, access closes, with no role
+change involved.
+
+**It is the calendar, and only the calendar.** This paragraph used to say the
+blog comment policy called the helper too. It never has: `Signed-in non-blocked
+users can comment` checks identity and block status and nothing else, so any
+signed-in person may comment whether or not they have ever paid the club a
+cent. `docs/blog.md` has always said so; this file disagreed with it.
+
+**The helper also answers for a person's dependants.** A parent who does not
+train holds no membership of their own, so without that they would be shut out
+of the class calendar they are paying for. It is the one place the "an active
+paid membership" rule reaches past the person being asked about, and it is
+deliberately NOT mirrored in `deriveLifecycleStatus` or `syncMemberRole` — a
+guardian is not themself a member, and the funnel phase should not say they are.
+
+Nobody has a dependant yet: `profiles.guardian_user_id` exists but nothing
+writes it, so today this sentence describes a rule with no rows to apply it to.
 
 That helper's **name is now a leftover**: it never read `paid_at`, and since
 `active` means authorised rather than paid, what it actually asks is "do they

--- a/supabase/migrations/20260827000000_household_guardian_link.sql
+++ b/supabase/migrations/20260827000000_household_guardian_link.sql
@@ -1,0 +1,173 @@
+-- Household: a person can be a DEPENDANT of another person.
+--
+-- The club takes children, and a parent has one email address. Until now the
+-- site made that impossible to record: a person IS an email (docs/waivers.md
+-- rule 1, enforced by auth's unique email), so a second child signed on the
+-- same parent address resolved to the FIRST child's person record. The second
+-- waiver filed against the wrong child, approving it overwrote that child's
+-- name, date of birth and medical notes, and the second child never got a free
+-- trial. Silently, with no error on any screen. See issue #102.
+--
+-- The fix keeps a dependant an ORDINARY person: an ordinary auth.users row and
+-- an ordinary profiles row. That is the whole point of this shape — every table
+-- that keys on a person (waivers, memberships, session_checkins, notifications,
+-- code_of_conduct_acceptances, user_roles, and the storage.objects waiver-PDF
+-- policies) keeps working untouched, because a child is a person like any other.
+-- Only two things mark them:
+--
+--   1. guardian_user_id below, the ONLY discriminator. It lives in `public` so
+--      RLS and every server function ask the question directly, rather than
+--      sniffing an email string to decide.
+--   2. Their auth.users row carries a reserved, non-deliverable address and a
+--      permanent ban. auth.users.email is unique and Supabase will not create a
+--      user without one, so a dependant gets a generated address in a subdomain
+--      the club never routes mail for. Never printed, never sent to, and the
+--      ban means it can never sign in even if guessed (/auth already passes
+--      shouldCreateUser: false). That is application behaviour, not schema —
+--      nothing here depends on the address's shape.
+--
+-- NO APPLICATION CODE READS THIS COLUMN YET, and no row can carry a non-null
+-- value until #105 creates the first dependant, so applying this changes nothing
+-- anybody can observe. Be precise about that rather than claiming more: the
+-- helper rewritten at the bottom of THIS file does read guardian_user_id, on
+-- every authenticated calendar access, from the moment this is applied. It is a
+-- no-op because the column is empty, not because nothing consults it.
+--
+-- The migration is still deliberately alone in its pull request
+-- (docs/database-changes.md): additive schema goes live before the code that
+-- needs it, so the currently-deployed app keeps working in the gap.
+
+-- ---------- the guardian link ----------
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS guardian_user_id UUID;
+
+-- The foreign key is added separately and re-asserted, NOT inlined above.
+-- `ADD COLUMN IF NOT EXISTS ... REFERENCES ...` skips the whole clause when the
+-- column already exists, so a first attempt that half-applied through Lovable's
+-- SQL editor would leave a column with no referential integrity and report
+-- success. Same reasoning as the CHECK and the index below.
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_guardian_user_id_fkey;
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_guardian_user_id_fkey
+    FOREIGN KEY (guardian_user_id) REFERENCES public.profiles(user_id)
+    ON DELETE RESTRICT;
+
+COMMENT ON COLUMN public.profiles.guardian_user_id IS
+  'The account holder responsible for this person. NOT NULL means they are a '
+  'dependant: no login of their own, and every email about them goes to the '
+  'guardian instead. NULL means an ordinary account holder, which is everyone '
+  'who existed before this column. Compare guardian_name/guardian_email, which '
+  'are contact details promoted from a waiver and name nobody in particular; '
+  'this is a real person record in this table.';
+
+-- RESTRICT, deliberately, and NOT the CASCADE that profiles.user_id itself uses
+-- against auth.users. A parent deleted while their children are still on the
+-- books must fail LOUDLY rather than take those children's waivers, memberships
+-- and attendance with it. The knock-on is intended: deleting a parent's auth
+-- user is now refused until a manager has dealt with the children first.
+-- Nothing documents that remedy yet: #107 adds it to
+-- docs/erasing-personal-data.md, which today says nothing about the case.
+
+-- Nobody is their own guardian. One level only — that a dependant may not
+-- itself BE a guardian is enforced in the server function that creates one, not
+-- here: a depth check would need a trigger, and the rule is cheap to hold at the
+-- single call site that writes this column.
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_guardian_not_self;
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_guardian_not_self
+    CHECK (guardian_user_id IS NULL OR guardian_user_id <> user_id);
+
+-- Partial: the overwhelming majority of rows are account holders and will never
+-- match, so the index only carries the dependants. Supports "who are this
+-- person's children", which the account page, the manager household card and
+-- the helper below all ask.
+CREATE INDEX IF NOT EXISTS profiles_guardian_user_id_idx
+  ON public.profiles (guardian_user_id)
+  WHERE guardian_user_id IS NOT NULL;
+
+-- ---------- members-only access reaches a parent through their child ----------
+--
+-- A parent who does not train holds no membership, so before this they were
+-- locked out of the members-only calendar and blog while paying for a child who
+-- was not. They need the class times more than the child does.
+--
+-- This is the ONLY change needed for that, because all THREE callers of this
+-- function go through it: the members-only calendar_events SELECT policy
+-- (20260802000000), src/lib/calendar.functions.ts and the subscribable ICS feed
+-- at src/routes/api/calendar/$token.ts.
+--
+-- All three are the calendar, and that is the whole of what this buys. The blog
+-- does NOT gate on membership: `Signed-in non-blocked users can comment`
+-- (20260802000000) checks identity and block status only, so any signed-in
+-- person could already comment and a guardian gains nothing there.
+-- docs/memberships.md claimed otherwise and is corrected in this change.
+--
+-- The caller-scoping guard from 20260820000000_scope_role_helpers_to_caller.sql
+-- is UNCHANGED and still load-bearing. The question this answers is still "about
+-- MYSELF" — a signed-in person may not ask it about anyone else — it is only the
+-- ANSWER that now consults rows belonging to people they are responsible for.
+-- Service-role callers still have a NULL auth.uid() and may still ask about
+-- anybody, which the digest, the agent API and the calendar feed all rely on.
+--
+-- Still SELECT EXISTS(...), so still never NULL: that is a documented contract
+-- (CLAUDE.md's RPC-nullability note and src/lib/supabase-rpc.ts) and the reason
+-- this function needs no wrapper. Still SET search_path = '' for advisor
+-- function_search_path_mutable.
+CREATE OR REPLACE FUNCTION public.has_active_paid_membership(_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    (
+      (SELECT auth.uid()) IS NULL
+      OR _user_id = (SELECT auth.uid())
+    )
+    AND EXISTS (
+      SELECT 1
+      FROM public.memberships m
+      JOIN public.membership_plans p ON p.id = m.plan_id
+      WHERE m.status = 'active'
+        AND p.kind <> 'trial'
+        AND m.price_cents > 0
+        AND (
+          m.user_id = _user_id
+          -- ...or the membership belongs to one of their dependants.
+          OR m.user_id IN (
+            SELECT d.user_id
+            FROM public.profiles d
+            WHERE d.guardian_user_id = _user_id
+          )
+        )
+    )
+$$;
+
+-- CREATE OR REPLACE keeps the existing ACL, so these restate intent next to the
+-- code they protect and make a from-scratch replay land where the live database
+-- already is. Same belt-and-braces as 20260820000000.
+REVOKE EXECUTE ON FUNCTION public.has_active_paid_membership(UUID) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.has_active_paid_membership(UUID) TO authenticated, service_role;
+
+-- ⚠️ This deliberately diverges from deriveLifecycleStatus (src/lib/validation.ts)
+-- and syncMemberRole (src/lib/membership.functions.ts), which still count only a
+-- person's OWN memberships. So once dependants exist, a guardian holds live
+-- members-only access while the manager directory and the agent API's list_users
+-- still label them `lead` or `lapsed` with no `member` role. That is a real
+-- inconsistency and it is not reachable yet: nobody has a guardian until #105
+-- creates the first one. #107 reconciles the two, and until then this comment is
+-- the record that the gap is known rather than missed.
+
+-- No grant changes anywhere else, so supabase/lint/client-grants-expected.txt
+-- needs no edit: profiles holds nothing for anon or authenticated (everything
+-- goes through service-role server functions), and the ONE RLS policy that
+-- calls the function above -- `Paid members can read members-only events` on
+-- calendar_events -- calls it unchanged. (That policy has been dropped and
+-- re-created twice under the same name, by 20260730113925 and 20260802000000,
+-- which makes it look like several in a grep. It is one.)
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Restores four files that a Lovable merge deleted from `main` about twenty minutes after #108 landed. Part of #102.

## What happened

`c1b3982` ("Fixed previewAuthStorage.ts lint") is a **merge commit**. Its second parent, `78f122c`, is a Lovable branch that forked from `main` *before* #108 merged, and the merge was resolved by taking that side. Four files went with it:

```
supabase/migrations/20260827000000_household_guardian_link.sql   (deleted, 173 lines)
docs/calendar.md      (my rule-5 correction reverted)
docs/database.md      (my has_active_paid_membership spec reverted)
docs/memberships.md   (my blog + dependants corrections reverted)
```

Nothing in the Lovable commit needed those deletions; it was fixing lint in `src/integrations/supabase/previewAuthStorage.ts`, at my request, because that file was failing `bun run lint` and holding `main` red.

## Why the migration one matters

**The SQL is applied and live.** The column, the self-FK, the `CHECK`, the partial index and the `has_active_paid_membership` rewrite are all in production, and `supabase_migrations.schema_migrations` carries version `20260827000000`. Deleting the file undid nothing in the database — it left the repo with no file for schema production is already running.

That is precisely the drift `docs/database-changes.md` exists to prevent, pointing the other way: **applied, with nothing here to show for it.** Two concrete consequences if it stayed deleted:

- The `supabase-lint` replay would stop covering it, so a from-scratch replay would build a schema that production no longer matches, and the grants and Advisors checks would run against the wrong shape.
- `check-migration-drift.py` compares files against the ledger. A ledger row with no file reports as "deleted or renamed here?", the same shape as the known `20260722131547` duplicate, so this would quietly blend into an existing acknowledged note.

## What this PR does

Restores all four files verbatim from `9a17a64`, the merge commit for #108. **Nothing of Lovable's is undone** — the diff re-adds those four files and touches nothing else. The `const timer` fix in `previewAuthStorage.ts` is intact and still lints clean.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (153 files, 2583 tests) and `bun run build` all green on this branch.

Re-confirmed against the live database after the deletion, so the restore matches reality:

| Live check | Result |
| --- | --- |
| `profiles.guardian_user_id` exists | yes |
| `profiles_guardian_user_id_fkey` delete action | `r` (RESTRICT) |
| `profiles_guardian_not_self` | present |
| `profiles_guardian_user_id_idx` | present |
| Helper carries the dependant branch, still `SECURITY DEFINER` | yes |
| Helper ACL | `authenticated`, `service_role` only |
| Ledger row `20260827000000` | present |
| New helper vs old rule, across all 9 people | **0 mismatches** |
| Live client grants | 18 live, 18 expected, 0 unexpected |

## Worth knowing for next time

This is a recurrence risk, not a one-off: Lovable merges long-lived branches into `main` and can resolve away commits that landed while its branch was open. Worth a look at `main` after any Lovable sync that follows a merge of ours, which is what caught this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzoqG3im9Qj3ygymp6qWan

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzoqG3im9Qj3ygymp6qWan)_