### PR TITLE
The notification-digest drift is not drift, and one "fix" would stop the digest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,9 @@ requests, the CI logs, and the screenshot artifacts.
   - The two live checks survive as **scripts you run by hand** through Lovable's
     SQL access (`supabase/lint/README.md` has the queries, and **owns these
     figures** — this is a summary of that file, so change it there first). Last
-    run **2026-09-04**: **76 migration files, 0 unapplied** (2 report as
-    unapplied and are allowlisted as already-live re-emissions, see below), and
+    run **2026-09-04**: **76 migration files, 2 reported unapplied**, both then
+    allowlisted as already-live re-emissions (see below), so the next run
+    reports 0 and lists them separately. Also
     **18 client grants live, 18 expected, 0 unexpected** as of **2026-09-01**. So
     `supabase/lint/client-grants-expected.txt` is verified against production as
     of that date, not just against the migration files, and `profiles` still
@@ -66,10 +67,12 @@ requests, the CI logs, and the screenshot artifacts.
     NOT drift, and one of them must never be applied.** This file said the
     opposite until 2026-09-04, when the live database was finally read rather
     than reasoned about. Both effects are already in production, carried there
-    by Lovable re-emissions of the same SQL under filenames of its own — the
-    duplicate-re-emission case, the same one as the ledger row below, not a
-    different thing. Both are now in `supabase/lint/migration-drift-allowlist.txt`
-    with the queries that proved it.
+    by Lovable re-emissions of the same SQL under filenames of its own. Same
+    cause as the ledger row below, opposite symptom: that one is a row with no
+    file, this is a file whose row sits under the re-emission's version. Both
+    are now in `supabase/lint/migration-drift-allowlist.txt` with the queries
+    that proved it, and the checker lists them rather than silently skipping
+    them.
     - `20260821000000_notification_digest_fails_loudly.sql` — **superseded, and
       applying it now would stop the digest.** Its payload (the unarmed branch
       raising instead of returning quietly) went live inside `20260822120041`,
@@ -84,7 +87,8 @@ requests, the CI logs, and the screenshot artifacts.
       `0 22 * * *`, so the digest goes out at 8am/9am Sydney and has since
       2026-08-23. It never was going out at 6am after that date.
 
-    The lesson is the one this section already teaches from the other end: the
+    The lesson is the one the orphan-row bullet below teaches from the other
+    end: the
     drift check compares **identities, not content**, so a file with no ledger
     row is a question, not a verdict. Read the object itself (`pg_proc.prosrc`,
     `cron.job`) before applying anything on its say-so. "Approval of the PR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,31 +53,42 @@ requests, the CI logs, and the screenshot artifacts.
   - The two live checks survive as **scripts you run by hand** through Lovable's
     SQL access (`supabase/lint/README.md` has the queries, and **owns these
     figures** — this is a summary of that file, so change it there first). Last
-    run **2026-09-01**, straight after applying
-    `20260828000000_waiver_pdf_guardian_read.sql`: **76 migration files, 2
-    unapplied**, and **18 client grants live, 18 expected, 0 unexpected**. So
+    run **2026-09-04**: **76 migration files, 0 unapplied** (2 report as
+    unapplied and are allowlisted as already-live re-emissions, see below), and
+    **18 client grants live, 18 expected, 0 unexpected** as of **2026-09-01**. So
     `supabase/lint/client-grants-expected.txt` is verified against production as
     of that date, not just against the migration files, and `profiles` still
     holds nothing for `anon` or `authenticated`. It goes stale the moment
     anyone changes a grant by hand in the Lovable UI, which produces no commit
     and no signal — so re-run them after applying a migration and before a
     release. Nothing does it for you.
-  - ⚠️ **The two unapplied migrations are real drift, not a naming artefact**,
-    and they are older than the run that found them. Both are notification-digest
-    migrations that were committed and merged without ever being applied, which
-    is the exact failure `docs/database-changes.md` exists to prevent, caught by
-    the check written to catch it. Do not confuse them with the ledger row below,
-    which is a different thing entirely.
-    - `20260821000000_notification_digest_fails_loudly.sql` — until it is
-      applied, `cron.job_run_details` keeps recording `succeeded` for a night on
-      which nothing was sent: the tick means "the function ran", not "the digest
-      went out".
-    - `20260823000000_notification_digest_morning_schedule.sql` — until it is
-      applied, the club's digest keeps going out at 6am rather than 8am.
+  - ⚠️ **The two notification-digest migrations that report as unapplied are
+    NOT drift, and one of them must never be applied.** This file said the
+    opposite until 2026-09-04, when the live database was finally read rather
+    than reasoned about. Both effects are already in production, carried there
+    by Lovable re-emissions of the same SQL under filenames of its own — the
+    duplicate-re-emission case, the same one as the ledger row below, not a
+    different thing. Both are now in `supabase/lint/migration-drift-allowlist.txt`
+    with the queries that proved it.
+    - `20260821000000_notification_digest_fails_loudly.sql` — **superseded, and
+      applying it now would stop the digest.** Its payload (the unarmed branch
+      raising instead of returning quietly) went live inside `20260822120041`,
+      which is the function's third body. Re-applying this file would install
+      the second body, which reads a `notification_digest_url` Vault secret that
+      `20260822120041` deliberately retired for an inlined URL. That secret does
+      not exist, so the job would raise every night and no member would be
+      emailed again.
+    - `20260823000000_notification_digest_morning_schedule.sql` — live via
+      `20260823002504`, its own SQL byte for byte. `cron.job` reports
+      `0 22 * * *`, so the digest goes out at 8am/9am Sydney and has since
+      2026-08-23. It never was going out at 6am after that date.
 
-    Neither is allowlisted, and neither belongs to whatever PR you are reading
-    this from, so they wait for a decision of their own: "approval of the PR
-    covers the SQL described in it, and nothing else".
+    The lesson is the one this section already teaches from the other end: the
+    drift check compares **identities, not content**, so a file with no ledger
+    row is a question, not a verdict. Read the object itself (`pg_proc.prosrc`,
+    `cron.job`) before applying anything on its say-so. "Approval of the PR
+    covers the SQL described in it, and nothing else" still holds, and there is
+    now nothing here awaiting approval.
 
   - The live ledger also carries one row with no file here
     (`20260722131544_3de60949-…`, recorded as version `20260722131547`). Its SQL

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,8 @@ requests, the CI logs, and the screenshot artifacts.
       not exist, so the job would raise every night and no member would be
       emailed again.
     - `20260823000000_notification_digest_morning_schedule.sql` — live via
-      `20260823002504`, its own SQL byte for byte. `cron.job` reports
+      `20260823002504`, which carries the same executable statements (the
+      re-emission strips the commentary). `cron.job` reports
       `0 22 * * *`, so the digest goes out at 8am/9am Sydney and has since
       2026-08-23. It never was going out at 6am after that date.
 

--- a/docs/database-changes.md
+++ b/docs/database-changes.md
@@ -231,8 +231,10 @@ does not actually need — after it there is no staging tier to absorb the mista
   `docs/database.md` aligned in the **code** PR that introduces the usage.
 
 Note: the unit suite never sees a live DB, and `bun run build` is Rollup-only
-(no type-check). The migration-drift workflow catches an _unapplied_ migration
-(but only after merge, and only once its secret is set), and `bun run typecheck`
+(no type-check). **Nothing automated catches an unapplied migration**: the
+migration-drift workflow was deleted on 2026-08-22 because the credential it
+needed can never exist on this project, so `check-migration-drift.py` is a
+script somebody runs by hand (see `supabase/lint/README.md`). `bun run typecheck`
 catches code that reads a column the generated types don't have — but neither
 sees a preview-only bundler-interop fault, and neither can prove the ordering
 above was respected. Sequencing and a browser/DB smoke check are still the real
@@ -273,7 +275,9 @@ older definition. Two live examples, both allowlisted with their proof in
 
 - `20260823000000_notification_digest_morning_schedule.sql` carries the same
   executable statements as the applied `20260823002504_…` (the re-emission keeps
-  the SQL and drops the commentary), so applying it would be a no-op. Benign.
+  the SQL and drops the commentary), so applying it would re-register the job
+  unchanged: a new jobid, the same name, schedule and command. Benign, though
+  still not drift.
 - `20260821000000_notification_digest_fails_loudly.sql` is **not** benign. Its
   behaviour is live via the later `20260822120041_…`, which also retired the
   `notification_digest_url` Vault secret. Applying the older file would restore

--- a/docs/database-changes.md
+++ b/docs/database-changes.md
@@ -262,3 +262,23 @@ the Supabase lint workflow could not run on any PR.
 - Prefer `DROP … IF EXISTS` before a deliberate re-create (see
   `on_auth_user_created_assign_role` in `20260721091500_…`), which is what makes
   a genuine re-point replay cleanly.
+
+⚠️ **The re-emitted copy is the one with the ledger row, so the hand-written
+original reports as unapplied forever — and applying it can be an outage.**
+`check-migration-drift.py` compares identities, not content, so it cannot tell
+"never ran" from "already live under Lovable's filename". Following its advice
+blindly re-runs SQL that a LATER migration has since superseded, reinstating the
+older definition. Two live examples, both allowlisted with their proof in
+`supabase/lint/migration-drift-allowlist.txt`:
+
+- `20260823000000_notification_digest_morning_schedule.sql` is byte-identical to
+  the applied `20260823002504_…`, so applying it would be a no-op. Benign.
+- `20260821000000_notification_digest_fails_loudly.sql` is **not** benign. Its
+  behaviour is live via the later `20260822120041_…`, which also retired the
+  `notification_digest_url` Vault secret. Applying the older file would restore
+  the read of a secret that no longer exists and stop the club's nightly digest.
+
+So when this check reports a file: **read the live object first**
+(`pg_proc.prosrc`, `cron.job`, `information_schema`), and check whether a later
+migration touches the same object. Only then decide between applying it and
+allowlisting it.

--- a/docs/database-changes.md
+++ b/docs/database-changes.md
@@ -271,8 +271,9 @@ blindly re-runs SQL that a LATER migration has since superseded, reinstating the
 older definition. Two live examples, both allowlisted with their proof in
 `supabase/lint/migration-drift-allowlist.txt`:
 
-- `20260823000000_notification_digest_morning_schedule.sql` is byte-identical to
-  the applied `20260823002504_…`, so applying it would be a no-op. Benign.
+- `20260823000000_notification_digest_morning_schedule.sql` carries the same
+  executable statements as the applied `20260823002504_…` (the re-emission keeps
+  the SQL and drops the commentary), so applying it would be a no-op. Benign.
 - `20260821000000_notification_digest_fails_loudly.sql` is **not** benign. Its
   behaviour is live via the later `20260822120041_…`, which also retired the
   `notification_digest_url` Vault secret. Applying the older file would restore

--- a/docs/database.md
+++ b/docs/database.md
@@ -1286,8 +1286,11 @@ reached from a link rather than by looking the token up.
 Added by `20260807000000_notification_digest_cron.sql`, which enables **pg_cron**
 (schema `cron`) and **pg_net** (schema `net`) and registers one job,
 `notification-digest`, at `0 20 * * *` UTC, moved to `0 22 * * *` by
-`20260823000000_notification_digest_morning_schedule.sql` so it lands at 8am
-Sydney in AEST and 9am in AEDT rather than 6am and 7am. It replaced a GitHub Actions
+`20260823002504_98356929-…` so it lands at 8am Sydney in AEST and 9am in AEDT
+rather than 6am and 7am. (That is Lovable's re-emission of
+`20260823000000_notification_digest_morning_schedule.sql`, which is the file
+carrying the reasoning but has no ledger row of its own — see
+`supabase/lint/migration-drift-allowlist.txt`.) It replaced a GitHub Actions
 workflow: scheduling production work from CI put a credential that makes the site
 email its members into a repo that takes same-repo branches from Lovable and from
 coding agents.
@@ -1358,10 +1361,13 @@ see `src/lib/supabase-rpc.ts` for why this RPC gets a typed wrapper (its real
 return is nullable; the generated type says otherwise) rather than being called
 directly.
 
-`20260821000000_notification_digest_fails_loudly.sql` made the unarmed branch
-**raise** instead of warning and returning, naming the missing secret, and that
-behaviour is unchanged by the third body above. A plpgsql function that returns
-is one pg_cron records as `succeeded`, so before that migration every unarmed
+The unarmed branch **raises** instead of warning and returning, naming the
+missing secret. That was written in
+`20260821000000_notification_digest_fails_loudly.sql`, but it reached production
+inside the third body above — the older file was never applied and must not be,
+since it still reads the retired `notification_digest_url` secret (see
+`supabase/lint/migration-drift-allowlist.txt`). A plpgsql function that returns
+is one pg_cron records as `succeeded`, so before that change every unarmed
 night went into `cron.job_run_details` as a success; it now goes in as a
 failure, which is what it is. Arming the job is what clears it; a club that does
 not want the digest at all should `cron.unschedule('notification-digest')`

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -289,12 +289,18 @@ honest:
   `LOVABLE_API_KEY`, where nothing is stamped at all: those notifications are
   still owed.
 
-`0 22 * * *` is 9am in Sydney during daylight saving and 8am outside it
-(written in `20260823000000_notification_digest_morning_schedule.sql`, live via
-Lovable's re-emission `20260823002504_98356929-…`; it was `0 20 * * *`,
-so 7am and 6am, until the club owner saw the first real run land at 6am). pg_cron
-schedules are UTC and have no notion of DST, and an hour's drift on a club digest
-is not worth a scheduler of our own.
+`0 22 * * *` is 9am in Sydney during daylight saving and 8am outside it. It was
+`0 20 * * *`, so 7am and 6am, until the club owner saw the first real run land at
+6am. The move is written in
+`20260823000000_notification_digest_morning_schedule.sql` and live via Lovable's
+re-emission `20260823002504_98356929-…`. pg_cron schedules are UTC and have no
+notion of DST, and an hour's drift on a club digest is not worth a scheduler of
+our own.
+
+"The first real run" there means the POST reached jitsu.au, not that anybody was
+emailed: the endpoint was still answering 503 from the old env-var path that
+morning (see the runbook below). It is the first time the job got past its
+fail-closed branch and actually called out.
 
 #### Knowing whether it actually ran ⚠️
 
@@ -458,17 +464,24 @@ notifications   0 unemailed; emailed_at by day: 2026-08-22 x12 (the stamping
                 below), then 08-24 x3, 08-26 x6, 09-02 x9
 ```
 
-Those last three days are real digest runs: nothing but the job stamps a row
-after 2026-08-22, and 2026-09-02's rows carry 22:00:06+00, the run itself. Days
-with no rows are nights nobody was owed anything, which is the expected shape.
+The 2026-09-02 rows are a real digest run: they carry 22:00:06+00, which is the
+`0 22 * * *` job firing. That timestamp is the whole proof, and it has to be —
+the digest is **not** the only writer of `emailed_at`. `sendReplyNotification`
+(`src/lib/notification-email.server.ts`) stamps a row the moment a comment reply
+goes out, and stamps it too when a preference is switched off, so a day with
+stamped rows is not by itself evidence the job ran. Read the clock, not the
+count. Days with no rows are nights nobody was owed anything.
 
 ⚠️ The 12 rows still dated 2026-08-22 are fewer than the **34** stamped that day
 below. Notifications are deleted when what they point at is, so rows have gone
 since; the gap is not evidence of a failed send, and nothing here re-derives the
 34 from today's table. Count runs, not totals.
 
-Steps 3 and 4 below are what gathered this. Keep them for the next time the key
-is rotated or the endpoint stops answering.
+That is NOT step 3 or 4 below: neither `net._http_response` nor
+`cron.job_run_details` was read, because pg_net garbage-collects the first after
+six hours and the send being proved is two days old. The stamped minute is the
+evidence that survives that long. Keep steps 3 and 4 for the next time the key
+is rotated or the endpoint stops answering, when they are the sharper check.
 
 **3. Prove it works, without waiting for the scheduled run.** Run the job by hand and
 read the response back inside pg_net's 6-hour TTL:

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -334,12 +334,18 @@ means the digest has stopped, whatever the scheduler thinks.
 Two changes, and the split between them is the point. One makes the scheduler
 stop lying; the other stops relying on the scheduler at all.
 
-- **An unarmed run is now recorded as failed**
-  (`20260821000000_notification_digest_fails_loudly.sql`). The fail-closed branch
-  raises instead of returning, naming whichever Vault secret is missing, so
+- **An unarmed run is now recorded as failed.** The fail-closed branch raises
+  instead of returning, naming the missing Vault secret, so
   `cron.job_run_details` says `failed` for a job that emailed nobody. This is
   narrow on purpose: it only catches the half of the problem the database can
   see. An armed job still records success no matter what the site answered.
+
+  Written in `20260821000000_notification_digest_fails_loudly.sql`, but that
+  file is **not** how it reached production and must never be applied: the
+  behaviour went live inside `20260822120041`, the function's third body, which
+  keeps the RAISE and drops the `notification_digest_url` read. See the entry in
+  `supabase/lint/migration-drift-allowlist.txt`.
+
 - **A stalled digest is an attention item on `/notifications`.** Any notification
   row that has sat unemailed for more than `DIGEST_STALL_HOURS` (36) raises "The
   daily email summary has stopped going out", with the backlog size and the date
@@ -362,9 +368,10 @@ Three things about that item are deliberate and will look like bugs otherwise:
   can stay up for weeks. It clears when the digest actually sends, or when
   somebody stamps the backlog as emailed. That is the correct behaviour while
   members are silently getting no email.
-- **It fires while the digest has simply never been armed**, which is the state
-  the club is in today. That is not a false positive: the rows are owed and
-  nobody has had them.
+- **It fires while the digest has simply never been armed**, which was the
+  state the club was in until 2026-08-22. That is not a false positive: the rows
+  are owed and nobody has had them. It is not the state today — the digest is
+  armed and sending.
 
 Still not built: a second job that reads `net._http_response` back and raises on
 a non-2xx, so an ARMED failure lands in `cron.job_run_details` the same night
@@ -438,11 +445,20 @@ SELECT name, created_at FROM vault.secrets WHERE name = 'notification_digest_key
 One row is the secret existing; there is nothing to compare it against, since
 there is no second copy any more.
 
-**What is still outstanding: the first real send has not been proved yet.** The
-code that reads the key from Vault had not been deployed at the time the migration
-was applied, so the endpoint was still answering 503 from the old env-var path.
-Steps 3 and 4 below are the remaining verification, and they need a deploy of the
-merged code first.
+**The first real send is now proved, as of 2026-09-04.** It was outstanding when
+this was written: the code that reads the key from Vault had not been deployed
+when the migration was applied, so the endpoint was still answering 503 from the
+old env-var path. It has since deployed and the digest is sending. Read
+read-only against the live database on 2026-09-04:
+
+```
+cron.job          notification-digest, '0 22 * * *', active
+notifications     30 emailed, 0 unemailed, last emailed_at 2026-09-02 22:00:06+00
+```
+
+That last timestamp lands on the 22:00 run itself, which is the end-to-end
+evidence steps 3 and 4 below were written to gather. Keep them for the next time
+the key is rotated or the endpoint stops answering.
 
 **3. Prove it works, without waiting for the scheduled run.** Run the job by hand and
 read the response back inside pg_net's 6-hour TTL:
@@ -637,28 +653,27 @@ Two consequences worth knowing:
 
 ## Where the code lives
 
-| Concern                      | File                                                                          |
-| ---------------------------- | ----------------------------------------------------------------------------- |
-| The rules (pure, tested)     | `src/lib/notifications.ts`                                                    |
-| The attention list           | `src/lib/manager-notifications.functions.ts`                                  |
-| Contact messages             | `src/lib/contact-messages.functions.ts`, `contact-email.server.ts`            |
-| Interest registrations       | `src/lib/leads.functions.ts`                                                  |
-| Waivers waiting on a manager | `countWaiversAwaitingApproval` in `src/lib/waiver.functions.ts`               |
-| The club-wide watermarks     | `src/lib/seen-markers.ts`                                                     |
-| Who hears about what         | `src/lib/notification-events.server.ts`                                       |
-| Sending, and the digest run  | `src/lib/notification-email.server.ts`                                        |
-| Page and settings server fns | `src/lib/notifications.functions.ts`                                          |
-| The shared query             | `src/hooks/useNotifications.ts`                                               |
-| The page                     | `src/routes/_authenticated/notifications.tsx`                                 |
-| The signed-out settings      | `src/routes/email-settings/index.tsx`                                         |
-| The link exchange            | `src/routes/email-settings/$token.ts`                                         |
-| The settings cookie          | `src/lib/email-settings-session.ts`                                           |
-| The switches                 | `src/components/site/NotificationSwitches.tsx`                                |
-| The sidebar badge            | `src/components/site/MemberLayout.tsx`                                        |
-| The digest endpoint          | `src/routes/api/notifications/digest.ts`                                      |
-| The schedule                 | `supabase/migrations/20260807000000_notification_digest_cron.sql`             |
-| Failing loudly when unarmed  | `supabase/migrations/20260821000000_notification_digest_fails_loudly.sql`     |
-| One key, minted once         | `supabase/migrations/20260822120041_68ab3908-faf6-49d1-8037-aaa3e39639aa.sql` |
-| The key's typed RPC wrapper  | `notificationDigestKey` in `src/lib/supabase-rpc.ts`                          |
-| The stalled-digest item      | `digestStalledNotifications` in `src/lib/validation.ts`                       |
-| Email templates              | `src/lib/email-templates/comment-reply.tsx`, `notification-digest.tsx`        |
+| Concern                                          | File                                                                          |
+| ------------------------------------------------ | ----------------------------------------------------------------------------- |
+| The rules (pure, tested)                         | `src/lib/notifications.ts`                                                    |
+| The attention list                               | `src/lib/manager-notifications.functions.ts`                                  |
+| Contact messages                                 | `src/lib/contact-messages.functions.ts`, `contact-email.server.ts`            |
+| Interest registrations                           | `src/lib/leads.functions.ts`                                                  |
+| Waivers waiting on a manager                     | `countWaiversAwaitingApproval` in `src/lib/waiver.functions.ts`               |
+| The club-wide watermarks                         | `src/lib/seen-markers.ts`                                                     |
+| Who hears about what                             | `src/lib/notification-events.server.ts`                                       |
+| Sending, and the digest run                      | `src/lib/notification-email.server.ts`                                        |
+| Page and settings server fns                     | `src/lib/notifications.functions.ts`                                          |
+| The shared query                                 | `src/hooks/useNotifications.ts`                                               |
+| The page                                         | `src/routes/_authenticated/notifications.tsx`                                 |
+| The signed-out settings                          | `src/routes/email-settings/index.tsx`                                         |
+| The link exchange                                | `src/routes/email-settings/$token.ts`                                         |
+| The settings cookie                              | `src/lib/email-settings-session.ts`                                           |
+| The switches                                     | `src/components/site/NotificationSwitches.tsx`                                |
+| The sidebar badge                                | `src/components/site/MemberLayout.tsx`                                        |
+| The digest endpoint                              | `src/routes/api/notifications/digest.ts`                                      |
+| The schedule                                     | `supabase/migrations/20260823002504_98356929-b00a-46da-941d-0aceb9f3bab7.sql` |
+| One key, minted once, and the live function body | `supabase/migrations/20260822120041_68ab3908-faf6-49d1-8037-aaa3e39639aa.sql` |
+| The key's typed RPC wrapper                      | `notificationDigestKey` in `src/lib/supabase-rpc.ts`                          |
+| The stalled-digest item                          | `digestStalledNotifications` in `src/lib/validation.ts`                       |
+| Email templates                                  | `src/lib/email-templates/comment-reply.tsx`, `notification-digest.tsx`        |

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -290,7 +290,8 @@ honest:
   still owed.
 
 `0 22 * * *` is 9am in Sydney during daylight saving and 8am outside it
-(`20260823000000_notification_digest_morning_schedule.sql`; it was `0 20 * * *`,
+(written in `20260823000000_notification_digest_morning_schedule.sql`, live via
+Lovable's re-emission `20260823002504_98356929-…`; it was `0 20 * * *`,
 so 7am and 6am, until the club owner saw the first real run land at 6am). pg_cron
 schedules are UTC and have no notion of DST, and an hour's drift on a club digest
 is not worth a scheduler of our own.
@@ -452,13 +453,22 @@ old env-var path. It has since deployed and the digest is sending. Read
 read-only against the live database on 2026-09-04:
 
 ```
-cron.job          notification-digest, '0 22 * * *', active
-notifications     30 emailed, 0 unemailed, last emailed_at 2026-09-02 22:00:06+00
+cron.job        notification-digest, '0 22 * * *', active
+notifications   0 unemailed; emailed_at by day: 2026-08-22 x12 (the stamping
+                below), then 08-24 x3, 08-26 x6, 09-02 x9
 ```
 
-That last timestamp lands on the 22:00 run itself, which is the end-to-end
-evidence steps 3 and 4 below were written to gather. Keep them for the next time
-the key is rotated or the endpoint stops answering.
+Those last three days are real digest runs: nothing but the job stamps a row
+after 2026-08-22, and 2026-09-02's rows carry 22:00:06+00, the run itself. Days
+with no rows are nights nobody was owed anything, which is the expected shape.
+
+⚠️ The 12 rows still dated 2026-08-22 are fewer than the **34** stamped that day
+below. Notifications are deleted when what they point at is, so rows have gone
+since; the gap is not evidence of a failed send, and nothing here re-derives the
+34 from today's table. Count runs, not totals.
+
+Steps 3 and 4 below are what gathered this. Keep them for the next time the key
+is rotated or the endpoint stops answering.
 
 **3. Prove it works, without waiting for the scheduled run.** Run the job by hand and
 read the response back inside pg_net's 6-hour TTL:
@@ -672,7 +682,8 @@ Two consequences worth knowing:
 | The switches                                     | `src/components/site/NotificationSwitches.tsx`                                |
 | The sidebar badge                                | `src/components/site/MemberLayout.tsx`                                        |
 | The digest endpoint                              | `src/routes/api/notifications/digest.ts`                                      |
-| The schedule                                     | `supabase/migrations/20260823002504_98356929-b00a-46da-941d-0aceb9f3bab7.sql` |
+| The job, the function and its REVOKE             | `supabase/migrations/20260807000000_notification_digest_cron.sql`             |
+| The schedule as it runs today                    | `supabase/migrations/20260823002504_98356929-b00a-46da-941d-0aceb9f3bab7.sql` |
 | One key, minted once, and the live function body | `supabase/migrations/20260822120041_68ab3908-faf6-49d1-8037-aaa3e39639aa.sql` |
 | The key's typed RPC wrapper                      | `notificationDigestKey` in `src/lib/supabase-rpc.ts`                          |
 | The stalled-digest item                          | `digestStalledNotifications` in `src/lib/validation.ts`                       |

--- a/supabase/lint/README.md
+++ b/supabase/lint/README.md
@@ -176,8 +176,10 @@ duplicate-re-emission case as the ledger row above:
   ```
 
 - `20260823000000_notification_digest_morning_schedule.sql` — live via
-  `20260823002504`, which is its SQL byte for byte. Applying it would be a
-  harmless no-op, but it is not drift either.
+  `20260823002504`, which carries the same executable statements (Lovable's
+  re-emission strips the commentary, so the files are 2819 and 576 bytes; the
+  SQL matches once comments are removed, the prose does not). Applying it would
+  be a harmless no-op, but it is not drift either.
 
   ```sql
   -- What proved it: '0 22 * * *', active, and a send that lands on it.
@@ -186,8 +188,9 @@ duplicate-re-emission case as the ledger row above:
   ```
 
 **The general lesson, which is why this is written up rather than quietly
-fixed:** this check compares identities, not content (see "Known blind spots"),
-so a file with no ledger row raises a question. It does not answer it. Read the
+fixed:** this check compares identities, not content (it is the fourth entry
+under "Known blind spots" below), so a file with no ledger row raises a
+question. It does not answer it. Read the
 object — `pg_proc.prosrc`, `cron.job`, `information_schema` — before applying
 anything on the strength of this check, because the checker's own advice
 ("apply each one against the live database") is, for a superseded migration,
@@ -197,8 +200,17 @@ the outage.
 
 A migration legitimately waiting to be applied (the contract phase of an
 expand/contract change, which must land _after_ the code deploys) goes in
-`migration-drift-allowlist.txt` with a note. Everything else failing there is
-real drift: apply the migration and record it in the ledger.
+`migration-drift-allowlist.txt` with a note, and the entry comes out once it is
+applied.
+
+A migration whose SQL is **already live under another ledger version** goes in
+the same file, but permanently, and is never applied. Establish which of the two
+you have by reading the live object, not the file: if a later migration touches
+the same object, applying the earlier one reinstates the older definition. See
+the two worked entries above.
+
+Everything else failing there is real drift: apply the migration and record it
+in the ledger.
 
 ### Known blind spots
 

--- a/supabase/lint/README.md
+++ b/supabase/lint/README.md
@@ -146,8 +146,10 @@ Worth doing after a migration is applied, before a release, and any time someone
 has changed a grant or a policy by hand in the Lovable UI. That last one
 produces no commit and no signal, and is exactly the drift these catch.
 
-**Migration drift last run: 2026-09-04.** 76 migration files, **0 unapplied**:
-two report as unapplied and are allowlisted as already-live re-emissions (below).
+**Migration drift last run: 2026-09-04.** 76 migration files, **2 reported
+unapplied** — the two below. Both were then allowlisted as already-live
+re-emissions, so the next run reports **0 unapplied** and lists them under
+"Allowlisted, so not counted above" instead.
 **Client grants last run: 2026-09-01**, straight after applying
 `20260828000000_waiver_pdf_guardian_read.sql`: 18 live, 18 expected, 0
 unexpected. The one ledger row with no file here (`20260722131547`) is the known
@@ -157,8 +159,10 @@ schema.
 ⚠️ **The two that report as unapplied are NOT drift, and one of them must never
 be applied.** This file said the opposite from 2026-09-01 until 2026-09-04, when
 the live objects were read instead of the SQL. Both changes are already in
-production, re-emitted by Lovable under filenames of its own — the same
-duplicate-re-emission case as the ledger row above:
+production, re-emitted by Lovable under filenames of its own. That is the same
+CAUSE as the ledger row above and the opposite SYMPTOM: there, a row with no
+file (an orphan, reported as a note, never fatal); here, a file whose ledger row
+is under the re-emission's version, so the original reports as unapplied:
 
 - `20260821000000_notification_digest_fails_loudly.sql` — **superseded. Applying
   it would stop the digest.** The RAISE it introduced is live, carried into
@@ -192,9 +196,11 @@ fixed:** this check compares identities, not content (it is the fourth entry
 under "Known blind spots" below), so a file with no ledger row raises a
 question. It does not answer it. Read the
 object — `pg_proc.prosrc`, `cron.job`, `information_schema` — before applying
-anything on the strength of this check, because the checker's own advice
-("apply each one against the live database") is, for a superseded migration,
-the outage.
+anything on the strength of this check. Until 2026-09-04 the checker's own
+failure message said only "apply each one against the live database", which for
+a superseded migration is the outage; it now leads with "CHECK BEFORE YOU
+APPLY" and lists the allowlisted files rather than passing over them in
+silence.
 
 ### When it reports drift
 
@@ -224,6 +230,14 @@ The check compares **identities**, not content. It cannot see:
   running the SQL passes. Verifying the object actually exists is a human step.
 - **A `.sql` file in a subdirectory, or a `.SQL` extension** — `glob("*.sql")`
   is non-recursive and case-sensitive, matching the Supabase CLI.
+- **A migration already live under a DIFFERENT ledger version.** Lovable
+  re-emits hand-written SQL under a filename of its own and records that
+  version, leaving the original with no row. The check cannot tell that apart
+  from a migration nobody ever ran, so it reports drift that is not drift — and
+  its advice to apply the file is, when a later migration has replaced the same
+  object, an outage. This is the blind spot with teeth: the other three make the
+  check miss something, this one makes it recommend harm. See the two
+  allowlisted entries above.
 
 A ledger row with no matching file is reported as a note and does not fail: it
 means the repo can no longer rebuild the live schema from scratch, which is

--- a/supabase/lint/README.md
+++ b/supabase/lint/README.md
@@ -146,29 +146,52 @@ Worth doing after a migration is applied, before a release, and any time someone
 has changed a grant or a policy by hand in the Lovable UI. That last one
 produces no commit and no signal, and is exactly the drift these catch.
 
-**Last run: 2026-09-01**, straight after applying
-`20260828000000_waiver_pdf_guardian_read.sql`. 76 migration files, **2
-unapplied**; 18 client grants live, 18 expected, 0 unexpected. The one ledger
-row with no file here (`20260722131547`) is the known duplicate re-emission
-described in `docs/database-changes.md`, not missing schema.
+**Migration drift last run: 2026-09-04.** 76 migration files, **0 unapplied**:
+two report as unapplied and are allowlisted as already-live re-emissions (below).
+**Client grants last run: 2026-09-01**, straight after applying
+`20260828000000_waiver_pdf_guardian_read.sql`: 18 live, 18 expected, 0
+unexpected. The one ledger row with no file here (`20260722131547`) is the known
+duplicate re-emission described in `docs/database-changes.md`, not missing
+schema.
 
-⚠️ **The two unapplied ones are real drift, and they are not new.** Both are
-notification-digest migrations that were committed and merged without ever
-being applied, which is the exact failure the rule in
-`docs/database-changes.md` exists to prevent:
+⚠️ **The two that report as unapplied are NOT drift, and one of them must never
+be applied.** This file said the opposite from 2026-09-01 until 2026-09-04, when
+the live objects were read instead of the SQL. Both changes are already in
+production, re-emitted by Lovable under filenames of its own — the same
+duplicate-re-emission case as the ledger row above:
 
-- `20260821000000_notification_digest_fails_loudly.sql` — makes the nightly job
-  RAISE rather than return quietly when it is not armed, so `cron.job_run_details`
-  stops recording `succeeded` for a night on which nothing was sent. Until it is
-  applied, the scheduler keeps reporting a green tick that means "the function
-  ran", not "the digest went out".
-- `20260823000000_notification_digest_morning_schedule.sql` — moves the digest
-  from 20:00 UTC to 22:00 UTC (6am/7am Sydney to 8am/9am). Until it is applied,
-  the club's digest keeps going out at 6am.
+- `20260821000000_notification_digest_fails_loudly.sql` — **superseded. Applying
+  it would stop the digest.** The RAISE it introduced is live, carried into
+  `20260822120041` (the function's third body, applied 2026-08-22). Re-applying
+  this file installs the _second_ body, which reads a `notification_digest_url`
+  Vault secret that `20260822120041` retired in favour of an inlined jitsu.au
+  URL. `vault.secrets` holds only `notification_digest_key`, so the job would
+  raise nightly and nobody would be emailed again.
 
-Neither is this PR's and neither is allowlisted, so they are left for a separate
-decision rather than applied on the back of an approval that did not cover them
-("Approval of the PR covers the SQL described in it, and nothing else").
+  ```sql
+  -- What proved it: RAISE EXCEPTION present, no RAISE WARNING, URL inlined.
+  SELECT prosrc FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'private' AND p.proname = 'run_notification_digest';
+  SELECT name FROM vault.secrets WHERE name LIKE 'notification_digest%';
+  ```
+
+- `20260823000000_notification_digest_morning_schedule.sql` — live via
+  `20260823002504`, which is its SQL byte for byte. Applying it would be a
+  harmless no-op, but it is not drift either.
+
+  ```sql
+  -- What proved it: '0 22 * * *', active, and a send that lands on it.
+  SELECT jobname, schedule, active FROM cron.job WHERE jobname = 'notification-digest';
+  SELECT max(emailed_at) FROM public.notifications;  -- 2026-09-02 22:00:06+00
+  ```
+
+**The general lesson, which is why this is written up rather than quietly
+fixed:** this check compares identities, not content (see "Known blind spots"),
+so a file with no ledger row raises a question. It does not answer it. Read the
+object — `pg_proc.prosrc`, `cron.job`, `information_schema` — before applying
+anything on the strength of this check, because the checker's own advice
+("apply each one against the live database") is, for a superseded migration,
+the outage.
 
 ### When it reports drift
 

--- a/supabase/lint/check-migration-drift.py
+++ b/supabase/lint/check-migration-drift.py
@@ -39,10 +39,10 @@ already live under a DIFFERENT ledger version, because Lovable re-emitted it
 under a filename of its own. This check compares identities, not content, so it
 cannot tell that apart from a migration nobody ever ran. Applying such a file is
 not a harmless no-op when a LATER migration has since replaced the same object:
-it reinstates the older definition. That is not hypothetical — it was true of
-`20260821000000_notification_digest_fails_loudly.sql` from 2026-08-22 onward,
-where applying it would have taken the club's nightly digest offline. Read the
-live object before acting on anything this script reports.
+it reinstates the older definition. That is not hypothetical — it has been true
+of `20260821000000_notification_digest_fails_loudly.sql` since 2026-08-22, and
+applying it today would take the club's nightly digest offline. Read the live
+object before acting on anything this script reports.
 
 Those go in `migration-drift-allowlist.txt` too, but PERMANENTLY: unlike a
 contract-phase entry, there is nothing to apply later and the entry never comes
@@ -237,6 +237,18 @@ def main():
 
     missing = unapplied(stems, versions, names, allowed)
     print(f"{len(stems)} migration files, {len(missing)} not applied to the live database.")
+
+    # Name the allowlisted files rather than passing over them in silence. A
+    # contract-phase entry is temporary and harmless to omit, but a permanently
+    # allowlisted one carries a warning the reader needs (the second category in
+    # migration-drift-allowlist.txt: already live under another ledger version,
+    # and for a SUPERSEDED file, applying it is an outage). Skipping it silently
+    # is how that warning ends up living only in prose that goes stale.
+    silenced = sorted(set(unapplied(stems, versions, names, set())) - set(missing))
+    if silenced:
+        print("\nAllowlisted, so not counted above (read the note beside each entry):")
+        for stem in silenced:
+            print(f"  {stem}")
 
     orphans = orphan_rows(rows, stems)
     if orphans:

--- a/supabase/lint/check-migration-drift.py
+++ b/supabase/lint/check-migration-drift.py
@@ -44,6 +44,10 @@ it reinstates the older definition. That is not hypothetical — it was true of
 where applying it would have taken the club's nightly digest offline. Read the
 live object before acting on anything this script reports.
 
+Those go in `migration-drift-allowlist.txt` too, but PERMANENTLY: unlike a
+contract-phase entry, there is nothing to apply later and the entry never comes
+out. Record which live query proved the effect is already there.
+
 Usage
 -----
     check-migration-drift.py APPLIED_CSV [--migrations DIR] [--allowlist FILE]

--- a/supabase/lint/check-migration-drift.py
+++ b/supabase/lint/check-migration-drift.py
@@ -34,6 +34,16 @@ that drops something must land AFTER the code that stopped using it deploys.
 List those in `migration-drift-allowlist.txt` while they wait, and remove the
 entry once applied.
 
+There is a second exception, and it is the dangerous one: a file whose SQL is
+already live under a DIFFERENT ledger version, because Lovable re-emitted it
+under a filename of its own. This check compares identities, not content, so it
+cannot tell that apart from a migration nobody ever ran. Applying such a file is
+not a harmless no-op when a LATER migration has since replaced the same object:
+it reinstates the older definition. That is not hypothetical — it was true of
+`20260821000000_notification_digest_fails_loudly.sql` from 2026-08-22 onward,
+where applying it would have taken the club's nightly digest offline. Read the
+live object before acting on anything this script reports.
+
 Usage
 -----
     check-migration-drift.py APPLIED_CSV [--migrations DIR] [--allowlist FILE]
@@ -238,11 +248,18 @@ def main():
         print(f"  supabase/migrations/{stem}.sql")
     print(
         "\nCommitting a migration does NOT apply it — nothing in this pipeline runs\n"
-        "supabase/migrations/*.sql. Apply each one against the live database (the\n"
+        "supabase/migrations/*.sql. But CHECK BEFORE YOU APPLY: this compares\n"
+        "identities, not content, so a file also lands here when its SQL is already\n"
+        "live under a different ledger version (Lovable re-emits hand-written SQL\n"
+        "under a filename of its own). Read the live object first — pg_proc.prosrc,\n"
+        "cron.job, information_schema — because applying a SUPERSEDED file reinstates\n"
+        "an older definition over a newer one, which is an outage, not a no-op.\n"
+        "\nIf it really has never run: apply it against the live database (the\n"
         "Lovable project's SQL access), record it in supabase_migrations.schema_migrations,\n"
-        "and re-run. If a migration is the contract (destructive) phase of an\n"
-        "expand/contract change and must land after the code deploys, add it to\n"
-        f"{allowlist_display(allowlist_path)} with a note, and remove it once applied.",
+        "and re-run. If it is the contract (destructive) phase of an expand/contract\n"
+        "change and must land after the code deploys, or it is already live under\n"
+        f"another version, add it to {allowlist_display(allowlist_path)} with a note\n"
+        "saying which live query proved it.",
         file=sys.stderr,
     )
     return 1

--- a/supabase/lint/migration-drift-allowlist.txt
+++ b/supabase/lint/migration-drift-allowlist.txt
@@ -4,16 +4,17 @@
 # never run against the live database, because committing a migration does not
 # apply it (see the script's header, and "Schema drift" in CLAUDE.md).
 #
-# The one legitimate reason to be unapplied is the CONTRACT phase of an
+# There are two legitimate reasons. The FIRST is the CONTRACT phase of an
 # expand/contract change: a migration that drops a column, table or function
 # must land AFTER the code that stopped using it has deployed. Park it here
-# while it waits, then apply it and delete the entry.
+# while it waits, then apply it and delete the entry. The second is below.
 #
 # One entry per line, either the full file stem
 # (20260101000000_drop_old_column) or just the version prefix
 # (20260101000000). Blank lines and everything after '#' are ignored.
-# Say WHY each entry is here and what unblocks it. An empty list is the
-# healthy state.
+# Say WHY each entry is here. For a contract-phase entry say what unblocks it;
+# a second-category entry is permanent and nothing unblocks it. An empty list
+# is the healthy state for the first category only.
 
 # ---------------------------------------------------------------------------
 # There is a SECOND legitimate reason, added 2026-09-04: a file whose SQL is
@@ -36,9 +37,15 @@
 #
 # Its whole payload -- the unarmed branch raising instead of returning quietly
 # -- was carried into 20260822120041 (the third body of the function, applied
-# 2026-08-22, ledger row present). Proof: pg_proc.prosrc for
-# private.run_notification_digest() contains RAISE EXCEPTION and no RAISE
-# WARNING.
+# 2026-08-22, ledger row present).
+#
+# Proof, and note WHICH query settles it: "contains RAISE EXCEPTION" does NOT,
+# because this file's body raises too -- it separates body 1 from bodies 2 and
+# 3, not 2 from 3. What discriminates is the Vault read. pg_proc.prosrc for
+# private.run_notification_digest() has NO 'notification_digest_url' and DOES
+# have the literal 'https://jitsu.au/api/notifications/digest', which only the
+# third body has. Corroborated by: SELECT name FROM vault.secrets WHERE name
+# LIKE 'notification_digest%' -> notification_digest_key alone.
 #
 # ⚠️ DO NOT APPLY THIS FILE. It would replace the live function body with the
 # SECOND one, which reads a `notification_digest_url` Vault secret that
@@ -52,8 +59,8 @@
 #
 # 20260823002504 carries this file's executable statements verbatim (Lovable's
 # re-emission of it, ledger row present; the re-emission drops the commentary,
-# so the files differ in size but not in SQL), so the schedule move is live. Proof: cron.job reports
-# jobname 'notification-digest' on '0 22 * * *', active, and the most recent
-# notifications.emailed_at is 2026-09-02 22:00:06 UTC -- the 22:00 run itself.
-# Applying this file would be a harmless no-op, but it is still not drift.
+# so the files differ in size but not in SQL), so the schedule move is live.
+# Proof: cron.job reports jobname 'notification-digest' on '0 22 * * *', active,
+# and notifications rows stamped 2026-09-02 22:00:06 UTC -- the 22:00 run
+# itself. Applying this file would be a harmless no-op, but it is not drift.
 20260823000000_notification_digest_morning_schedule

--- a/supabase/lint/migration-drift-allowlist.txt
+++ b/supabase/lint/migration-drift-allowlist.txt
@@ -14,3 +14,45 @@
 # (20260101000000). Blank lines and everything after '#' are ignored.
 # Say WHY each entry is here and what unblocks it. An empty list is the
 # healthy state.
+
+# ---------------------------------------------------------------------------
+# There is a SECOND legitimate reason, added 2026-09-04: a file whose SQL is
+# already live under a DIFFERENT ledger version, because Lovable re-emitted it.
+#
+# docs/database-changes.md describes Lovable re-emitting hand-written SQL under
+# a filename of its own and recording THAT version in the ledger. When it does,
+# the hand-written file is left with no ledger row of its own and this check
+# reports it as drift forever. It is not drift: the database already has the
+# change. Unlike a contract-phase entry, an entry here is PERMANENT and the
+# migration must NEVER be applied -- re-running a superseded function body is
+# how you undo a later one.
+#
+# Before adding an entry here, prove the effect is live by reading the object
+# itself (pg_proc.prosrc, cron.job, information_schema), not by reading the SQL
+# and assuming. Say which live query proved it.
+# ---------------------------------------------------------------------------
+
+# Superseded, verified live 2026-09-04 against the club's database.
+#
+# Its whole payload -- the unarmed branch raising instead of returning quietly
+# -- was carried into 20260822120041 (the third body of the function, applied
+# 2026-08-22, ledger row present). Proof: pg_proc.prosrc for
+# private.run_notification_digest() contains RAISE EXCEPTION and no RAISE
+# WARNING.
+#
+# ⚠️ DO NOT APPLY THIS FILE. It would replace the live function body with the
+# SECOND one, which reads a `notification_digest_url` Vault secret that
+# 20260822120041 deliberately retired in favour of an inlined jitsu.au URL.
+# That row does not exist (vault.secrets holds only notification_digest_key),
+# so the function would raise every night and the digest would stop dead.
+# "Fixing the drift" here is the outage.
+20260821000000_notification_digest_fails_loudly
+
+# Duplicate re-emission, verified live 2026-09-04 against the club's database.
+#
+# 20260823002504 is this file's SQL byte for byte (Lovable's re-emission of it,
+# ledger row present), so the schedule move is live. Proof: cron.job reports
+# jobname 'notification-digest' on '0 22 * * *', active, and the most recent
+# notifications.emailed_at is 2026-09-02 22:00:06 UTC -- the 22:00 run itself.
+# Applying this file would be a harmless no-op, but it is still not drift.
+20260823000000_notification_digest_morning_schedule

--- a/supabase/lint/migration-drift-allowlist.txt
+++ b/supabase/lint/migration-drift-allowlist.txt
@@ -50,8 +50,9 @@
 
 # Duplicate re-emission, verified live 2026-09-04 against the club's database.
 #
-# 20260823002504 is this file's SQL byte for byte (Lovable's re-emission of it,
-# ledger row present), so the schedule move is live. Proof: cron.job reports
+# 20260823002504 carries this file's executable statements verbatim (Lovable's
+# re-emission of it, ledger row present; the re-emission drops the commentary,
+# so the files differ in size but not in SQL), so the schedule move is live. Proof: cron.job reports
 # jobname 'notification-digest' on '0 22 * * *', active, and the most recent
 # notifications.emailed_at is 2026-09-02 22:00:06 UTC -- the 22:00 run itself.
 # Applying this file would be a harmless no-op, but it is still not drift.

--- a/supabase/migrations/20260821000000_notification_digest_fails_loudly.sql
+++ b/supabase/migrations/20260821000000_notification_digest_fails_loudly.sql
@@ -1,3 +1,26 @@
+-- ⛔ DO NOT APPLY THIS FILE. IT IS SUPERSEDED, AND APPLYING IT IS AN OUTAGE.
+--
+-- Added 2026-09-04. This file has no row in the live ledger, so
+-- check-migration-drift.py prints this path and tells you to apply it. Do not.
+-- Everything below went to production inside 20260822120041 instead (the third
+-- body of this function), which keeps the RAISE and replaces the two Vault
+-- reads with ONE: it retired `notification_digest_url` in favour of an inlined
+-- https://jitsu.au/... URL, and that Vault row no longer exists.
+--
+-- So applying this file installs the SECOND body over the third. It would read
+-- a secret that is not there, raise every night, and the club's digest would
+-- stop. Verified live 2026-09-04: pg_proc.prosrc holds the third body, and
+-- vault.secrets holds only `notification_digest_key`.
+--
+-- The file stays for the history and the reasoning, and because a from-scratch
+-- replay applies it BEFORE 20260822120041 and therefore still ends on the right
+-- body. It is allowlisted permanently in
+-- supabase/lint/migration-drift-allowlist.txt. The sequencing note below was
+-- true when written and is kept as written; it is no longer a reason to apply
+-- this.
+--
+-- ---------------------------------------------------------------------------
+
 -- The nightly digest job stops reporting success when it did nothing.
 --
 -- WHY. `private.run_notification_digest()` (20260807000000) reads two Vault

--- a/supabase/migrations/20260821000000_notification_digest_fails_loudly.sql
+++ b/supabase/migrations/20260821000000_notification_digest_fails_loudly.sql
@@ -1,7 +1,10 @@
 -- ⛔ DO NOT APPLY THIS FILE. IT IS SUPERSEDED, AND APPLYING IT IS AN OUTAGE.
 --
 -- Added 2026-09-04. This file has no row in the live ledger, so
--- check-migration-drift.py prints this path and tells you to apply it. Do not.
+-- check-migration-drift.py would report it as unapplied and tell you to apply
+-- it. It is allowlisted now, so it prints under "Allowlisted, so not counted"
+-- instead -- which is a pointer to this warning, never a clearance. Do not
+-- apply it.
 -- Everything below went to production inside 20260822120041 instead (the third
 -- body of this function), which keeps the RAISE and replaces the two Vault
 -- reads with ONE: it retired `notification_digest_url` in favour of an inlined


### PR DESCRIPTION
## What changes for people using the site

**Nothing. That is the finding.** No SQL was applied, none is waiting for approval, and no member or manager sees anything different. The club's daily email summary is going out, at the intended time, and has been all along.

What changes is what the repo *says* about it. Several documents told the next person that the digest was broken and that the fix was to apply two migrations. One of those migrations would have stopped the digest entirely.

## What was investigated

The by-hand drift check has reported two notification-digest migrations as unapplied since 2026-09-01, and `CLAUDE.md` and `supabase/lint/README.md` recorded that as real, live drift with named consequences. This branch read the live database instead of the migration files.

Read read-only through Lovable's SQL access on 2026-09-04:

| Query | Answer |
| --- | --- |
| `cron.job` | `notification-digest`, `0 22 * * *`, active |
| `pg_proc.prosrc` for `private.run_notification_digest()` | no `notification_digest_url`, jitsu.au URL inlined — the third body |
| `vault.secrets` | `notification_digest_key` only — **no `notification_digest_url`** |
| `public.notifications` | 0 unemailed; `emailed_at` by day: 2026-08-22 ×12 (backlog stamping), 08-24 ×3, 08-26 ×6, 09-02 ×9 |

The 2026-09-02 rows are the proof of a live send: they carry `22:00:06+00`, the scheduled minute. That timestamp has to carry it alone, because the digest is **not** the only writer of `emailed_at` — `sendReplyNotification` stamps a row when a comment reply goes out, and again when a preference is off. Read the clock, not the count.

Both migrations' effects are already in production, carried there by Lovable re-emissions under filenames of its own — the duplicate-re-emission case `docs/database-changes.md` already describes:

- `20260823000000_notification_digest_morning_schedule.sql` — `20260823002504_…` carries its executable statements verbatim (the re-emission strips the commentary, so the files are 2819 and 576 bytes; the SQL matches, the prose does not). The digest has gone out at 8am/9am Sydney since 2026-08-23.
- `20260821000000_notification_digest_fails_loudly.sql` — superseded by `20260822120041_…`, the function's **third** body, which keeps the `RAISE` and drops the second Vault read.

So the two recorded consequences — "keeps going out at 6am" and "keeps recording `succeeded` for a night on which nothing was sent" — were both false.

## The part worth reviewing carefully

**`20260821000000_notification_digest_fails_loudly.sql` must never be applied.** It is the function's second body, and it reads a `notification_digest_url` Vault secret that `20260822120041` deliberately retired in favour of an inlined URL. That secret does not exist. Applying the file would install a function that raises every night, and the club's digest would stop dead — silently for members, visibly only in `cron.job_run_details`.

Note which query settles that, since it is easy to get wrong: "contains `RAISE EXCEPTION`" does **not**, because the superseded body raises too. It separates body 1 from bodies 2 and 3, not 2 from 3. The discriminator is the Vault read.

Applying a superseded migration reinstates an older definition over a newer one. Here, "fixing the drift" *is* the outage, and it is what both the docs and the checker's own failure message told you to do.

The file is kept rather than neutralised because a from-scratch replay applies it **before** `20260822120041` and therefore still ends on the correct third body. The warning added to it is comments only — the executable SQL is byte-identical to `main`, confirmed by the green Advisors + plpgsql_check job, which replays every migration.

## Changes

- **`supabase/lint/check-migration-drift.py`** — allowlisted files are no longer silently dropped from the report. A contract-phase entry is temporary and harmless to omit; a permanent "never apply this" one is not, and burying it in prose is how the warning goes stale. The checker now prints them, which is the only part of this change that survives the docs drifting again:
  ```
  76 migration files, 0 not applied to the live database.

  Allowlisted, so not counted above (read the note beside each entry):
    20260821000000_notification_digest_fails_loudly
    20260823000000_notification_digest_morning_schedule
  ```
  The failure message and docstring also now lead with "check before you apply". Strings and comments only; both selftests pass.
- **`supabase/lint/migration-drift-allowlist.txt`** — both files allowlisted with the discriminating query for each. A second, permanent category alongside the contract phase, with the header's "one legitimate reason" corrected and the "never apply" rule split: an outage for a superseded file, merely pointless for a true duplicate.
- **`supabase/migrations/20260821000000_…`** — opens with a "do not apply" banner, since it is the file a reader ends up holding. Comments only.
- **`CLAUDE.md`, `supabase/lint/README.md`, `docs/database-changes.md`, `docs/database.md`, `docs/notifications.md`** — corrected, with the queries that settle it rather than a claim to trust. "Already live under a different ledger version" is now the fourth entry under the README's Known blind spots, and the one with teeth: the other three make the check miss something, this one makes it recommend harm.
- Also fixed a pre-existing falsehood in `docs/database-changes.md`: it claimed a migration-drift workflow still catches unapplied migrations. It was deleted on 2026-08-22 and nothing automated has done this since.

## What is deliberately left open

`docs/notifications.md` records 34 rows stamped on 2026-08-22 but only 12 survive today. Notifications are deleted along with what they point at, so rows have gone since; the gap is called out in the doc rather than reconciled.

Not done, and worth a separate decision: this narrative now appears in several documents, against CLAUDE.md's own "link it, don't repeat it" rule. Restructuring them is larger than this change should carry, and the checker output now covers the case where they drift apart.

## Verification

Both selftests pass (both run in CI). The drift check was run against the real live ledger before and after: 2 reported unapplied → 0, with the two listed separately. Prettier clean. No TypeScript touched.

## The general lesson

The drift check compares identities, not content. A file with no ledger row raises a question; it does not answer it. Read the object (`pg_proc.prosrc`, `cron.job`, `information_schema`) and check whether a later migration touches the same object, before applying anything on the check's say-so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3EWmY2SiSi1gtvxS1tj75