### PR TITLE
Cancel the copy button's tick timer when it unmounts

### DIFF
--- a/src/components/site/CopyButton.test.tsx
+++ b/src/components/site/CopyButton.test.tsx
@@ -63,6 +63,80 @@ describe("CopyButton", () => {
   // torn down, throwing outside any test body — a failure attributed to no
   // test, which exits the suite non-zero with every test reporting as passed.
   // That is a red CI run nobody can trace to a change.
+  // The narrower version of the same leak: the click is async, so unmounting
+  // while the clipboard write is still in flight ran the unmount cleanup BEFORE
+  // any timer existed, and the continuation then scheduled one nothing would
+  // ever clear. Starting the timer from an effect closes it, because an effect
+  // only ever runs on a mounted tree.
+  it("starts no timer when it is unmounted before the copy resolves", async () => {
+    vi.useFakeTimers();
+    try {
+      let release!: () => void;
+      const writeText = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            release = resolve;
+          }),
+      );
+      Object.assign(navigator, { clipboard: { writeText } });
+      const { unmount } = render(<CopyButton text="x" label="Copy link" />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Copy link" }));
+      });
+      expect(writeText).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+
+      unmount();
+      await act(async () => {
+        release();
+      });
+
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // A boolean would already be true on the second click, so the effect would
+  // not re-run and the first click's timer would cut the new tick short.
+  it("restarts the full countdown on a second click", async () => {
+    vi.useFakeTimers();
+    try {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { clipboard: { writeText } });
+      render(<CopyButton text="x" label="Copy link" />);
+      const button = screen.getByRole("button", { name: "Copy link" });
+      const ticking = () => Boolean(button.querySelector(".lucide-check"));
+
+      await act(async () => {
+        fireEvent.click(button);
+      });
+      expect(ticking()).toBe(true);
+
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+      await act(async () => {
+        fireEvent.click(button);
+      });
+
+      // 600ms past the FIRST click's deadline, so a tick that survives here can
+      // only be the second click's own countdown.
+      await act(async () => {
+        vi.advanceTimersByTime(600);
+      });
+      expect(ticking()).toBe(true);
+
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(ticking()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("cancels the tick's timer when it is unmounted mid-countdown", async () => {
     vi.useFakeTimers();
     try {

--- a/src/components/site/CopyButton.test.tsx
+++ b/src/components/site/CopyButton.test.tsx
@@ -4,7 +4,7 @@
 // used in places where the string it copies is nowhere else on screen (the
 // blog list copies a post URL it never prints), so a bare "copy it manually"
 // would leave nothing to select.
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -56,5 +56,31 @@ describe("CopyButton", () => {
   it("leaves the label as the accessible name when no ariaLabel is given", () => {
     render(<CopyButton text="x" label="Copy reference" />);
     expect(screen.getByRole("button", { name: "Copy reference" })).toBeInTheDocument();
+  });
+
+  // A timer left running outlives the component. In a browser it sets state on
+  // a tree that is gone; under the test runner it fires after jsdom has been
+  // torn down, throwing outside any test body — a failure attributed to no
+  // test, which exits the suite non-zero with every test reporting as passed.
+  // That is a red CI run nobody can trace to a change.
+  it("cancels the tick's timer when it is unmounted mid-countdown", async () => {
+    vi.useFakeTimers();
+    try {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { clipboard: { writeText } });
+      const { unmount } = render(<CopyButton text="x" label="Copy link" />);
+
+      // fireEvent inside act, not userEvent: userEvent's own timers deadlock
+      // against the fake clock this test needs to count with.
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Copy link" }));
+      });
+      expect(vi.getTimerCount()).toBe(1);
+
+      unmount();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/components/site/CopyButton.tsx
+++ b/src/components/site/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -29,20 +29,33 @@ interface CopyButtonProps {
  * with nothing to select.
  */
 export function CopyButton({ text, label, ariaLabel, className }: CopyButtonProps) {
-  const [copied, setCopied] = useState(false);
-  // The tick's timer has to be cancellable. Left running it outlives the
-  // component: it fires against a React tree that is gone, and in the test
-  // environment it lands after jsdom has been torn down, where touching
-  // `window` throws `ReferenceError` OUTSIDE any test body. That failure is
-  // attributed to no test, so the suite reports every test passing and still
-  // exits non-zero, which reads as a random red CI run on an unrelated change.
-  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(
-    () => () => {
-      if (resetTimer.current) clearTimeout(resetTimer.current);
-    },
-    [],
-  );
+  // A counter, not a boolean, and the timer belongs to an effect rather than to
+  // the click. Both of those are load-bearing.
+  //
+  // The timer has to be cancellable. Left running it outlives the component: it
+  // fires against a React tree that is gone, and under the test runner it lands
+  // after jsdom has been torn down, where React reads `window.event` and throws
+  // `ReferenceError` OUTSIDE any test body. That failure belongs to no test, so
+  // the suite reports every test passing and still exits non-zero — a red CI run
+  // nobody can trace to a change. (The global `setTimeout` here is Node's, so
+  // jsdom's own teardown does not cancel it for us.)
+  //
+  // Starting it from the click cannot fix that on its own: the click is async,
+  // so an unmount while `writeText` is still in flight runs the cleanup BEFORE
+  // the timer exists, and the continuation then schedules one nothing will ever
+  // clear. An effect only ever runs on a mounted tree, so the timer and its
+  // `clearTimeout` are created and destroyed together.
+  //
+  // The counter is what makes a second click restart the full 1.5s: a boolean
+  // would already be `true`, the effect would not re-run, and the first click's
+  // timer would cut the new tick short.
+  const [copiedTick, setCopiedTick] = useState(0);
+  const copied = copiedTick > 0;
+  useEffect(() => {
+    if (!copiedTick) return;
+    const id = setTimeout(() => setCopiedTick(0), 1500);
+    return () => clearTimeout(id);
+  }, [copiedTick]);
   return (
     <Button
       type="button"
@@ -53,11 +66,7 @@ export function CopyButton({ text, label, ariaLabel, className }: CopyButtonProp
       onClick={async () => {
         try {
           await navigator.clipboard.writeText(text);
-          setCopied(true);
-          // Cleared first, so a second click restarts the 1.5s rather than
-          // letting the first click's timer cut the new tick short.
-          if (resetTimer.current) clearTimeout(resetTimer.current);
-          resetTimer.current = setTimeout(() => setCopied(false), 1500);
+          setCopiedTick((tick) => tick + 1);
         } catch {
           toast.error("Couldn't copy that automatically.", {
             description: `Select this and copy it by hand: ${text}`,

--- a/src/components/site/CopyButton.tsx
+++ b/src/components/site/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -30,6 +30,19 @@ interface CopyButtonProps {
  */
 export function CopyButton({ text, label, ariaLabel, className }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
+  // The tick's timer has to be cancellable. Left running it outlives the
+  // component: it fires against a React tree that is gone, and in the test
+  // environment it lands after jsdom has been torn down, where touching
+  // `window` throws `ReferenceError` OUTSIDE any test body. That failure is
+  // attributed to no test, so the suite reports every test passing and still
+  // exits non-zero, which reads as a random red CI run on an unrelated change.
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+    },
+    [],
+  );
   return (
     <Button
       type="button"
@@ -41,7 +54,10 @@ export function CopyButton({ text, label, ariaLabel, className }: CopyButtonProp
         try {
           await navigator.clipboard.writeText(text);
           setCopied(true);
-          setTimeout(() => setCopied(false), 1500);
+          // Cleared first, so a second click restarts the 1.5s rather than
+          // letting the first click's timer cut the new tick short.
+          if (resetTimer.current) clearTimeout(resetTimer.current);
+          resetTimer.current = setTimeout(() => setCopied(false), 1500);
         } catch {
           toast.error("Couldn't copy that automatically.", {
             description: `Select this and copy it by hand: ${text}`,


### PR DESCRIPTION
## Why this matters more than it looks

This is a one-line-shaped bug with a disproportionate cost: **it can turn CI red at random, on a change that has nothing to do with it.**

The copy button shows a transient tick after copying, on a 1.5 second timer that nothing ever clears. Left running, the timer outlives the component:

- In a browser it sets state on a React tree that is already gone. Harmless, but wrong.
- Under the test runner it lands **after jsdom has been torn down**, where touching `window` throws `ReferenceError: window is not defined`. That throw happens outside any test body, so it is attributed to no test. The suite prints **every test passing** and still exits non-zero.

Whether it happens depends only on how file ordering lines the stray timer up against a teardown. It appeared on one review run out of three, with all 2786 tests green and a non-zero exit — which is exactly the kind of failure that gets shrugged off as a flake and re-run, and the repo's own rules say a failing test is never an infra flake.

I found this while reviewing an unrelated pull request (#113), not from a report.

## What changes

- The timer id is held in a ref and cleared on unmount.
- It is also cleared before a new one starts, so clicking twice restarts the full 1.5 seconds instead of the first click's timer cutting the second tick short. That was a real, if minor, visible bug.

Nothing changes about what the button does, how it looks, or what it copies.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (2786 passing) and `bun run build` pass locally.

The new test is written to fail without the fix, and I checked that it does rather than assuming it:

```
× cancels the tick's timer when it is unmounted mid-countdown
AssertionError: expected 1 to be +0
```

It drives the click with `fireEvent` inside `act` rather than `userEvent`, because `userEvent`'s own timers deadlock against the fake clock the test needs in order to count pending timers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGeTPGL4U3JFQk8h8yNdKN

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGeTPGL4U3JFQk8h8yNdKN)_