### PR TITLE
Open a person's record from their name in every manager list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -878,8 +878,8 @@ Then hold the change to this:
   you the timeout, the retry that carries the same `client_submission_id`, the
   "did it actually land?" confirm, and a failure panel that stays on screen with
   a button in it. Do not write another `setLoading(true) / catch / toast.error`
-  form. Also `StatusPill`, `SiteLayout` / `MemberLayout` / `KbLayout`, and
-  `components/ui/*`.
+  form. Also `StatusPill`, `UserLink`, `SiteLayout` / `MemberLayout` / `KbLayout`,
+  and `components/ui/*`.
 - **A toast is not a UI for anything that matters.** It auto-dismisses, it is
   easy to miss on a phone, and it leaves nothing to press. Use it for "saved",
   not for "your waiver did not go through".
@@ -935,6 +935,13 @@ Then hold the change to this:
   `aria-live="polite"` wiring `AuthPending` and `SubmitStatus` already have.
   Without it a screen-reader user gets no signal that a page started fetching
   or finished.
+- **A person's name in a manager's list is always a link to their record.**
+  Use **`components/site/UserLink`**, never a bare `<Link>` or plain text: it
+  carries the route, the always-visible underline (a hover-only one is invisible
+  on the phone most of this club's admin happens on), and the plain-text
+  fallback for a row with no account behind it, such as a lead who has only
+  registered interest. A name a manager cannot click sends them back to
+  `/manager/users` to search for the person already in front of them.
 - **Never lose someone's input.** A failed submit keeps the form filled and
   offers the retry. Ask for as little as possible in the first place, and prefill
   what we already know (the waiver does this with `getMyLatestWaiver`). Every

--- a/docs/knowledge-base.md
+++ b/docs/knowledge-base.md
@@ -294,7 +294,10 @@ comment gets: the commenter's own
 Both manager-facing views of the same feedback, the "Feedback" panel on
 `/manager/kb` and the agent API's `list_kb_comments`, show the full legal name
 instead, since a manager needs to identify who wrote a comment for moderation.
-That difference from the member-facing view is deliberate.
+That difference from the member-facing view is deliberate. On the panel the
+name is a link to the commenter's record, like every name in a manager's list,
+which is why that list carries the author's id and the member-facing one
+deliberately does not.
 
 A manager can moderate (resolve a thread, delete an abusive comment) but can
 never **rewrite** words attributed to somebody else. A comment feature people
@@ -424,7 +427,8 @@ What is here that the waiver template does not have:
   Restoring publishes the stored version, not what is in the editor, and the
   screen says so before it does.
 - **Feedback.** Open shared threads members left, quoted passage and all.
-  Private notes are never listed here. Replying happens on the article itself.
+  Private notes are never listed here. The commenter's name opens their record.
+  Replying happens on the article itself.
 
 Widening who can read an article (managers → members) asks first. Narrowing does
 not: it takes an article away from people, which is recoverable.

--- a/docs/waivers.md
+++ b/docs/waivers.md
@@ -552,7 +552,9 @@ step happens. See `docs/notifications.md` for the two items and how each clears.
 
 The manager waivers screen lists submissions newest first with the submitted
 name/email, date, template version, status badge (pending / active /
-superseded), the PDF, and Approve / Revoke approval. Approve = promote + unlock +
+superseded), the PDF, and Approve / Revoke approval. The submitted name opens
+the person who signed it: every name in a manager's list is a link to that
+person's record, through `components/site/UserLink`. Approve = promote + unlock +
 assign the trial (see rule 6). The applicant becomes a visitor.
 
 Approve asks first, in the app's own dialog (`useConfirm`), naming the three
@@ -563,8 +565,8 @@ Revoking is not gated: it flips the row back to pending and re-approving
 restores it, which is why the button no longer says "Unapprove". It never
 undid the email, the login or the trial, and the old label promised it did.
 
-For one person there is a user page (`/manager/users/:userId`, reached from the
-directory), which is where a review normally happens: the profile (the club's
+For one person there is a user page (`/manager/users/:userId`), which is where a
+review normally happens: the profile (the club's
 current record), their memberships, and every submission they ever made, newest
 first. Each submission is a collapsible panel holding the frozen submission in
 full, the signing record (IP + browser context), when it was approved and by

--- a/src/components/site/UserLink.test.tsx
+++ b/src/components/site/UserLink.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    to,
+    params,
+    children,
+    ...props
+  }: {
+    to: string;
+    params?: Record<string, string>;
+    children: React.ReactNode;
+  }) => (
+    <a
+      href={Object.entries(params ?? {}).reduce(
+        (path, [key, value]) => path.replace(`$${key}`, value),
+        to,
+      )}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+import { UserLink } from "./UserLink";
+
+describe("UserLink", () => {
+  it("opens the person's record from their name", () => {
+    render(<UserLink userId="u-1" name="Sam Lee" />);
+    const link = screen.getByRole("link", { name: "Sam Lee" });
+    expect(link).toHaveAttribute("href", "/manager/users/u-1");
+  });
+
+  // The bug this component was extracted for: half the manager tables printed
+  // the name as dead text, so a manager had to go back to the directory and
+  // search for the person they were already looking at.
+  it("is a link a phone can see, not one that waits for a hover", () => {
+    render(<UserLink userId="u-1" name="Sam Lee" />);
+    expect(screen.getByRole("link", { name: "Sam Lee" }).className).toContain("underline");
+  });
+
+  it("keeps the caller's own classes alongside its own", () => {
+    render(<UserLink userId="u-1" name="Sam Lee" className="font-medium" />);
+    expect(screen.getByRole("link", { name: "Sam Lee" }).className).toContain("font-medium");
+  });
+
+  it("prints the name as plain text when there is no record to open", () => {
+    render(<UserLink userId={null} name="Kim Tran" />);
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText("Kim Tran")).toBeInTheDocument();
+  });
+
+  it("still gives a nameless row something to click", () => {
+    render(<UserLink userId="u-2" name={null} fallback="Unknown" />);
+    expect(screen.getByRole("link", { name: "Unknown" })).toHaveAttribute(
+      "href",
+      "/manager/users/u-2",
+    );
+  });
+
+  // A profile saved with a space in the name field is not a name, and rendering
+  // it makes an invisible link out of the row a manager most needs to open.
+  it("treats a blank name as no name", () => {
+    render(<UserLink userId="u-3" name="   " fallback="Unknown" />);
+    expect(screen.getByRole("link", { name: "Unknown" })).toBeInTheDocument();
+  });
+
+  it("falls back to an em dash when there is neither a name nor a record", () => {
+    const { container } = render(<UserLink userId={null} name={null} />);
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(container).toHaveTextContent("—");
+  });
+});

--- a/src/components/site/UserLink.tsx
+++ b/src/components/site/UserLink.tsx
@@ -1,0 +1,45 @@
+import { Link } from "@tanstack/react-router";
+import { cn } from "@/lib/utils";
+
+/**
+ * A person's name in a manager's list, as the way in to their record.
+ *
+ * Every manager table shows names for the same reason: the name is the row a
+ * manager wants to open. Before this existed each table decided that for
+ * itself, so half of them linked and half printed the name as dead text, and a
+ * manager looking at a signed waiver had to go back to the directory and search
+ * for the same person by hand.
+ *
+ * The underline is permanent rather than on hover. Most of this club's admin
+ * happens on a phone between classes, where there is no hover, so a link that
+ * only reveals itself to a mouse is a link nobody can see.
+ *
+ * Not every row has a person behind it: an interest registration is a lead with
+ * no account yet, and a membership can outlive the account it was raised for.
+ * Those render as plain text, because a link to a page that does not exist is
+ * worse than no link.
+ */
+export function UserLink({
+  userId,
+  name,
+  fallback = "—",
+  className,
+}: {
+  userId: string | null | undefined;
+  name: string | null | undefined;
+  /** What to show when the row carries no name. */
+  fallback?: string;
+  className?: string;
+}) {
+  const label = name?.trim() ? name : fallback;
+  if (!userId) return <>{label}</>;
+  return (
+    <Link
+      to="/manager/users/$userId"
+      params={{ userId }}
+      className={cn("underline underline-offset-2 hover:no-underline", className)}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/src/lib/kb.functions.ts
+++ b/src/lib/kb.functions.ts
@@ -1167,6 +1167,11 @@ export const listManagerAnnotations = createServerFn({ method: "POST" })
 
     return annotations.map((a) => ({
       id: a.id,
+      // So the manager screen can open whoever wrote it. The member-facing
+      // `listAnnotations` deliberately ships no author id at all, for the
+      // reason stated there; this list is manager-only (`requireManagerViewer`
+      // above), and identifying a commenter is the whole point of it.
+      user_id: a.user_id,
       body: a.body,
       visibility: a.visibility,
       block_id: a.block_id,

--- a/src/lib/waiver.functions.ts
+++ b/src/lib/waiver.functions.ts
@@ -1725,6 +1725,10 @@ export const listWaivers = createServerFn({ method: "GET" })
     const statuses = deriveWaiverListStatuses(rows);
     return rows.map((row) => ({
       id: row.id,
+      // Who signed it, so the list's name column can open their record. The
+      // waiver holds the name AS SUBMITTED, which is the evidence and may not
+      // match the profile any more; the person behind it is still this one.
+      user_id: row.user_id,
       // The legal name as submitted, with the preferred name quoted in when
       // they gave one: managers see who signed AND what to call them.
       full_name: nameWithPreferred(row),

--- a/src/routes/_authenticated/manager.blog-comments.tsx
+++ b/src/routes/_authenticated/manager.blog-comments.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Pill } from "@/components/site/StatusPill";
+import { UserLink } from "@/components/site/UserLink";
 import { LoadFailure } from "@/components/site/LoadFailure";
 import { Loading } from "@/components/site/Loading";
 import { describeLoadError } from "@/lib/load-error";
@@ -229,7 +230,9 @@ function BlogCommentsPage() {
                       {c.parent_comment_id && (
                         <span className="mr-1 text-xs text-muted-foreground">↳ reply</span>
                       )}
-                      <div>{c.author_name}</div>
+                      <div>
+                        <UserLink userId={c.user_id} name={c.author_name} />
+                      </div>
                       {c.author_email && (
                         <div className="text-xs text-muted-foreground">{c.author_email}</div>
                       )}
@@ -336,7 +339,9 @@ function BlogCommentsPage() {
               <tbody>
                 {blocked.map((row) => (
                   <tr key={row.user_id} className="border-t">
-                    <td className="p-3">{row.name}</td>
+                    <td className="p-3">
+                      <UserLink userId={row.user_id} name={row.name} />
+                    </td>
                     <td className="p-3 text-muted-foreground">{row.email ?? "—"}</td>
                     <td className="p-3 text-muted-foreground">{row.reason ?? "—"}</td>
                     <td className="p-3 text-muted-foreground">{formatDateTime(row.blocked_at)}</td>

--- a/src/routes/_authenticated/manager.calendar.tsx
+++ b/src/routes/_authenticated/manager.calendar.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { LoadFailure } from "@/components/site/LoadFailure";
 import { Loading } from "@/components/site/Loading";
+import { UserLink } from "@/components/site/UserLink";
 import { describeLoadError } from "@/lib/load-error";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -848,7 +849,11 @@ function ManagerCalendarPage() {
                                 {rsvpRows.map((r) => (
                                   <li key={r.user_id} className="flex flex-wrap gap-2">
                                     <span className="font-medium">
-                                      {r.name || r.email || "Someone"}
+                                      <UserLink
+                                        userId={r.user_id}
+                                        name={r.name || r.email}
+                                        fallback="Someone"
+                                      />
                                     </span>
                                     {r.name && r.email && (
                                       <span className="text-muted-foreground">{r.email}</span>

--- a/src/routes/_authenticated/manager.check-in.tsx
+++ b/src/routes/_authenticated/manager.check-in.tsx
@@ -7,6 +7,7 @@ import { LoadFailure } from "@/components/site/LoadFailure";
 import { describeLoadError } from "@/lib/load-error";
 import { Input } from "@/components/ui/input";
 import { Pill } from "@/components/site/StatusPill";
+import { UserLink } from "@/components/site/UserLink";
 import { coverageClass, UNREAD_CLASS } from "@/lib/status-colours";
 import { cn } from "@/lib/utils";
 import { useAuth, useRoles } from "@/hooks/useAuth";
@@ -420,13 +421,7 @@ function CheckInPage() {
               {(board?.checkins ?? []).map((c) => (
                 <tr key={c.id} className="border-t">
                   <td className="px-3 py-2 font-medium">
-                    <Link
-                      className="hover:underline"
-                      to="/manager/users/$userId"
-                      params={{ userId: c.user_id }}
-                    >
-                      {c.name ?? "Unknown"}
-                    </Link>
+                    <UserLink userId={c.user_id} name={c.name} fallback="Unknown" />
                   </td>
                   <td className="px-3 py-2">
                     <div className="flex flex-wrap items-center gap-1">
@@ -494,13 +489,7 @@ function CheckInPage() {
               {matches.slice(0, MATCH_LIMIT).map((r) => (
                 <tr key={r.user_id} className="border-t">
                   <td className="px-3 py-2 font-medium">
-                    <Link
-                      className="hover:underline"
-                      to="/manager/users/$userId"
-                      params={{ userId: r.user_id }}
-                    >
-                      {r.name ?? "Unknown"}
-                    </Link>
+                    <UserLink userId={r.user_id} name={r.name} fallback="Unknown" />
                   </td>
                   <td className="px-3 py-2">
                     <div className="flex flex-wrap items-center gap-1">
@@ -583,13 +572,7 @@ function CheckInPage() {
                 <Fragment key={row.id}>
                   <tr className="border-t">
                     <td className="px-3 py-2 font-medium">
-                      <Link
-                        className="hover:underline"
-                        to="/manager/users/$userId"
-                        params={{ userId: row.user_id }}
-                      >
-                        {row.name ?? "Unknown"}
-                      </Link>
+                      <UserLink userId={row.user_id} name={row.name} fallback="Unknown" />
                     </td>
                     <td className="px-3 py-2">
                       {row.event_title ?? "Unknown class"}

--- a/src/routes/_authenticated/manager.kb.test.tsx
+++ b/src/routes/_authenticated/manager.kb.test.tsx
@@ -18,7 +18,26 @@ import type { ReactNode } from "react";
 vi.mock("@tanstack/react-router", () => ({
   createFileRoute: () => (opts: Record<string, unknown>) => opts,
   useNavigate: () => vi.fn(),
-  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+  Link: ({
+    to,
+    params,
+    children,
+    ...props
+  }: {
+    to?: string;
+    params?: Record<string, string>;
+    children: ReactNode;
+  }) => (
+    <a
+      href={Object.entries(params ?? {}).reduce(
+        (path, [key, value]) => path.replace(`$${key}`, value),
+        to ?? "",
+      )}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
 }));
 
 vi.mock("@tanstack/react-start", () => ({
@@ -33,6 +52,13 @@ vi.mock("@/hooks/useAuth", () => ({
 vi.mock("react-markdown", () => ({
   default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
+
+/**
+ * The comments the feedback panel renders. Mutated by the tests that need one,
+ * and read lazily by the mocked server function, which `vi.mock` hoists above
+ * this declaration.
+ */
+let managerAnnotations: Record<string, unknown>[] = [];
 
 const article = {
   slug: "our-history",
@@ -126,7 +152,7 @@ vi.mock("@/lib/kb.functions", () => ({
         created_at: article.updated_at,
       },
     ]),
-  listManagerAnnotations: () => Promise.resolve([]),
+  listManagerAnnotations: () => Promise.resolve(managerAnnotations),
   saveManagerArticle: vi.fn(),
   saveManagerSection: vi.fn(),
   deleteManagerSection: vi.fn(),
@@ -330,6 +356,44 @@ describe("/manager/kb section editing", () => {
     await waitFor(() =>
       expect(screen.queryByRole("button", { name: /save the name/i })).not.toBeInTheDocument(),
     );
+  });
+});
+
+describe("/manager/kb feedback", () => {
+  // Every other manager list opens the person behind a name. This panel is
+  // where a manager decides whether a comment needs acting on, and knowing who
+  // wrote it is usually the next question.
+  it("opens the commenter's record from their name", async () => {
+    managerAnnotations = [
+      {
+        id: "a-1",
+        user_id: "u-9",
+        body: "This paragraph is out of date.",
+        visibility: "shared",
+        block_id: null,
+        quote: null,
+        parent_id: null,
+        article_version: 3,
+        author: "Sam Lee",
+        is_mine: false,
+        can_edit: false,
+        can_resolve: true,
+        resolved_at: null,
+        created_at: "2026-02-01T00:00:00Z",
+        updated_at: "2026-02-01T00:00:00Z",
+      },
+    ];
+    try {
+      render(<KnowledgeBaseManager />);
+
+      await screen.findByLabelText(/sidebar label/i);
+      expect(await screen.findByRole("link", { name: "Sam Lee" })).toHaveAttribute(
+        "href",
+        "/manager/users/u-9",
+      );
+    } finally {
+      managerAnnotations = [];
+    }
   });
 });
 

--- a/src/routes/_authenticated/manager.kb.tsx
+++ b/src/routes/_authenticated/manager.kb.tsx
@@ -49,6 +49,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { MarkdownEditor } from "@/components/site/MarkdownEditor";
 import { CopyButton } from "@/components/site/CopyButton";
+import { UserLink } from "@/components/site/UserLink";
 import { Badge } from "@/components/ui/badge";
 import {
   Select,
@@ -2022,7 +2023,11 @@ function KnowledgeBaseManager() {
                     <div key={f.id} className="rounded-md bg-muted/50 p-3 text-sm">
                       <div className="mb-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                         <span className="font-medium text-foreground">
-                          {f.author ?? "Someone at the club"}
+                          <UserLink
+                            userId={f.user_id}
+                            name={f.author}
+                            fallback="Someone at the club"
+                          />
                         </span>
                         <span>v{f.article_version}</span>
                         <span>{formatDate(f.created_at)}</span>

--- a/src/routes/_authenticated/manager.memberships.tsx
+++ b/src/routes/_authenticated/manager.memberships.tsx
@@ -4,6 +4,7 @@ import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Pill } from "@/components/site/StatusPill";
+import { UserLink } from "@/components/site/UserLink";
 import { LoadFailure } from "@/components/site/LoadFailure";
 import { Loading } from "@/components/site/Loading";
 import { describeLoadError } from "@/lib/load-error";
@@ -122,7 +123,12 @@ function ManagerMembershipsPage() {
                 {rows.map((r) => (
                   <tr key={r.id} className="border-t">
                     <td className="px-3 py-2">
-                      <div className="font-medium">{r.member_name ?? "—"}</div>
+                      {/* A membership outlives the account it was raised for, so
+                          a row with no `user_id` left has a name and nowhere to
+                          send you. `UserLink` prints it rather than linking. */}
+                      <div className="font-medium">
+                        <UserLink userId={r.user_id} name={r.member_name} />
+                      </div>
                       <div className="text-xs text-muted-foreground">
                         {r.member_email ?? r.user_id ?? "—"}
                       </div>

--- a/src/routes/_authenticated/manager.memberships.tsx
+++ b/src/routes/_authenticated/manager.memberships.tsx
@@ -123,9 +123,10 @@ function ManagerMembershipsPage() {
                 {rows.map((r) => (
                   <tr key={r.id} className="border-t">
                     <td className="px-3 py-2">
-                      {/* A membership outlives the account it was raised for, so
-                          a row with no `user_id` left has a name and nowhere to
-                          send you. `UserLink` prints it rather than linking. */}
+                      {/* `memberships.user_id` is ON DELETE SET NULL, and the
+                          name is looked up through it, so a row whose person is
+                          gone has neither. `UserLink` renders the dash rather
+                          than a link to a page that is not there. */}
                       <div className="font-medium">
                         <UserLink userId={r.user_id} name={r.member_name} />
                       </div>

--- a/src/routes/_authenticated/manager.users.tsx
+++ b/src/routes/_authenticated/manager.users.tsx
@@ -15,6 +15,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Pill } from "@/components/site/StatusPill";
+import { UserLink } from "@/components/site/UserLink";
 import { LoadFailure } from "@/components/site/LoadFailure";
 import { Loading } from "@/components/site/Loading";
 import { describeLoadError } from "@/lib/load-error";
@@ -335,18 +336,11 @@ function ManagerUsersPage() {
                   {visible.map((r) => (
                     <tr key={r.user_id ?? r.email ?? r.name ?? ""} className="border-t align-top">
                       <td className="px-3 py-2 font-medium">
-                        {r.user_id ? (
-                          <Link
-                            to="/manager/users/$userId"
-                            params={{ userId: r.user_id }}
-                            className="underline underline-offset-2 hover:no-underline"
-                          >
-                            {r.name ?? r.email ?? "View"}
-                          </Link>
-                        ) : (
-                          // A lead has no person record yet, so nothing to open.
-                          (r.name ?? "—")
-                        )}
+                        {/* A lead has no person record yet, so `UserLink` prints
+                            the name instead of linking to a page that is not
+                            there. The address stands in when a row has no name:
+                            it is the only thing a lead is guaranteed to have. */}
+                        <UserLink userId={r.user_id} name={r.name ?? r.email} />
                       </td>
                       <td className="px-3 py-2">
                         {r.email ? (

--- a/src/routes/_authenticated/manager.waivers.test.tsx
+++ b/src/routes/_authenticated/manager.waivers.test.tsx
@@ -11,7 +11,26 @@ const listWaivers = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
   createFileRoute: () => (opts: Record<string, unknown>) => opts,
-  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+  Link: ({
+    to,
+    params,
+    children,
+    ...props
+  }: {
+    to?: string;
+    params?: Record<string, string>;
+    children: ReactNode;
+  }) => (
+    <a
+      href={Object.entries(params ?? {}).reduce(
+        (path, [key, value]) => path.replace(`$${key}`, value),
+        to ?? "",
+      )}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
   useNavigate: () => vi.fn(),
 }));
 vi.mock("@tanstack/react-start", () => ({ useServerFn: (fn: unknown) => fn }));
@@ -59,5 +78,31 @@ describe("manager waivers list", () => {
     render(<WaiversPage />);
 
     expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+  });
+
+  // The name used to be dead text here, so approving a waiver and then checking
+  // anything else about the person meant going back to the directory and
+  // searching for the name that was already on screen.
+  it("opens the signer's record from their name", async () => {
+    listWaivers.mockResolvedValue([
+      {
+        id: "w-1",
+        user_id: "u-1",
+        full_name: "Sam Lee",
+        email: "sam@example.com",
+        signed_at: "2026-08-01T00:00:00Z",
+        template_version: 3,
+        pdf_path: null,
+        status: "pending",
+        approved_at: null,
+        is_paper: false,
+      },
+    ]);
+    render(<WaiversPage />);
+
+    expect(await screen.findByRole("link", { name: "Sam Lee" })).toHaveAttribute(
+      "href",
+      "/manager/users/u-1",
+    );
   });
 });

--- a/src/routes/_authenticated/manager.waivers.tsx
+++ b/src/routes/_authenticated/manager.waivers.tsx
@@ -4,6 +4,7 @@ import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Pill } from "@/components/site/StatusPill";
+import { UserLink } from "@/components/site/UserLink";
 import { LoadFailure } from "@/components/site/LoadFailure";
 import { Loading } from "@/components/site/Loading";
 import { describeLoadError } from "@/lib/load-error";
@@ -30,6 +31,7 @@ export const Route = createFileRoute("/_authenticated/manager/waivers")({
 
 type Row = {
   id: string;
+  user_id: string;
   full_name: string;
   email: string;
   signed_at: string;
@@ -234,7 +236,12 @@ function WaiversPage() {
                   const up = uploads[r.id];
                   return (
                     <tr key={r.id} className="border-t">
-                      <td className="px-3 py-2 font-medium">{r.full_name}</td>
+                      <td className="px-3 py-2 font-medium">
+                        {/* The name as signed, opening the person who signed it.
+                            A manager reading this list is usually on their way
+                            to the record behind a row anyway. */}
+                        <UserLink userId={r.user_id} name={r.full_name} />
+                      </td>
                       <td className="px-3 py-2">{r.email}</td>
                       <td className="px-3 py-2">
                         {formatDateTime(r.signed_at)}


### PR DESCRIPTION
## What a manager sees

Anywhere a person's name appears in a manager's list, clicking it opens that person's page. Before this, half the lists linked and half printed the name as dead text, so a manager reading a row often had to go back to the directory and search for the person already in front of them.

Newly clickable:

- **Signed waivers** (`/manager/waivers`) — the name as signed opens whoever signed it. This is the one that cost the most: a manager approving a waiver and then wanting to check anything else about that person had no way through from here.
- **Memberships** (`/manager/memberships`) — the member an invoice belongs to.
- **Blog comments** (`/manager/blog-comments`) — the author of a comment, and each blocked commenter.
- **Calendar** (`/manager/calendar`) — everyone listed under "who's coming" for a class.
- **Knowledge base feedback** (`/manager/kb`) — the member who left a comment.

Already clickable, now consistent: the users directory and the three check-in tables.

## What is deliberately not a link

- **Contact messages** — an enquiry comes from a stranger with no account, so there is no page to open.
- **Reconciliation** — the member names there sit inside a dropdown, which cannot hold a link.
- **Rows with nothing behind them** — an interest registration is a lead with no account yet, and an invoice whose member was deleted keeps neither the name nor the id. Those render as plain text rather than a link to a page that is not there.
- **The member-facing knowledge base** — a member reading an article still sees other members signed with a privacy-conscious display name and no link. Only the manager view identifies people, which is the existing rule, unchanged.

## Things you would feel

- Links now carry a **permanent underline** rather than appearing on hover. The check-in board previously used hover only, which is invisible on a phone, and that is where most of this club's admin happens.
- On the users directory, a lead with **no name on file** now shows their email address in the Name column instead of a dash. It is the only thing a lead is guaranteed to have, and a dash said nothing about which row you were on.
- Nothing about permissions changes. These are all manager-only screens already, and the person page they open was manager-only before.

## How it is built

Three commits:

1. **Preparatory refactor** — extract `components/site/UserLink`, which owns the route, the underline and the plain-text fallback, and move the two screens that already linked onto it. No feature in this commit.
2. **The change** — point the four remaining lists at it. `listWaivers` did not carry the signer's id at all, so it now returns it alongside the name as submitted (the frozen evidence, which may no longer match the profile; the person behind it is the same either way).
3. **Review follow-ups** — the knowledge base feedback panel, which the first pass missed, plus a correction to a comment on the memberships screen that described the deleted-account case wrongly. `listManagerAnnotations` now returns the author's id; the member-facing `listAnnotations` still ships none, deliberately.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (2683 passing) and `bun run build` all pass locally. New unit tests cover `UserLink` (linked, unlinked, blank name, fallback, caller classes); the waivers list and the knowledge base feedback panel each pin that a name opens the right record.

Docs updated: the reuse rule is in CLAUDE.md's UX bar, with `docs/waivers.md` and `docs/knowledge-base.md` noting the names that are now a way in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGeTPGL4U3JFQk8h8yNdKN